### PR TITLE
[MWPW-192302]notify parent when push to DA succeeds or fails

### DIFF
--- a/streamlibs/previewer.js
+++ b/streamlibs/previewer.js
@@ -51,6 +51,20 @@ import {
 } from './utils/loader.js';
 import { fetchDAContent } from './sources/da.js';
 
+const PUSH_TO_DA_RESULT = 'PUSH_TO_DA_RESULT';
+
+function notifyParentPushToDaResult(success, detailMessage) {
+  if (!window.parent || window.parent === window) return;
+  window.parent.postMessage(
+    {
+      type: PUSH_TO_DA_RESULT,
+      success: !!success,
+      message: detailMessage ? String(detailMessage) : '',
+    },
+    '*',
+  );
+}
+
 function parseBooleanFlag(value) {
   if (value === true || value === 'true') return true;
   if (value === false || value === 'false') return false;
@@ -219,7 +233,11 @@ async function setupMessageListener() {
     if (!isOriginAllowed) return;
 
     if (event.data.type === 'PUSH_TO_DA') {
-      await persist();
+      try {
+        await persist();
+      } catch {
+        // persist() notifies the parent on failure; swallow to avoid unhandled rejection
+      }
     }
     if (event.data.type === 'SAVE_ANNOTATION_CHANGES') {
       await saveChanges();
@@ -311,9 +329,12 @@ export async function persist() {
     }
     hideLoader();
     showDOMElements([document.querySelector('main')]);
+    notifyParentPushToDaResult(true);
   } catch (error) {
     hideLoader();
     showDOMElements([document.querySelector('main')]);
+    const detail = error?.message ? String(error.message) : '';
+    notifyParentPushToDaResult(false, detail);
     handleError(error, 'persisting content');
     throw error;
   }


### PR DESCRIPTION
Implements a postMessage or the preview iframe to report "Push to DA" results. The iframe now wraps persist() in a try/catch block, sending a PUSH_TO_DA_RESULT message (with success or failure details) back to the parent.
<img width="434" height="398" alt="image" src="https://github.com/user-attachments/assets/5a6f3d0f-8785-4c46-9e5e-e36cbe6ca50b" />


Test URLs:
- Before: https://main--{repo}--{owner}.aem.live/
- After: https://<branch>--{repo}--{owner}.aem.live/
