### PR TITLE
Add placeholder blocks for empty fig-comp-details responses

### DIFF
--- a/streamlibs/operations/edit/drag-drop.js
+++ b/streamlibs/operations/edit/drag-drop.js
@@ -118,7 +118,7 @@ export default function createEditDragDropController({
   };
 
   function enablePanelDragAndDrop(sourcePanel, targetPanel) {
-    sourcePanel.querySelectorAll('div[data-source="figma"]').forEach((block) => {
+    sourcePanel.querySelectorAll('div[data-source="figma"]:not([data-placeholder])').forEach((block) => {
       block.classList.add('figma-panel-block');
       block.addEventListener('pointerdown', (event) => {
         if (event.button !== 0) return;

--- a/streamlibs/sources/figma.js
+++ b/streamlibs/sources/figma.js
@@ -20,6 +20,7 @@ function isEmptyBlockContent(properties) {
 function createPlaceholder() {
   const div = document.createElement('div');
   div.classList.add('stream-placeholder');
+  div.dataset.placeholder = 'true';
   div.innerHTML = `<p><a href='${PLACEHOLDER_URL}'>${PLACEHOLDER_URL}</a></p>`;
   return div;
 }

--- a/streamlibs/sources/figma.js
+++ b/streamlibs/sources/figma.js
@@ -1,6 +1,29 @@
 import { handleError, safeFetch } from '../utils/error-handler.js';
 import { createFigmaLoaderReporter } from '../utils/loader.js';
 
+const PLACEHOLDER_URL = 'https://main--stream-mapper--adobecom.aem.live/fragments/stream-block-placeholder';
+const METADATA_KEYS = new Set(['colorTheme', 'miloTag','layout']);
+
+function isEmptyBlockContent(properties) {
+  if (!properties || typeof properties !== 'object') return true;
+  const entries = Object.entries(properties);
+  if (entries.length === 0) return true;
+  return entries.every(([key, value]) => {
+    if (METADATA_KEYS.has(key)) return true;
+    if (value === false || value === '' || value == null) return true;
+    if (Array.isArray(value)) return value.length === 0;
+    if (typeof value === 'object') return Object.keys(value).length === 0;
+    return false;
+  });
+}
+
+function createPlaceholder() {
+  const div = document.createElement('div');
+  div.classList.add('stream-placeholder');
+  div.innerHTML = `<p><a href='${PLACEHOLDER_URL}'>${PLACEHOLDER_URL}</a></p>`;
+  return div;
+}
+
 async function fetchFigmaMapping(figmaUrl) {
   try {
     const config = await import('../utils/utils.js').then((m) => m.getConfig());
@@ -106,6 +129,14 @@ async function processBlock(block, figmaUrl, onDetailResponse = () => {}) {
     fetchContent(block.path),
     fetchBlockContent(block.figId, block.id, figmaUrl).finally(() => onDetailResponse()),
   ]);
+
+  const properties = figContent?.details?.properties;
+  if (figContent?.success && isEmptyBlockContent(properties)) {
+    const placeholder = createPlaceholder();
+    block.blockDomEl = placeholder;
+    return placeholder;
+  }
+
   let blockContent = getHtml(doc, block.miloId, block.variant);
   figContent.details.properties.miloTag = block.tag;
   blockContent = await mapFigmaContent(blockContent, block, figContent);

--- a/streamlibs/target/da.js
+++ b/streamlibs/target/da.js
@@ -37,7 +37,7 @@ function replaceSpanWithColonText(html) {
 function removePlaceholderBlocks(html) {
   const parser = new DOMParser();
   const doc = parser.parseFromString(html, 'text/html');
-  doc.querySelectorAll('.stream-placeholder').forEach((el) => el.remove());
+  doc.querySelectorAll('.stream-placeholder, [data-placeholder]').forEach((el) => el.remove());
   return doc.body.innerHTML;
 }
 

--- a/streamlibs/target/da.js
+++ b/streamlibs/target/da.js
@@ -34,7 +34,15 @@ function replaceSpanWithColonText(html) {
 }
 // TODO: check span tag with icon and add in html
 
+function removePlaceholderBlocks(html) {
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(html, 'text/html');
+  doc.querySelectorAll('.stream-placeholder').forEach((el) => el.remove());
+  return doc.body.innerHTML;
+}
+
 export function getDACompatibleHtml(html) {
+  html = removePlaceholderBlocks(html);
   html = replacePictureWithImg(html);
   html = replaceSpanWithColonText(html);
   html = html.replaceAll('\n', '');


### PR DESCRIPTION
## Summary
- When `fig-comp-details` returns all-falsy content properties (ignoring metadata keys like `colorTheme`, `miloTag`, `layout`), render a placeholder fragment link instead of the actual block
- Placeholder blocks are automatically stripped from HTML before pushing to DA via `getDACompatibleHtml`, covering all three push paths (create, edit, annotation)
- Placeholder blocks in the edit mode figma panel are not draggable to the DA panel
## Implementation details
- **figma.js**: `isEmptyBlockContent` checks properties with early exit on first truthy value; `createPlaceholder` creates a div with `stream-placeholder` class and `data-placeholder` attribute; guard in `processBlock` only triggers when `figContent.success` is true (avoids masking API errors)
- **da.js**: `removePlaceholderBlocks` strips `.stream-placeholder` and `[data-placeholder]` elements as the first step in `getDACompatibleHtml`
- **drag-drop.js**: `enablePanelDragAndDrop` selector excludes `[data-placeholder]` blocks from drag handlers (`data-*` attributes survive Milo's `loadArea` processing, unlike CSS classes)


<img width="1511" height="680" alt="Screenshot 2026-04-09 at 9 00 22 PM" src="https://github.com/user-attachments/assets/8ad633cc-529b-496b-9160-eb0e619f69a0" />


Test URLs:
- Before: https://main--{repo}--{owner}.aem.live/
- After: https://<branch>--{repo}--{owner}.aem.live/
