### PR TITLE
MWPW-188956 | DA HTML to show a side comparison has broken blocks

### DIFF
--- a/streamlibs/sources/da.js
+++ b/streamlibs/sources/da.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-param-reassign */
 import { handleError, safeFetch } from '../utils/error-handler.js';
 
 function restoreImgToPicture(html) {
@@ -20,6 +21,7 @@ function restoreImgToPicture(html) {
 }
 
 function restoreColonTextToSpan(html) {
+  // eslint-disable-next-line arrow-body-style
   return html.replace(/:([a-zA-Z0-9_-]+):/g, (_, iconText) => {
     return `<span class="icon icon-${iconText}"></span>`;
   });

--- a/streamlibs/sources/da.js
+++ b/streamlibs/sources/da.js
@@ -1,5 +1,36 @@
 import { handleError, safeFetch } from '../utils/error-handler.js';
 
+function restoreImgToPicture(html) {
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(html, 'text/html');
+  doc.querySelectorAll('p').forEach((p) => {
+    const img = p.querySelector(':scope > img');
+    const hasOnlyImg = img && p.childNodes.length === 1;
+    if (hasOnlyImg) {
+      const picture = document.createElement('picture');
+      const newImg = document.createElement('img');
+      Array.from(img.attributes).forEach((attr) => {
+        newImg.setAttribute(attr.name, attr.value);
+      });
+      picture.appendChild(newImg);
+      p.replaceWith(picture);
+    }
+  });
+  return doc.body.innerHTML;
+}
+
+function restoreColonTextToSpan(html) {
+  return html.replace(/:([a-zA-Z0-9_-]+):/g, (_, iconText) => {
+    return `<span class="icon icon-${iconText}"></span>`;
+  });
+}
+
+export function getMiloCompatibleHtml(html) {
+  html = restoreColonTextToSpan(html);
+  html = restoreImgToPicture(html);
+  return html;
+}
+
 async function getDAContent() {
   let url = window.streamConfig.targetUrl;
   if (!url.startsWith('/')) url = `/${url}`;
@@ -18,7 +49,8 @@ async function getDAContent() {
     handleError(error, 'getting html from DA page');
     throw error;
   }
-  const html = await response.text();
+  let html = await response.text();
+  html = getMiloCompatibleHtml(html);
   return html;
 }
 

--- a/streamlibs/styles/styles.css
+++ b/streamlibs/styles/styles.css
@@ -851,6 +851,7 @@ img.da-process-wait {
   body.editor-mode {
     height: 100vh;
     overflow: hidden;
+    background: white;
   }
 
   body.editor-mode .da-panel {
@@ -875,7 +876,7 @@ img.da-process-wait {
     overflow: auto;
     scale: 0.5;
     transform-origin: top left;
-    background: #c8c9ca;
+    background: white;
     border-right: 3px solid #e7e0e0;
   }
 
@@ -915,16 +916,6 @@ img.da-process-wait {
     padding: 0 22px;
     box-sizing: border-box;
   }
-
-  /* body.editor-mode .figma-panel .panel-location-searchbox {
-    background: rgba(219, 234, 254, 75%);
-    border-color: rgba(59, 130, 246, 45%);
-  }
-
-  body.editor-mode .da-panel .panel-location-searchbox {
-    background: rgba(226, 232, 240, 78%);
-    border-color: rgba(71, 85, 105, 45%);
-  } */
 
   body.editor-mode .panel-location-search-icon {
     font-size: 40px;

--- a/streamlibs/target/da.js
+++ b/streamlibs/target/da.js
@@ -39,7 +39,6 @@ export function getDACompatibleHtml(html) {
   html = replaceSpanWithColonText(html);
   html = html.replaceAll('\n', '');
   html = html.replaceAll('"', "'");
-  html = html.replaceAll("alt= ','");
   return html;
 }
 


### PR DESCRIPTION
When our html is pushed to DA is is preprocessed to remove picture tags and replace span icons to have text on DA.
When using DA as source and rendering via milo load area, these dom changes are not reverted back and the DOM has misaligned blocks which fail to apply stypes or process due to missing picture tag and icons in :text: format as they are not returned as span

Updating the code to have a reverse processing for DA Dom in our area before Milo DOM rendering.