### PR TITLE
MWPW-190046: Fix annotation marker refresh and optimize thread polling

### DIFF
--- a/streamlibs/operations/annotation/comments-panel.js
+++ b/streamlibs/operations/annotation/comments-panel.js
@@ -1028,13 +1028,26 @@ export default function createCommentsPanelController({
     }
   };
 
+  function stopThreadPolling() {
+    if (!annotationState.commentThreadPollId) return;
+    window.clearInterval(annotationState.commentThreadPollId);
+    annotationState.commentThreadPollId = null;
+  }
+
+  function startThreadPolling() {
+    if (!isCommentsServiceAvailable()) return;
+    if (document.visibilityState !== 'visible') return;
+    if (annotationState.commentThreadPollId) return;
+
+    annotationState.commentThreadPollId = window.setInterval(() => {
+      refreshThreadsFromService();
+    }, ANNOTATION_COMMENT_THREAD_POLL_INTERVAL_MS);
+  }
+
   function teardownGlobalListeners() {
     hideGlobalSnackbar();
     closeCommentEditor();
-    if (annotationState.commentThreadPollId) {
-      window.clearInterval(annotationState.commentThreadPollId);
-      annotationState.commentThreadPollId = null;
-    }
+    stopThreadPolling();
     if (annotationState.floatingUiFrameId) {
       window.cancelAnimationFrame(annotationState.floatingUiFrameId);
       annotationState.floatingUiFrameId = null;
@@ -1089,6 +1102,10 @@ export default function createCommentsPanelController({
       document.removeEventListener('click', annotationState.documentClickHandler);
       annotationState.documentClickHandler = null;
     }
+    if (annotationState.documentVisibilityHandler) {
+      document.removeEventListener('visibilitychange', annotationState.documentVisibilityHandler);
+      annotationState.documentVisibilityHandler = null;
+    }
     if (annotationState.windowResizeHandler) {
       window.removeEventListener('resize', annotationState.windowResizeHandler);
       annotationState.windowResizeHandler = null;
@@ -1106,11 +1123,7 @@ export default function createCommentsPanelController({
     renderThreadMarkers({ resolveTargets: true });
     renderCommentsPanel();
     await refreshThreadsFromService();
-    if (isCommentsServiceAvailable()) {
-      annotationState.commentThreadPollId = window.setInterval(() => {
-        refreshThreadsFromService();
-      }, ANNOTATION_COMMENT_THREAD_POLL_INTERVAL_MS);
-    }
+    startThreadPolling();
 
     annotationState.mainClickHandler = (event) => {
       if (annotationUI.inlineMode) return;
@@ -1311,6 +1324,16 @@ export default function createCommentsPanelController({
     };
     document.addEventListener('click', annotationState.documentClickHandler);
 
+    annotationState.documentVisibilityHandler = () => {
+      if (document.visibilityState === 'visible') {
+        refreshThreadsFromServiceInBackground();
+        startThreadPolling();
+        return;
+      }
+      stopThreadPolling();
+    };
+    document.addEventListener('visibilitychange', annotationState.documentVisibilityHandler);
+
     annotationState.mainScrollHandler = scheduleFloatingUISync;
     annotationState.windowResizeHandler = scheduleFloatingUISync;
     mainEl.addEventListener('scroll', annotationState.mainScrollHandler);
@@ -1347,6 +1370,7 @@ export default function createCommentsPanelController({
         } finally {
           target.disabled = false;
         }
+        renderThreadMarkers({ resolveTargets: true });
         renderCommentsPanel();
       };
       annotationUI.inlineToggleEl.addEventListener('change', annotationState.inlineToggleChangeHandler);
@@ -1361,6 +1385,7 @@ export default function createCommentsPanelController({
         await disableInlineEditMode();
         if (annotationUI.inlineToggleEl) annotationUI.inlineToggleEl.checked = false;
         if (annotationUI.inlineAssetsToggleEl) annotationUI.inlineAssetsToggleEl.checked = false;
+        renderThreadMarkers({ resolveTargets: true });
         renderCommentsPanel();
       };
       annotationUI.inlineCommentsToggleEl.addEventListener(
@@ -1380,6 +1405,7 @@ export default function createCommentsPanelController({
         if (annotationUI.inlineCommentsToggleEl) {
           annotationUI.inlineCommentsToggleEl.checked = false;
         }
+        renderThreadMarkers({ resolveTargets: true });
         renderCommentsPanel();
       };
       annotationUI.inlineAssetsToggleEl.addEventListener(

--- a/streamlibs/operations/annotation/service.js
+++ b/streamlibs/operations/annotation/service.js
@@ -112,9 +112,7 @@ export default function createAnnotationServiceClient() {
   }
 
   function getCurrentUserIdentity() {
-    const profileId = window.streamConfig?.profileId
-      ?? window.streamConfig?.profile_id
-      ?? null;
+    const profileId = window.streamConfig?.profileId ?? null;
 
     return {
       profileId: profileId === null || profileId === undefined ? null : `${profileId}`,

--- a/streamlibs/operations/annotation/state.js
+++ b/streamlibs/operations/annotation/state.js
@@ -21,6 +21,7 @@ export function createAnnotationState() {
     inlineCommentsToggleChangeHandler: null,
     inlineAssetsToggleChangeHandler: null,
     documentClickHandler: null,
+    documentVisibilityHandler: null,
     windowResizeHandler: null,
     mainScrollHandler: null,
   };

--- a/streamlibs/previewer.js
+++ b/streamlibs/previewer.js
@@ -110,16 +110,12 @@ async function requestStreamConfigFromParent() {
       target: getQueryParam('target'),
       targetUrl: getQueryParam('targetUrl'),
       token: getQueryParam('token'),
-      profile_id: getQueryParam('profile_id') || getQueryParam('profileId'),
       profileId: getQueryParam('profileId') || getQueryParam('profile_id'),
-      collab_id: getQueryParam('collab_id') || getQueryParam('collabId'),
       collabId: getQueryParam('collabId') || getQueryParam('collab_id'),
       operation: getQueryParam('operation') || 'create',
       preflightUrl: getQueryParam('preflightUrl'),
       selectedPageBlocks: getQueryParam('selectedPageBlock') ? getQueryParam('selectedPageBlock').split(',') : [],
       selectedPageBlockIndices: getQueryParam('selectedPageBlockIndex') ? getQueryParam('selectedPageBlockIndex').split(',') : [],
-      collabId: getQueryParam('collabId') || getQueryParam('collab_id'),
-      profileId: getQueryParam('profileId') || getQueryParam('profile_id'),
       reviewId: getQueryParam('reviewId') || getQueryParam('reviewid'),
       startReview: getQueryParam('startReview') || getQueryParam('startreview'),
     };
@@ -195,20 +191,12 @@ export default async function initPreviewer() {
     target: previewParams.target,
     targetUrl: previewParams.targetUrl,
     token: previewParams.token,
-    profile_id: previewParams.profile_id || previewParams.profileId || null,
     profileId: previewParams.profileId || previewParams.profile_id || null,
-    collab_id: previewParams.collab_id || previewParams.collabId || null,
     collabId: previewParams.collabId || previewParams.collab_id || null,
     operation: previewParams.operation || 'create',
     preflightUrl: previewParams.preflightUrl,
     selectedPageBlocks: previewParams.selectedPageBlocks || [],
     selectedPageBlockIndices: previewParams.selectedPageBlockIndices || [],
-    collabId: previewParams.collabId
-      || previewParams.collab_id
-      || null,
-    profileId: previewParams.profileId
-      || previewParams.profile_id
-      || null,
     displayName: previewParams.displayName
       || previewParams.userName
       || previewParams.username

--- a/streamlibs/utils/constants.js
+++ b/streamlibs/utils/constants.js
@@ -218,7 +218,7 @@ export const ANNOTATION_DEFAULT_USERNAME = 'stream';
 
 export const ANNOTATION_COMMENT_STATUSES = ['Open', 'Resolved', 'Closed'];
 
-export const ANNOTATION_COMMENT_THREAD_POLL_INTERVAL_MS = 60000;
+export const ANNOTATION_COMMENT_THREAD_POLL_INTERVAL_MS = 30000;
 
 export const ANNOTATION_MESSAGES = {
   collabUnavailableTitle: 'Collaboration unavailable',


### PR DESCRIPTION
This PR improves annotation marker behavior and polling in stream-mapper.

Changes

- fix comment/edit marker refresh when switching between Comments, Edit, and Assets
- clear markers immediately in Assets and restore them immediately when switching back
- reduce annotation thread polling interval to 30 seconds
- pause polling when the browser tab is hidden and resume with a refresh when it becomes visible
- keep mapper config usage consistent around collabId and profileId
- 

Notes

- this visibility-aware polling currently covers browser tab visibility
- parent app tab / hidden iframe visibility handling can be added later if needed





JIRA: https://jira.corp.adobe.com/browse/MWPW-190046

<img width="2552" height="1022" alt="Screenshot 2026-03-18 at 1 10 52 AM" src="https://github.com/user-attachments/assets/29f6fa41-73a6-4e69-a221-71f1ea34385d" />


Test URLs:
- Before: https://main--{repo}--{owner}.aem.live/
- After: https://<branch>--{repo}--{owner}.aem.live/
