### PR TITLE
[MWPW-191205] Preview interactive signal

### DIFF
--- a/streamlibs/previewer.js
+++ b/streamlibs/previewer.js
@@ -42,7 +42,12 @@ import {
   LOADER_PROGRESS_STEPS,
   LOADER_STEP_MESSAGES,
 } from './utils/constants.js';
-import { initializeLoader, updateLoader, hideLoader } from './utils/loader.js';
+import {
+  initializeLoader,
+  updateLoader,
+  hideLoader,
+  notifyParentPreviewInteractive,
+} from './utils/loader.js';
 
 function parseBooleanFlag(value) {
   if (value === true || value === 'true') return true;
@@ -282,6 +287,7 @@ export default async function initPreviewer() {
 
 export async function persist() {
   try {
+    notifyParentPreviewInteractive(false);
     updateLoader({ message: 'Pushing content to DA' });
     hideDOMElements([document.querySelector('main')]);
     if (window.streamConfig.operation === 'annotation') {

--- a/streamlibs/utils/loader.js
+++ b/streamlibs/utils/loader.js
@@ -55,6 +55,15 @@ export function emitLoaderProgress(percentage, message) {
   }));
 }
 
+export function notifyParentPreviewInteractive(ready) {
+  try {
+    if (!window.parent || window.parent === window) return;
+    window.parent.postMessage({ type: 'STREAM_PREVIEW_INTERACTIVE', ready: !!ready }, '*');
+  } catch {
+    /* cross-origin or detached */
+  }
+}
+
 export function initializeLoader() {
   if (!isListenerAttached) {
     window.addEventListener(LOADER_PROGRESS_EVENT, onLoaderProgressEvent);
@@ -63,6 +72,7 @@ export function initializeLoader() {
   loaderPercentage = LOADER_PROGRESS_STEPS.START;
   loaderMessage = LOADER_STEP_MESSAGES.INITIAL;
   renderLoader();
+  notifyParentPreviewInteractive(false);
 }
 
 export function updateLoader({ percentage, message } = {}) {
@@ -73,9 +83,13 @@ export function updateLoader({ percentage, message } = {}) {
 
 export function hideLoader() {
   const { container } = getLoaderElements();
-  if (!container) return;
+  if (!container) {
+    notifyParentPreviewInteractive(true);
+    return;
+  }
   container.style.display = 'none';
   container.classList.remove('is-visible');
+  notifyParentPreviewInteractive(true);
 }
 
 export function createFigmaLoaderReporter() {


### PR DESCRIPTION
 Posts STREAM_PREVIEW_INTERACTIVE with ready: true/false from the loader (not ready while loading, ready when hidden) and from persist() (not ready until push finishes). Allows the parent to disable toolbar actions until the preview is interactive.
<img width="959" height="451" alt="image" src="https://github.com/user-attachments/assets/1610cb09-7c9e-4217-bb29-4813fcfef282" />
<img width="953" height="445" alt="image" src="https://github.com/user-attachments/assets/789c7c2a-b599-44ea-b1eb-7ad7f846e934" />

Related to https://github.com/Adobe-acom/stream-client/pull/85


Test URLs:
- Before: https://main--{repo}--{owner}.aem.live/
- After: https://<branch>--{repo}--{owner}.aem.live/
