### PR TITLE
fix:restrict annotation thread status updates to thread authors

### DIFF
--- a/streamlibs/operations/annotation/comments-panel.js
+++ b/streamlibs/operations/annotation/comments-panel.js
@@ -188,6 +188,11 @@ export default function createCommentsPanelController({
     return Boolean(currentProfileId && authorProfileId && currentProfileId === authorProfileId);
   }
 
+  function isThreadStatusEditableByCurrentUser(thread) {
+    if (!thread) return false;
+    return isCommentEditableByCurrentUser(getRootComment(thread));
+  }
+
   function getCommentEditorKey(threadId, commentId) {
     return `${threadId || ''}::${commentId || ''}`;
   }
@@ -881,9 +886,15 @@ export default function createCommentsPanelController({
           const statusControls = document.createElement('div');
           statusControls.className = 'annotation-panel-status-controls';
           const statusSelect = document.createElement('select');
+          const canEditThreadStatus = isThreadStatusEditableByCurrentUser(thread);
           statusSelect.className = 'annotation-panel-status-select';
           statusSelect.dataset.threadId = thread.id;
           statusSelect.dataset.messageId = group.comment.id || '';
+          statusSelect.disabled = !canEditThreadStatus;
+          if (!canEditThreadStatus) {
+            statusSelect.title = ANNOTATION_MESSAGES.updateStatusRestricted;
+            statusSelect.setAttribute('aria-label', ANNOTATION_MESSAGES.updateStatusRestricted);
+          }
           COMMENT_STATUSES.forEach((status) => {
             const option = document.createElement('option');
             option.value = status;
@@ -1876,6 +1887,15 @@ export default function createCommentsPanelController({
       if (!threadId) return;
       const thread = store.getThreadById(threadId);
       if (!thread) return;
+      if (!isThreadStatusEditableByCurrentUser(thread)) {
+        target.value = thread.status;
+        target.disabled = true;
+        showGlobalSnackbar(ANNOTATION_MESSAGES.updateStatusRestricted);
+        window.setTimeout(() => {
+          target.disabled = false;
+        }, 0);
+        return;
+      }
       const previousStatus = thread.status;
       const nextStatus = target.value;
       target.value = previousStatus;

--- a/streamlibs/styles/styles.css
+++ b/streamlibs/styles/styles.css
@@ -1715,6 +1715,13 @@ body.annotation-mode main::-webkit-scrollbar {
   min-width: 76px;
 }
 
+.annotation-panel-status-select:disabled {
+  background: #f3f4f6;
+  border-color: #d1d5db;
+  color: #6b7280;
+  cursor: not-allowed;
+}
+
 .annotation-panel-message-list {
   display: flex;
   flex-direction: column;

--- a/streamlibs/utils/constants.js
+++ b/streamlibs/utils/constants.js
@@ -249,6 +249,7 @@ export const ANNOTATION_MESSAGES = {
   sendReplyError: "Couldn't send reply. Please try again.",
   saveCommentError: "Couldn't save comment. Please try again.",
   updateStatusError: "Couldn't update comment status. Please try again.",
+  updateStatusRestricted: 'Only the thread author can update its status.',
   syncEditError: "Couldn't sync edit thread. Please try again.",
   editCommentAriaLabel: 'Edit comment',
   saveCommentAction: 'Save',


### PR DESCRIPTION
Restricts annotation thread status changes to the thread author by disabling the status control for other users and guarding the update path. Validated with Playwright coverage for owner/non-owner behavior.

<img width="1506" height="825" alt="Screenshot 2026-03-30 at 3 11 10 PM" src="https://github.com/user-attachments/assets/0b6bd85d-c542-4c60-918c-0904b54fcbf1" />
