### PR TITLE
MWPW-193324 | Change block request firing logic to use retries with exponential backoff on 503 status code.

### DIFF
--- a/streamlibs/scripts.js
+++ b/streamlibs/scripts.js
@@ -37,7 +37,7 @@ const CONFIG = {
   },
   figmaServiceRetry: {
     retryCount: 3,
-    retryDelaysMs: [1000, 2000, 4000],
+    retryDelaysMs: [1000, 2000, 4000, 6000],
     blockContentConcurrency: 3,
   },
   prod: {

--- a/streamlibs/scripts.js
+++ b/streamlibs/scripts.js
@@ -37,7 +37,7 @@ const CONFIG = {
   },
   figmaServiceRetry: {
     retryCount: 3,
-    retryDelaysMs: [2000, 4000, 8000],
+    retryDelaysMs: [1000, 2000, 8000],
     blockContentConcurrency: 3,
   },
   prod: {

--- a/streamlibs/scripts.js
+++ b/streamlibs/scripts.js
@@ -37,7 +37,7 @@ const CONFIG = {
   },
   figmaServiceRetry: {
     retryCount: 3,
-    retryDelaysMs: [1000, 2000, 8000],
+    retryDelaysMs: [1000, 2000, 4000],
     blockContentConcurrency: 3,
   },
   prod: {

--- a/streamlibs/scripts.js
+++ b/streamlibs/scripts.js
@@ -35,6 +35,11 @@ const CONFIG = {
     de: { ietf: 'de-DE', tk: 'hah7vzn.css' },
     kr: { ietf: 'ko-KR', tk: 'zfo3ouc' },
   },
+  figmaServiceRetry: {
+    retryCount: 3,
+    retryDelaysMs: [2000, 4000, 8000],
+    blockContentConcurrency: 3,
+  },
   prod: {
     streamMapper: {
       serviceEP: 'https://adobe-acom-stream-service-deploy-ethos502-prod-or2-1de07c.cloud.adobe.io',

--- a/streamlibs/sources/figma.js
+++ b/streamlibs/sources/figma.js
@@ -25,24 +25,43 @@ function createPlaceholder() {
   return div;
 }
 
-const FIGMA_SERVICE_MAX_RETRIES = 2;
-const FIGMA_SERVICE_RETRY_BASE_DELAY_MS = 500;
+const DEFAULT_FIGMA_RETRY_CONFIG = {
+  retryCount: 3,
+  retryDelaysMs: [2000, 4000, 8000],
+  blockContentConcurrency: 3,
+};
 
-async function fetchJsonWithRetry(url, options, retries = FIGMA_SERVICE_MAX_RETRIES) {
-  for (let attempt = 0; attempt <= retries; attempt += 1) {
+async function getFigmaRetryConfig() {
+  try {
+    const config = await import('../utils/utils.js').then((m) => m.getConfig());
+    return { ...DEFAULT_FIGMA_RETRY_CONFIG, ...(config?.figmaServiceRetry || {}) };
+  } catch (e) {
+    return DEFAULT_FIGMA_RETRY_CONFIG;
+  }
+}
+
+function getRetryDelay(delays, attempt) {
+  if (!Array.isArray(delays) || delays.length === 0) return 0;
+  const idx = Math.min(attempt, delays.length - 1);
+  return delays[idx];
+}
+
+async function fetchJsonWithRetry(url, options) {
+  const { retryCount, retryDelaysMs } = await getFigmaRetryConfig();
+  const maxRetries = Number.isInteger(retryCount) && retryCount >= 0 ? retryCount : 0;
+  for (let attempt = 0; attempt <= maxRetries; attempt += 1) {
     // eslint-disable-next-line no-await-in-loop
     const response = await fetch(url, options);
     if (response.ok) {
       // eslint-disable-next-line no-await-in-loop, no-return-await
       return await response.json();
     }
-    if (response.status !== 503 || attempt === retries) {
+    if (response.status !== 503 || attempt === maxRetries) {
       throw new Error(`HTTP error! Status: ${url} ${response.status}`);
     }
+    const delay = getRetryDelay(retryDelaysMs, attempt);
     // eslint-disable-next-line no-await-in-loop
-    await new Promise((resolve) => {
-      setTimeout(resolve, FIGMA_SERVICE_RETRY_BASE_DELAY_MS * (attempt + 1));
-    });
+    await new Promise((resolve) => { setTimeout(resolve, delay); });
   }
   return {};
 }
@@ -171,15 +190,31 @@ async function processBlock(block, figmaUrl, onDetailResponse = () => {}) {
   return blockContent || '';
 }
 
+async function runWithConcurrency(items, concurrency, worker) {
+  const results = new Array(items.length);
+  let cursor = 0;
+  const limit = Math.max(1, concurrency);
+  async function runner() {
+    while (cursor < items.length) {
+      const current = cursor;
+      cursor += 1;
+      // eslint-disable-next-line no-await-in-loop
+      results[current] = await worker(items[current], current);
+    }
+  }
+  const runnerCount = Math.min(limit, items.length);
+  await Promise.all(Array.from({ length: runnerCount }, () => runner()));
+  return results;
+}
+
 async function createHTML(blockMapping, figmaUrl, tracker) {
   const blocks = blockMapping.details.components;
-  const htmlParts = [];
-  // eslint-disable-next-line no-restricted-syntax
-  for (const block of blocks) {
-    // eslint-disable-next-line no-await-in-loop
-    const part = await processBlock(block, figmaUrl, () => tracker.markDetailResponse());
-    htmlParts.push(part);
-  }
+  const { blockContentConcurrency } = await getFigmaRetryConfig();
+  const htmlParts = await runWithConcurrency(
+    blocks,
+    blockContentConcurrency,
+    (block) => processBlock(block, figmaUrl, () => tracker.markDetailResponse()),
+  );
   return htmlParts.filter(Boolean);
 }
 

--- a/streamlibs/sources/figma.js
+++ b/streamlibs/sources/figma.js
@@ -68,13 +68,20 @@ async function fetchJsonWithRetry(url, options) {
       // eslint-disable-next-line no-await-in-loop, no-return-await
       return await response.json();
     }
-    if (response.status !== 503 || attempt === maxRetries) {
-      throw new Error(`HTTP error! Status: ${url} ${response.status}`);
+    if (response.status === 503) {
+      lastError = new Error(`HTTP 503 from ${url}`);
+      lastError.is503Exhausted = attempt === maxRetries;
+      if (attempt === maxRetries) {
+        handleError(lastError, ' experiencing high server load. Please try again later');
+        throw lastError;
+      }
+      const delay = getRetryDelay(retryDelaysMs, attempt);
+      // eslint-disable-next-line no-await-in-loop
+      await new Promise((resolve) => { setTimeout(resolve, delay); });
+      // eslint-disable-next-line no-continue
+      continue;
     }
-    lastError = new Error(`HTTP 503 from ${url}`);
-    const delay = getRetryDelay(retryDelaysMs, attempt);
-    // eslint-disable-next-line no-await-in-loop
-    await new Promise((resolve) => { setTimeout(resolve, delay); });
+    throw new Error(`HTTP error! Status: ${url} ${response.status}`);
   }
   if (lastError) throw lastError;
   return {};
@@ -99,7 +106,7 @@ async function fetchFigmaMapping(figmaUrl) {
       },
     );
   } catch (error) {
-    handleError(error, 'getting figma mapping');
+    if (!error?.is503Exhausted) handleError(error, 'getting figma mapping');
     throw error;
   }
 }
@@ -159,6 +166,7 @@ async function fetchBlockContent(figId, id, figmaUrl) {
       },
     );
   } catch (error) {
+    if (error?.is503Exhausted) throw error;
     handleError(error, 'getting block content');
     return {};
   }
@@ -207,17 +215,26 @@ async function processBlock(block, figmaUrl, onDetailResponse = () => {}) {
 async function runWithConcurrency(items, concurrency, worker) {
   const results = new Array(items.length);
   let cursor = 0;
+  let stopped = false;
+  let firstError = null;
   const limit = Math.max(1, concurrency);
   async function runner() {
-    while (cursor < items.length) {
+    while (cursor < items.length && !stopped) {
       const current = cursor;
       cursor += 1;
-      // eslint-disable-next-line no-await-in-loop
-      results[current] = await worker(items[current], current);
+      try {
+        // eslint-disable-next-line no-await-in-loop
+        results[current] = await worker(items[current], current);
+      } catch (error) {
+        stopped = true;
+        if (!firstError) firstError = error;
+        return;
+      }
     }
   }
   const runnerCount = Math.min(limit, items.length);
   await Promise.all(Array.from({ length: runnerCount }, () => runner()));
+  if (firstError) throw firstError;
   return results;
 }
 

--- a/streamlibs/sources/figma.js
+++ b/streamlibs/sources/figma.js
@@ -49,9 +49,21 @@ function getRetryDelay(delays, attempt) {
 async function fetchJsonWithRetry(url, options) {
   const { retryCount, retryDelaysMs } = await getFigmaRetryConfig();
   const maxRetries = Number.isInteger(retryCount) && retryCount >= 0 ? retryCount : 0;
+  let lastError;
   for (let attempt = 0; attempt <= maxRetries; attempt += 1) {
-    // eslint-disable-next-line no-await-in-loop
-    const response = await fetch(url, options);
+    let response;
+    try {
+      // eslint-disable-next-line no-await-in-loop
+      response = await fetch(url, options);
+    } catch (networkError) {
+      lastError = networkError;
+      if (attempt === maxRetries) throw networkError;
+      const delay = getRetryDelay(retryDelaysMs, attempt);
+      // eslint-disable-next-line no-await-in-loop
+      await new Promise((resolve) => { setTimeout(resolve, delay); });
+      // eslint-disable-next-line no-continue
+      continue;
+    }
     if (response.ok) {
       // eslint-disable-next-line no-await-in-loop, no-return-await
       return await response.json();
@@ -59,10 +71,12 @@ async function fetchJsonWithRetry(url, options) {
     if (response.status !== 503 || attempt === maxRetries) {
       throw new Error(`HTTP error! Status: ${url} ${response.status}`);
     }
+    lastError = new Error(`HTTP 503 from ${url}`);
     const delay = getRetryDelay(retryDelaysMs, attempt);
     // eslint-disable-next-line no-await-in-loop
     await new Promise((resolve) => { setTimeout(resolve, delay); });
   }
+  if (lastError) throw lastError;
   return {};
 }
 

--- a/streamlibs/sources/figma.js
+++ b/streamlibs/sources/figma.js
@@ -25,19 +25,9 @@ function createPlaceholder() {
   return div;
 }
 
-const DEFAULT_FIGMA_RETRY_CONFIG = {
-  retryCount: 3,
-  retryDelaysMs: [2000, 4000, 8000],
-  blockContentConcurrency: 3,
-};
-
 async function getFigmaRetryConfig() {
-  try {
-    const config = await import('../utils/utils.js').then((m) => m.getConfig());
-    return { ...DEFAULT_FIGMA_RETRY_CONFIG, ...(config?.figmaServiceRetry || {}) };
-  } catch (e) {
-    return DEFAULT_FIGMA_RETRY_CONFIG;
-  }
+  const config = await import('../utils/utils.js').then((m) => m.getConfig());
+  return config.figmaServiceRetry;
 }
 
 function getRetryDelay(delays, attempt) {

--- a/streamlibs/sources/figma.js
+++ b/streamlibs/sources/figma.js
@@ -62,7 +62,7 @@ async function fetchJsonWithRetry(url, options) {
       lastError = new Error(`HTTP 503 from ${url}`);
       lastError.is503Exhausted = attempt === maxRetries;
       if (attempt === maxRetries) {
-        handleError(lastError, ' experiencing high server load. Please try again later');
+        handleError(lastError, 'We are experiencing high server load. Please try again later', '');
         throw lastError;
       }
       const delay = getRetryDelay(retryDelaysMs, attempt);

--- a/streamlibs/utils/error-handler.js
+++ b/streamlibs/utils/error-handler.js
@@ -1,4 +1,4 @@
-export function showErrorPage(context = '') {
+export function showErrorPage(context = '', preMessage = 'Oops! Something broke while') {
   const safeContext = (context || 'processing your request').replace(/[<>]/g, '');
   document.body.innerHTML = `
       <div class="enigma-error-page">
@@ -10,7 +10,7 @@ export function showErrorPage(context = '') {
               >
             </div>
             <div class="enigma-error-copy">
-                <h1 class="enigma-error-title">Oops! Something broke while ${safeContext}</h1>
+                <h1 class="enigma-error-title">${preMessage} ${safeContext}</h1>
                 <p class="enigma-retry-line">
                   <span class="enigma-retry-text">Give it another go?</span>
                   <button type="button" id="enigma-retry-btn" class="enigma-retry-btn">Yes Retry</button>
@@ -32,10 +32,10 @@ export function showErrorPage(context = '') {
 }
 
 // eslint-disable-next-line no-unused-vars
-export function handleError(error, context = '') {
+export function handleError(error, context = '', preMessage='Oops! Something broke while') {
   // eslint-disable-next-line no-console
   console.log(error);
-  showErrorPage(context);
+  showErrorPage(context, preMessage);
 }
 
 export async function safeFetch(url, options = {}, customSettings = {}) {


### PR DESCRIPTION
### MWPW-193324 | Change block request firing logic to use retries with exponential backoff on 503 status code.
Improves resilience when calling the Figma service (/api/fig-comps and /api/fig-comp-details) by adding configurable retry behavior with increasing delays, parallel block-detail fetching, and a clear user-facing error when the service still returns 503 after all attempts.
- Add figmaServiceRetry on CONFIG with retryCount, retryDelaysMs (exponential-style backoff, e.g. 1s / 2s / 4s in config), and blockContentConcurrency (default 3) so behavior can be tuned per deployment without code changes.
streamlibs/sources/figma.js:
- Centralize Figma calls through fetchJsonWithRetry, which reads retry settings from getConfig().figmaServiceRetry (with sensible defaults if missing).
- Retries on HTTP 503 and on thrown fetch errors (e.g. transient network failures) using the configured delay array.
- After the last failed attempt on 503, calls handleError with a “high server load, try again later” message, then throws; errors are tagged with is503Exhausted so outer callers do not show a second, conflicting error page.
- fetchFigmaMapping and fetchBlockContent are wired to this path; re-throw on exhausted 503 for block content so the pipeline can stop.
- runWithConcurrency processes blocks with up to blockContentConcurrency workers and stops the pool on the first thrown error (e.g. exhausted 503) so the rest of the work does not keep running in parallel.