### PR TITLE
MWPW-191761: Improve medium-editor link input visibility in annotation inline editing

### DIFF
--- a/streamlibs/styles/styles.css
+++ b/streamlibs/styles/styles.css
@@ -2189,6 +2189,94 @@ body.annotation-inline-edit-mode .annotation-selected-element {
   cursor: pointer;
 }
 
+.annotation-inline-edit-mode .medium-editor-toolbar-form-active {
+  background: #fff;
+  border: 1px solid #bfdbfe;
+  border-radius: 10px;
+  box-shadow: 0 8px 24px rgba(30, 64, 175, 0.16);
+}
+
+.annotation-inline-edit-mode .medium-editor-toolbar-form {
+  color: #1f2937;
+  padding: 6px 8px;
+  font-family: 'Adobe Clean', 'Trebuchet MS', sans-serif;
+}
+
+.annotation-inline-edit-mode .medium-editor-toolbar-form .medium-editor-toolbar-input {
+  background: #f8fafc;
+  border: 1px solid #93c5fd;
+  border-radius: 6px;
+  color: #111827;
+  padding: 6px 10px;
+  font-size: 13px;
+  font-family: inherit;
+  height: auto;
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.05);
+}
+
+.annotation-inline-edit-mode .medium-editor-toolbar-form .medium-editor-toolbar-input:focus {
+  border-color: #2563eb;
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.2);
+}
+
+.annotation-inline-edit-mode .medium-editor-toolbar-form .medium-editor-toolbar-input::placeholder {
+  color: #9ca3af;
+}
+
+.annotation-inline-edit-mode .medium-editor-toolbar-form .medium-editor-toolbar-save,
+.annotation-inline-edit-mode .medium-editor-toolbar-form .medium-editor-toolbar-close {
+  min-width: auto;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  margin: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 6px;
+  font-size: 16px;
+  line-height: 1;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+}
+
+.annotation-inline-edit-mode .medium-editor-toolbar-form .medium-editor-toolbar-save {
+  color: #2563eb;
+}
+
+.annotation-inline-edit-mode .medium-editor-toolbar-form .medium-editor-toolbar-save:hover {
+  background: #eff6ff;
+  color: #1d4ed8;
+}
+
+.annotation-inline-edit-mode .medium-editor-toolbar-form .medium-editor-toolbar-close {
+  color: #6b7280;
+}
+
+.annotation-inline-edit-mode .medium-editor-toolbar-form .medium-editor-toolbar-close:hover {
+  background: #fef2f2;
+  color: #dc2626;
+}
+
+.annotation-inline-edit-mode .medium-editor-anchor-preview {
+  background: #fff;
+  border: 1px solid #bfdbfe;
+  border-radius: 8px;
+  box-shadow: 0 6px 16px rgba(30, 64, 175, 0.14);
+  padding: 6px 12px;
+  font-family: 'Adobe Clean', 'Trebuchet MS', sans-serif;
+}
+
+.annotation-inline-edit-mode .medium-editor-anchor-preview a {
+  color: #2563eb;
+  text-decoration: underline;
+  font-size: 13px;
+}
+
+.annotation-inline-edit-mode .medium-editor-toolbar-anchor-preview-inner a:hover {
+  color: #1d4ed8;
+}
 
 @media (max-width: 1200px) {
   .annotation-comments-panel {


### PR DESCRIPTION
## Summary
- The medium-editor "Paste or type a link" anchor form was nearly invisible during annotation inline editing — no background, border, or contrast against the white page
- Added scoped CSS overrides under `.annotation-inline-edit-mode` so the link input, save/close buttons, and anchor preview are clearly visible and match the existing annotation UI design language (blue accents, rounded corners, Adobe Clean font)
- All styles are scoped to inline edit mode only — no impact on other medium-editor instances or components


JIRA: https://jira.corp.adobe.com/browse/MWPW-191761
<img width="1504" height="576" alt="Screenshot 2026-04-09 at 2 32 49 AM" src="https://github.com/user-attachments/assets/e923afbd-1b75-4208-bfaa-24b041048708" />

Test URLs:
- Before: https://main--{repo}--{owner}.aem.live/
- After: https://<branch>--{repo}--{owner}.aem.live/
