### PR TITLE
Lock closed annotation threads while allowing owners to reopen them

### DIFF
--- a/streamlibs/operations/annotation/comments-panel.js
+++ b/streamlibs/operations/annotation/comments-panel.js
@@ -192,7 +192,11 @@ export default function createCommentsPanelController({
       || normalizedRole === 'collab owner';
   }
 
-  function isCommentEditableByCurrentUser(message) {
+  function isThreadClosed(thread) {
+    return Boolean(thread) && store.normalizeCommentStatus(thread.status) === 'Closed';
+  }
+
+  function isCommentEditableByCurrentUser(thread, message) {
     if (!message || annotationUI.inlineMode || annotationUI.annotationMode !== 'comments') return false;
     const currentUser = getCurrentUserIdentity();
     const currentProfileId = `${currentUser?.profileId || ''}`.trim();
@@ -792,6 +796,15 @@ export default function createCommentsPanelController({
     captureTransientDraftsFromDom();
     renderRefreshAction();
 
+    const activePopupThreadId = `${annotationUI.popupEl?.dataset.threadId || ''}`.trim();
+    if (activePopupThreadId) {
+      const popupThread = store.getThreadById(activePopupThreadId);
+      if (isThreadClosed(popupThread)) {
+        closePopupAndSelection();
+        showGlobalSnackbar(ANNOTATION_MESSAGES.closedThreadRestricted);
+      }
+    }
+
     let preservedComposer = null;
     let preservedComposerKey = '';
     let preservedEditForm = null;
@@ -882,6 +895,9 @@ export default function createCommentsPanelController({
       const groups = buildCommentGroups(thread);
       groups.forEach((group, idx) => {
         const isLatestInThread = idx === groups.length - 1;
+        const isClosedThread = isThreadClosed(thread);
+        const canEditRootComment = !isClosedThread
+          && isCommentEditableByCurrentUser(thread, group.comment);
         const card = document.createElement('article');
         card.className = 'annotation-panel-comment';
         card.dataset.threadId = thread.id;
@@ -905,8 +921,11 @@ export default function createCommentsPanelController({
           statusSelect.dataset.messageId = group.comment.id || '';
           statusSelect.disabled = !canEditThreadStatus;
           if (!canEditThreadStatus) {
-            statusSelect.title = ANNOTATION_MESSAGES.updateStatusRestricted;
-            statusSelect.setAttribute('aria-label', ANNOTATION_MESSAGES.updateStatusRestricted);
+            const restrictionMessage = isClosedThread
+              ? ANNOTATION_MESSAGES.closedThreadRestricted
+              : ANNOTATION_MESSAGES.updateStatusRestricted;
+            statusSelect.title = restrictionMessage;
+            statusSelect.setAttribute('aria-label', restrictionMessage);
           }
           COMMENT_STATUSES.forEach((status) => {
             const option = document.createElement('option');
@@ -916,7 +935,7 @@ export default function createCommentsPanelController({
             statusSelect.appendChild(option);
           });
           statusControls.append(statusSelect);
-          if (isCommentEditableByCurrentUser(group.comment)) {
+          if (canEditRootComment) {
             const editThreadBtn = document.createElement('button');
             editThreadBtn.type = 'button';
             editThreadBtn.className = 'annotation-panel-edit-btn';
@@ -941,7 +960,7 @@ export default function createCommentsPanelController({
           || ANNOTATION_DEFAULT_USERNAME;
 
         const rootCommentKey = `${thread.id}::${group.comment.id || ''}`;
-        const isEditingRootComment = isEditingComment(thread.id, group.comment.id || '');
+        const isEditingRootComment = canEditRootComment && isEditingComment(thread.id, group.comment.id || '');
         if (isEditingRootComment) {
           if (preservedEditForm && !preservedIsReply && preservedEditKey === rootCommentKey) {
             card.append(username, preservedEditForm);
@@ -969,7 +988,9 @@ export default function createCommentsPanelController({
           replyRow.className = 'annotation-panel-reply-row';
 
           const replyKey = `${thread.id}::${reply.id || ''}`;
-          const isEditingReply = isEditingComment(thread.id, reply.id || '');
+          const canEditReply = !isClosedThread
+            && isCommentEditableByCurrentUser(thread, reply);
+          const isEditingReply = canEditReply && isEditingComment(thread.id, reply.id || '');
           if (isEditingReply) {
             if (preservedEditForm && preservedIsReply && preservedEditKey === replyKey) {
               replyRow.append(preservedEditForm);
@@ -994,7 +1015,7 @@ export default function createCommentsPanelController({
             replyRow.append(replyText);
           }
 
-          if (showComments && isCommentEditableByCurrentUser(reply) && !isEditingReply) {
+          if (showComments && canEditReply && !isEditingReply) {
             const replyEditBtn = document.createElement('button');
             replyEditBtn.type = 'button';
             replyEditBtn.className = 'annotation-panel-edit-btn annotation-panel-edit-btn-reply';
@@ -1014,7 +1035,7 @@ export default function createCommentsPanelController({
 
         card.append(repliesWrap);
 
-        if (showComments) {
+        if (showComments && !isClosedThread) {
           const composerKey = `${thread.id}::${group.comment.id || ''}`;
           if (preservedComposer && preservedComposerKey === composerKey) {
             card.append(preservedComposer);
@@ -1292,6 +1313,10 @@ export default function createCommentsPanelController({
     if (!value) return;
     const thread = store.getThreadById(threadId);
     if (!thread) return;
+    if (isThreadClosed(thread)) {
+      showGlobalSnackbar(ANNOTATION_MESSAGES.closedThreadRestricted);
+      return;
+    }
     let activeThread = thread;
     let didPersistToService = false;
     let didHydrateThread = false;
@@ -1361,8 +1386,13 @@ export default function createCommentsPanelController({
     if (pendingCommentEditIds.has(editKey)) return;
 
     const thread = store.getThreadById(threadId);
-    const message = thread?.messages?.find((item) => item.id === commentId);
-    if (!thread || !message || !isCommentEditableByCurrentUser(message)) return;
+    if (!thread) return;
+    const message = thread.messages?.find((item) => item.id === commentId);
+    if (isThreadClosed(thread)) {
+      showGlobalSnackbar(ANNOTATION_MESSAGES.closedThreadRestricted);
+      return;
+    }
+    if (!message || !isCommentEditableByCurrentUser(thread, message)) return;
 
     const nextValue = `${rawValue || ''}`.trim();
     const previousValue = `${message.text || ''}`.trim();
@@ -1420,6 +1450,10 @@ export default function createCommentsPanelController({
 
     let thread = store.getCommentThreadByElement(annotationState.selectedElement);
     const isReply = Boolean(thread);
+    if (isReply && isThreadClosed(thread)) {
+      showGlobalSnackbar(ANNOTATION_MESSAGES.closedThreadRestricted);
+      return;
+    }
     let didPersistToService = false;
     let didHydrateThread = false;
     setPopupSubmitPending(true);
@@ -1548,6 +1582,12 @@ export default function createCommentsPanelController({
     setSelectedElement(element);
     syncPopupDraftScope(nextElementPath);
     const thread = store.getCommentThreadByElement(annotationState.selectedElement);
+    if (thread && isThreadClosed(thread)) {
+      store.clearSelectedElement();
+      removePopup();
+      showGlobalSnackbar(ANNOTATION_MESSAGES.closedThreadRestricted);
+      return;
+    }
     annotationState.activeThreadId = thread?.id || '';
     annotationState.activeMessageId = '';
     renderCommentsPanel();
@@ -1791,6 +1831,11 @@ export default function createCommentsPanelController({
         if (!(replyBtn instanceof HTMLButtonElement)) return;
         const { threadId, commentId } = replyBtn.dataset;
         if (!threadId) return;
+        const thread = store.getThreadById(threadId);
+        if (isThreadClosed(thread)) {
+          showGlobalSnackbar(ANNOTATION_MESSAGES.closedThreadRestricted);
+          return;
+        }
         const input = annotationUI.panelEl.querySelector(
           `.annotation-panel-reply-input[data-thread-id="${threadId}"][data-comment-id="${commentId}"]`,
         );
@@ -1825,7 +1870,11 @@ export default function createCommentsPanelController({
         if (!threadId || !commentId) return;
         const thread = store.getThreadById(threadId);
         const message = thread?.messages?.find((item) => item.id === commentId);
-        if (!message || !isCommentEditableByCurrentUser(message)) return;
+        if (isThreadClosed(thread)) {
+          showGlobalSnackbar(ANNOTATION_MESSAGES.closedThreadRestricted);
+          return;
+        }
+        if (!message || !isCommentEditableByCurrentUser(thread, message)) return;
         if (!openCommentEditor(threadId, commentId, message.text || '')) return;
         renderCommentsPanel();
         focusCommentEditor(threadId, commentId);
@@ -1843,6 +1892,12 @@ export default function createCommentsPanelController({
       annotationState.activeMessageId = card.dataset.messageId || '';
       const targetEl = store.getElementForThread(thread);
       if (!targetEl) return;
+      if (isThreadClosed(thread)) {
+        annotationState.activeThreadId = thread.id;
+        renderCommentsPanel();
+        targetEl.scrollIntoView({ block: 'center', behavior: 'smooth' });
+        return;
+      }
       openPopupForElement(targetEl, true);
     };
     annotationUI.panelEl.addEventListener('click', annotationState.panelClickHandler);

--- a/streamlibs/utils/constants.js
+++ b/streamlibs/utils/constants.js
@@ -232,6 +232,7 @@ export const ANNOTATION_MESSAGES = {
   collabUnavailableDescription: 'This review does not have a collab ID yet, so comments and edits cannot load or sync.',
   collabUnavailableSnackbar: 'Comments and edits are unavailable until a collab is attached.',
   commentsUnavailableSnackbar: 'Comments are unavailable until a collab is attached.',
+  closedThreadRestricted: 'Closed threads can no longer be updated.',
   inlineEditRestrictedTitle: 'Edit access restricted',
   inlineEditRestrictedDescription: 'Only collab owners can use inline editing in this review.',
   inlineEditRestrictedSnackbar: 'Inline editing is only available to collab owners.',


### PR DESCRIPTION
This change makes closed annotation threads read-only for comments and replies while keeping them navigable in the UI. Users can still jump to the linked marker/thread, but they can no longer add replies, edit existing messages, or open the reply popup while the thread is closed.

The collab owner still retains status control so a closed thread can be reopened by changing it back to Open. The PR also adds Playwright coverage for the closed-thread flow, including navigation, read-only behavior, and owner reopen behavior.

JIRA: https://jira.corp.adobe.com/browse/MWPW-191378

Test URLs:
- Before: https://main--{repo}--{owner}.aem.live/
- After: https://<branch>--{repo}--{owner}.aem.live/
