### PR TITLE
Fix false annotation refresh banner after saving edits

### DIFF
--- a/streamlibs/operations/annotation.js
+++ b/streamlibs/operations/annotation.js
@@ -93,7 +93,10 @@ async function buildPersistedAnnotationPayload() {
   };
 }
 
-export async function annotationOperation() {
+export async function annotationOperation(options = {}) {
+  const {
+    preserveRemoteEditState = false,
+  } = options;
   const previousAnnotationMode = annotationUI.annotationMode || 'comments';
   const shouldRestoreInlineMode = annotationUI.inlineMode
     && window.streamConfig?.inlineEditingAllowed !== false;
@@ -101,15 +104,19 @@ export async function annotationOperation() {
   inlineEditing.resetInlineEditModeState();
   annotationUI.annotationMode = shouldRestoreInlineMode ? 'edit' : previousAnnotationMode;
   document.body.classList.add('annotation-mode');
-  annotationState.latestSavedEditsUpdatedAt = null;
-  annotationState.pendingRemoteEditsSnapshot = null;
-  annotationState.hasLoadedInitialEditsSnapshot = false;
+  if (!preserveRemoteEditState) {
+    annotationState.latestSavedEditsUpdatedAt = null;
+    annotationState.pendingRemoteEditsSnapshot = null;
+    annotationState.hasLoadedInitialEditsSnapshot = false;
+  }
   await initializePreview();
   await miloLoadArea();
   const mainEl = document.querySelector('main');
   if (!mainEl) return;
 
-  await commentsPanel.setupAnnotationUI(mainEl);
+  await commentsPanel.setupAnnotationUI(mainEl, {
+    preserveRemoteEditState,
+  });
   if (annotationState.latestRemoteCollabSnapshot) {
     commentsPanel.applyRemoteCollabSnapshot(annotationState.latestRemoteCollabSnapshot, {
       includeEdits: false,

--- a/streamlibs/operations/annotation/comments-panel.js
+++ b/streamlibs/operations/annotation/comments-panel.js
@@ -493,13 +493,35 @@ export default function createCommentsPanelController({
     };
   }
 
+  function getStableStringValue(input) {
+    if (Array.isArray(input)) {
+      return input.map((item) => getStableStringValue(item));
+    }
+    if (input && typeof input === 'object') {
+      return Object.keys(input)
+        .sort()
+        .reduce((result, key) => {
+          result[key] = getStableStringValue(input[key]);
+          return result;
+        }, {});
+    }
+    return input;
+  }
+
+  function stringifyStableValue(value) {
+    try {
+      return JSON.stringify(getStableStringValue(value));
+    } catch {
+      return '';
+    }
+  }
+
   function getEasyEditComparisonSnapshot(edit) {
     return {
-      id: edit?.id || '',
       editType: edit?.editType || '',
       attrName: edit?.attrName || '',
       elementPath: edit?.elementPath || '',
-      elementProps: getDraftScopeKey(edit?.elementProps || {}),
+      elementProps: stringifyStableValue(edit?.elementProps || {}),
       from: edit?.from || '',
       to: edit?.to || '',
       fromHtml: edit?.fromHtml || '',
@@ -513,8 +535,8 @@ export default function createCommentsPanelController({
     const normalizedEdits = [...edits]
       .map((edit) => {
         const snapshot = getEasyEditComparisonSnapshot(edit);
-        const stableKey = `${snapshot.id}::${snapshot.elementPath}::${snapshot.attrName}`;
-        return `${stableKey}|${JSON.stringify(snapshot)}`;
+        const stableKey = `${snapshot.elementPath}::${snapshot.attrName}::${snapshot.editType}`;
+        return `${stableKey}|${stringifyStableValue(snapshot)}`;
       })
       .sort();
 
@@ -1581,13 +1603,18 @@ export default function createCommentsPanelController({
     });
   }
 
-  function teardownGlobalListeners() {
+  function teardownGlobalListeners(options = {}) {
+    const {
+      preserveRemoteEditState = false,
+    } = options;
     hideGlobalSnackbar();
     closeCommentEditor();
     pendingCommentsPanelRefresh = false;
-    clearSelfSavedEditsFingerprint();
-    annotationState.pendingRemoteEditsSnapshot = null;
-    annotationState.hasLoadedInitialEditsSnapshot = false;
+    if (!preserveRemoteEditState) {
+      clearSelfSavedEditsFingerprint();
+      annotationState.pendingRemoteEditsSnapshot = null;
+      annotationState.hasLoadedInitialEditsSnapshot = false;
+    }
     panelReplyDrafts.clear();
     popupDraft = '';
     popupDraftKey = '';
@@ -1666,8 +1693,11 @@ export default function createCommentsPanelController({
     }
   }
 
-  async function setupAnnotationUI(mainEl) {
-    teardownGlobalListeners();
+  async function setupAnnotationUI(mainEl, options = {}) {
+    const {
+      preserveRemoteEditState = false,
+    } = options;
+    teardownGlobalListeners({ preserveRemoteEditState });
     annotationUI.mainEl = mainEl;
     ensureFloatingLayer();
     ensureCommentsPanel();

--- a/streamlibs/previewer.js
+++ b/streamlibs/previewer.js
@@ -326,7 +326,9 @@ export async function saveChanges() {
         message: LOADER_STEP_MESSAGES.START_PAINTING,
         percentage: LOADER_PROGRESS_STEPS.START_PAINTING,
       });
-      await annotationOperation();
+      await annotationOperation({
+        preserveRemoteEditState: true,
+      });
     } else {
       await persistOnTarget();
     }
@@ -360,7 +362,9 @@ export async function refreshAnnotationCanvas() {
     });
     hideDOMElements([document.querySelector('main')]);
     preparePendingRemoteEditsRefresh();
-    await annotationOperation();
+    await annotationOperation({
+      preserveRemoteEditState: true,
+    });
     showDOMElements([document.querySelector('main')]);
     await refreshAnnotationFloatingUI();
     hideLoader();


### PR DESCRIPTION
This PR fixes the annotation edit refresh-banner flow so users do not see a false “refresh canvas” prompt immediately after their own save.

It preserves accepted edit sync state across the save/refresh rehydrate path and hardens self-save edit comparison against backend response differences such as merged timestamps, edit ids, and object key ordering. Real remote edit saves still trigger the refresh banner as expected.

<img width="1507" height="749" alt="Screenshot 2026-03-30 at 12 04 17 PM" src="https://github.com/user-attachments/assets/fe01fbca-e588-47b4-92e9-7d664f7601f5" />


