### PR TITLE
Preserve Medium inline formatting on save and align collab thread status rules

### DIFF
--- a/streamlibs/operations/annotation/comments-panel.js
+++ b/streamlibs/operations/annotation/comments-panel.js
@@ -180,6 +180,18 @@ export default function createCommentsPanelController({
     return annotationService.getCurrentUserIdentity();
   }
 
+  function isCurrentUserCollabOwner() {
+    const normalizedRole = `${window.streamConfig?.collabRole || ''}`
+      .trim()
+      .toLowerCase()
+      .replace(/[_-]+/g, ' ');
+    if (!normalizedRole) {
+      return window.streamConfig?.inlineEditingAllowed === true;
+    }
+    return normalizedRole === 'owner'
+      || normalizedRole === 'collab owner';
+  }
+
   function isCommentEditableByCurrentUser(message) {
     if (!message || annotationUI.inlineMode || annotationUI.annotationMode !== 'comments') return false;
     const currentUser = getCurrentUserIdentity();
@@ -190,7 +202,8 @@ export default function createCommentsPanelController({
 
   function isThreadStatusEditableByCurrentUser(thread) {
     if (!thread) return false;
-    return isCommentEditableByCurrentUser(getRootComment(thread));
+    if (annotationUI.inlineMode || annotationUI.annotationMode !== 'comments') return false;
+    return isCurrentUserCollabOwner();
   }
 
   function getCommentEditorKey(threadId, commentId) {

--- a/streamlibs/operations/annotation/inline-editing.js
+++ b/streamlibs/operations/annotation/inline-editing.js
@@ -16,6 +16,40 @@ export default function createInlineEditingController({
   const annotationService = createAnnotationServiceClient();
   const isInlineEditingAllowed = () => window.streamConfig?.inlineEditingAllowed !== false;
 
+  function normalizeInlineFormattingHtml(html = '') {
+    const template = document.createElement('template');
+    template.innerHTML = html;
+
+    template.content.querySelectorAll('*').forEach((element) => {
+      element.classList.remove(
+        'annotation-inline-editable',
+        'annotation-inline-editable-image',
+      );
+      [
+        'contenteditable',
+        'spellcheck',
+        'data-medium-editor-element',
+        'medium-editor-index',
+        'data-medium-editor-editor-index',
+        'role',
+        'aria-multiline',
+        'data-placeholder',
+      ].forEach((attr) => element.removeAttribute(attr));
+    });
+
+    template.content.querySelectorAll('b, i').forEach((element) => {
+      const replacementTagName = element.tagName.toLowerCase() === 'b' ? 'strong' : 'em';
+      const replacement = document.createElement(replacementTagName);
+      Array.from(element.attributes).forEach((attr) => {
+        replacement.setAttribute(attr.name, attr.value);
+      });
+      replacement.innerHTML = element.innerHTML;
+      element.replaceWith(replacement);
+    });
+
+    return template.innerHTML;
+  }
+
   async function loadMediumEditor() {
     if (window.MediumEditor) return;
     if (annotationState.mediumEditorLoadPromise) {
@@ -58,13 +92,27 @@ export default function createInlineEditingController({
       'p', 'li', 'blockquote', 'figcaption',
       '[class*="heading"]', '[class*="title"]', '[class*="description"]',
     ];
-    return Array.from(annotationUI.mainEl.querySelectorAll(selectors.join(', ')))
+    const candidates = Array.from(annotationUI.mainEl.querySelectorAll(selectors.join(', ')))
       .filter((el) => {
         if (!(el instanceof HTMLElement)) return false;
         if (!el.textContent || !el.textContent.trim()) return false;
         if (el.closest('.annotation-comments-panel') || el.closest('.annotation-floating-popup')) return false;
         return true;
       });
+    const candidateSet = new Set(candidates);
+    const nonLeafCandidates = new Set();
+
+    candidates.forEach((candidate) => {
+      let parent = candidate.parentElement;
+      while (parent && parent !== annotationUI.mainEl) {
+        if (candidateSet.has(parent)) {
+          nonLeafCandidates.add(parent);
+        }
+        parent = parent.parentElement;
+      }
+    });
+
+    return candidates.filter((element) => !nonLeafCandidates.has(element));
   }
 
   function getInlineEditableImages() {
@@ -83,9 +131,11 @@ export default function createInlineEditingController({
     const snapshot = annotationUI.inlineElementSnapshot.get(elementRef);
     if (!snapshot) return;
 
-    const currentHtml = element.innerHTML;
+    const currentHtml = normalizeInlineFormattingHtml(element.innerHTML);
     const currentText = element.textContent || '';
-    if (currentText.trim() === snapshot.originalText.trim()) return;
+    const didTextChange = currentText.trim() !== snapshot.originalText.trim();
+    const didHtmlChange = currentHtml !== snapshot.originalHtml;
+    if (!didTextChange && !didHtmlChange) return;
 
     const editAnchor = store.buildEditElementAnchor(element, annotationUI.mainEl);
     const easyEditElementPath = editAnchor.elementPath;
@@ -470,7 +520,7 @@ export default function createInlineEditingController({
     annotationUI.editableElements.forEach((element) => {
       const elementRef = store.ensureElementRef(element);
       annotationUI.inlineElementSnapshot.set(elementRef, {
-        originalHtml: element.innerHTML,
+        originalHtml: normalizeInlineFormattingHtml(element.innerHTML),
         originalText: element.textContent || '',
       });
       element.classList.add('annotation-inline-editable');

--- a/streamlibs/operations/annotation/store.js
+++ b/streamlibs/operations/annotation/store.js
@@ -207,6 +207,15 @@ export function createAnnotationStore({ annotationState, annotationUI }) {
     if (edit.editType === 'image-alt') {
       return `changed alt "${truncateInlineEditText(edit.from, 40)}" -> "${truncateInlineEditText(edit.to, 40)}"`;
     }
+    if (
+      edit.editType === 'text'
+      && edit.from === edit.to
+      && edit.fromHtml
+      && edit.toHtml
+      && edit.fromHtml !== edit.toHtml
+    ) {
+      return `updated formatting for "${truncateInlineEditText(edit.to || edit.from)}"`;
+    }
     return `changed "${truncateInlineEditText(edit.from)}" -> "${truncateInlineEditText(edit.to)}"`;
   }
 
@@ -775,6 +784,68 @@ export function createAnnotationStore({ annotationState, annotationUI }) {
     ));
   }
 
+  function getElementForEdit(edit) {
+    if (!annotationUI.mainEl) return null;
+    if (!edit.elementPath && !Object.keys(edit.elementProps || {}).length) {
+      return edit.elementRef ? getElementByRef(edit.elementRef) : null;
+    }
+    const anchorRecord = buildElementAnchorRecord(edit.elementPath, edit.elementProps);
+    const byPath = getElementByCommentPath(anchorRecord);
+    if (byPath instanceof HTMLElement) return byPath;
+    if (edit.elementRef) {
+      const byRef = getElementByRef(edit.elementRef);
+      if (byRef) return byRef;
+    }
+    return null;
+  }
+
+  function pruneNestedTextEasyEdits() {
+    const textEditTargets = annotationState.store.easyEdits.map((edit, index) => {
+      if (edit?.editType !== 'text') return null;
+      const target = getElementForEdit(edit);
+      if (!(target instanceof HTMLElement)) return null;
+      return { index, target };
+    }).filter(Boolean);
+
+    const targetToIndexes = new Map();
+    textEditTargets.forEach(({ index, target }) => {
+      const existingIndexes = targetToIndexes.get(target) || [];
+      existingIndexes.push(index);
+      targetToIndexes.set(target, existingIndexes);
+    });
+
+    const nestedAncestorIndexes = new Set();
+    textEditTargets.forEach(({ target }) => {
+      let parent = target.parentElement;
+      while (parent && parent !== annotationUI.mainEl) {
+        const ancestorIndexes = targetToIndexes.get(parent);
+        if (ancestorIndexes?.length) {
+          ancestorIndexes.forEach((index) => nestedAncestorIndexes.add(index));
+        }
+        parent = parent.parentElement;
+      }
+    });
+
+    const nextEasyEdits = annotationState.store.easyEdits.filter((edit, index) => (
+      edit?.editType !== 'text' || !nestedAncestorIndexes.has(index)
+    ));
+
+    if (nextEasyEdits.length === annotationState.store.easyEdits.length) return false;
+    annotationState.store.easyEdits = nextEasyEdits;
+    rebuildEditThreadsFromEasyEdits();
+    return true;
+  }
+
+  function resolveStoredEasyEdit(normalizedEditRecord) {
+    return annotationState.store.easyEdits.find((edit) => edit.id === normalizedEditRecord.id)
+      || getEasyEditByElement(
+        normalizedEditRecord.elementRef,
+        normalizedEditRecord.elementPath,
+        normalizedEditRecord.elementProps,
+      )
+      || null;
+  }
+
   function upsertEasyEdit(editRecord) {
     const normalizedEditRecord = normalizeEasyEdit(editRecord);
     const normalizedEditPathKey = getEditElementPathKey(
@@ -793,12 +864,14 @@ export function createAnnotationStore({ annotationState, annotationUI }) {
         ...annotationState.store.easyEdits[index],
         ...normalizedEditRecord,
       };
-      rebuildEditThreadsFromEasyEdits();
-      return annotationState.store.easyEdits[index];
+      const didPruneNestedEdits = pruneNestedTextEasyEdits();
+      if (!didPruneNestedEdits) rebuildEditThreadsFromEasyEdits();
+      return resolveStoredEasyEdit(normalizedEditRecord);
     }
     annotationState.store.easyEdits.push(normalizedEditRecord);
-    rebuildEditThreadsFromEasyEdits();
-    return normalizedEditRecord;
+    const didPruneNestedEdits = pruneNestedTextEasyEdits();
+    if (!didPruneNestedEdits) rebuildEditThreadsFromEasyEdits();
+    return resolveStoredEasyEdit(normalizedEditRecord);
   }
 
   function replaceEasyEdits(nextEasyEdits = []) {
@@ -807,7 +880,8 @@ export function createAnnotationStore({ annotationState, annotationUI }) {
         .filter((edit) => edit && typeof edit === 'object')
         .map((edit) => normalizeEasyEdit(edit))
       : [];
-    rebuildEditThreadsFromEasyEdits();
+    const didPruneNestedEdits = pruneNestedTextEasyEdits();
+    if (!didPruneNestedEdits) rebuildEditThreadsFromEasyEdits();
   }
 
   function getChangedSegments(fromText, toText) {
@@ -882,21 +956,6 @@ export function createAnnotationStore({ annotationState, annotationUI }) {
     annotationState.activeThreadId = thread.id;
     annotationState.activeMessageId = '';
     annotationState.activeEditId = '';
-  }
-
-  function getElementForEdit(edit) {
-    if (!annotationUI.mainEl) return null;
-    if (!edit.elementPath && !Object.keys(edit.elementProps || {}).length) {
-      return edit.elementRef ? getElementByRef(edit.elementRef) : null;
-    }
-    const anchorRecord = buildElementAnchorRecord(edit.elementPath, edit.elementProps);
-    const byPath = getElementByCommentPath(anchorRecord);
-    if (byPath instanceof HTMLElement) return byPath;
-    if (edit.elementRef) {
-      const byRef = getElementByRef(edit.elementRef);
-      if (byRef) return byRef;
-    }
-    return null;
   }
 
   function rebindEasyEditsToCurrentDom() {

--- a/streamlibs/utils/constants.js
+++ b/streamlibs/utils/constants.js
@@ -249,7 +249,7 @@ export const ANNOTATION_MESSAGES = {
   sendReplyError: "Couldn't send reply. Please try again.",
   saveCommentError: "Couldn't save comment. Please try again.",
   updateStatusError: "Couldn't update comment status. Please try again.",
-  updateStatusRestricted: 'Only the thread author can update its status.',
+  updateStatusRestricted: 'Only the collab owner can update thread status.',
   syncEditError: "Couldn't sync edit thread. Please try again.",
   editCommentAriaLabel: 'Edit comment',
   saveCommentAction: 'Save',


### PR DESCRIPTION
This updates stream-mapper so Medium inline formatting changes like bold and italic are preserved when saving to DA and the backend, normalizing bold to <strong> and italic to <em>. It also aligns thread-status behavior with stream-service by making status updates owner-only, and fixes duplicate/stale inline edit artifacts that could create extra edit markers or comments after saving.


<img width="2273" height="1098" alt="Screenshot 2026-04-01 at 2 55 25 PM" src="https://github.com/user-attachments/assets/6334a208-cdd5-44ac-952b-30cf6d97c901" />

Test URLs:
- Before: https://main--{repo}--{owner}.aem.live/
- After: https://<branch>--{repo}--{owner}.aem.live/
