### PR TITLE
MWPW-191330: Refine annotation thread card layout in comments panel

### DIFF
--- a/streamlibs/operations/annotation/comments-panel.js
+++ b/streamlibs/operations/annotation/comments-panel.js
@@ -911,8 +911,9 @@ export default function createCommentsPanelController({
           card.classList.add('is-active');
         }
 
+        let statusControls;
         if (showComments) {
-          const statusControls = document.createElement('div');
+          statusControls = document.createElement('div');
           statusControls.className = 'annotation-panel-status-controls';
           const statusSelect = document.createElement('select');
           const canEditThreadStatus = isThreadStatusEditableByCurrentUser(thread);
@@ -950,7 +951,6 @@ export default function createCommentsPanelController({
           `;
             statusControls.append(editThreadBtn);
           }
-          card.append(statusControls);
         }
 
         const username = document.createElement('p');
@@ -980,6 +980,7 @@ export default function createCommentsPanelController({
           text.textContent = group.comment.text || '';
           card.append(username, text);
         }
+        if (statusControls) card.append(statusControls);
 
         const repliesWrap = document.createElement('div');
         repliesWrap.className = 'annotation-panel-replies-list';
@@ -1006,13 +1007,16 @@ export default function createCommentsPanelController({
               replyRow.append(editForm);
             }
           } else {
-            const replyText = document.createElement('p');
-            replyText.className = 'annotation-panel-reply-text';
-            const replyUsername = document.createElement('span');
+            const replyContent = document.createElement('div');
+            replyContent.className = 'annotation-panel-reply-content';
+            const replyUsername = document.createElement('p');
             replyUsername.className = 'annotation-panel-reply-user';
             replyUsername.textContent = reply.username || ANNOTATION_DEFAULT_USERNAME;
-            replyText.append(replyUsername, document.createTextNode(reply.text || ''));
-            replyRow.append(replyText);
+            const replyText = document.createElement('p');
+            replyText.className = 'annotation-panel-reply-text';
+            replyText.textContent = reply.text || '';
+            replyContent.append(replyUsername, replyText);
+            replyRow.append(replyContent);
           }
 
           if (showComments && canEditReply && !isEditingReply) {

--- a/streamlibs/styles/styles.css
+++ b/streamlibs/styles/styles.css
@@ -1692,16 +1692,20 @@ body.annotation-mode main::-webkit-scrollbar {
   color: #1d4ed8;
   font-size: 12px;
   font-weight: 700;
-  padding-right: 100px;
+  line-height: 1.4;
+  overflow-wrap: anywhere;
 }
 
 .annotation-panel-status-controls {
-  position: absolute;
-  top: 7px;
-  right: 8px;
   display: flex;
   align-items: center;
+  justify-content: space-between;
   gap: 6px;
+  margin-top: 8px;
+}
+
+.annotation-panel-status-controls .annotation-panel-edit-btn {
+  margin-left: auto;
 }
 
 .annotation-panel-status-select {
@@ -1743,19 +1747,32 @@ body.annotation-mode main::-webkit-scrollbar {
   display: flex;
   flex-direction: column;
   gap: 0;
-  margin-top: 6px;
+}
+
+.annotation-panel-replies-list:not(:empty) {
+  margin-top: 10px;
+  padding: 8px 10px 0;
+  background: #f8fbff;
+  border: 1px solid #e0edff;
+  border-radius: 10px;
 }
 
 .annotation-panel-reply-row {
   display: flex;
   align-items: flex-start;
   gap: 8px;
-  padding: 6px 0;
+  padding: 8px 0;
+}
+
+.annotation-panel-reply-content {
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
 }
 
 .annotation-panel-reply-text {
   margin: 0;
-  flex: 1 1 auto;
   color: #374151;
   font-size: 11px;
   line-height: 1.4;
@@ -1763,9 +1780,11 @@ body.annotation-mode main::-webkit-scrollbar {
 }
 
 .annotation-panel-reply-user {
+  margin: 0;
   color: #1d4ed8;
+  font-size: 12px;
   font-weight: 700;
-  margin-right: 6px;
+  line-height: 1.35;
 }
 
 .annotation-panel-reply-row + .annotation-panel-reply-row {


### PR DESCRIPTION
JIRA: https://jira.corp.adobe.com/browse/MWPW-191330

Updates the annotation comments panel card layout to improve hierarchy and scanability in the narrow side rail. Thread cards now place status and thread actions beneath the main comment, while replies are shown in a softer grouped treatment with cleaner two-line reply metadata.
<img width="1512" height="680" alt="Screenshot 2026-04-06 at 1 39 46 PM" src="https://github.com/user-attachments/assets/7c6aeba1-10dd-42b8-8545-9212158bc065" />


Test URLs:
- Before: https://main--{repo}--{owner}.aem.live/
- After: https://<branch>--{repo}--{owner}.aem.live/
