### PR TITLE
MWPW-192811: prevent false positive formatting and race condition on disable

### DIFF
--- a/streamlibs/operations/annotation/inline-editing.js
+++ b/streamlibs/operations/annotation/inline-editing.js
@@ -15,6 +15,15 @@ export default function createInlineEditingController({
 }) {
   const annotationService = createAnnotationServiceClient();
   const isInlineEditingAllowed = () => window.streamConfig?.inlineEditingAllowed !== false;
+  const EXPLICIT_FORMATTING_TOOLBAR_ACTIONS = new Set([
+    'bold',
+    'italic',
+    'underline',
+    'anchor',
+    'append-h2',
+    'append-h3',
+    'append-blockquote',
+  ]);
 
   function normalizeInlineFormattingHtml(html = '') {
     const template = document.createElement('template');
@@ -125,6 +134,81 @@ export default function createInlineEditingController({
       });
   }
 
+  function clearExplicitFormattingIntent(elementRef = '') {
+    if (!elementRef) return;
+    annotationState.explicitFormattingElementRefs.delete(elementRef);
+    if (annotationUI.inlineActiveElementRef === elementRef) {
+      annotationUI.inlineActiveElementRef = '';
+    }
+  }
+
+  function markInlineElementAsFormattingIntent(elementRef = '') {
+    if (!elementRef) return;
+    annotationState.explicitFormattingElementRefs.add(elementRef);
+  }
+
+  function setActiveInlineEditableElement(element) {
+    if (!(element instanceof HTMLElement)) return;
+    annotationUI.inlineActiveElementRef = store.ensureElementRef(element);
+  }
+
+  function getActiveInlineEditableElementRef() {
+    const currentRef = annotationUI.inlineActiveElementRef;
+    if (currentRef && annotationUI.mainEl?.querySelector(`[data-annotation-ref="${currentRef}"]`)) {
+      return currentRef;
+    }
+
+    const selection = window.getSelection();
+    const candidateNodes = [
+      selection?.anchorNode,
+      selection?.focusNode,
+      selection?.rangeCount ? selection.getRangeAt(0).commonAncestorContainer : null,
+    ];
+
+    for (let idx = 0; idx < candidateNodes.length; idx += 1) {
+      const node = candidateNodes[idx];
+      const element = node instanceof HTMLElement ? node : node?.parentElement;
+      const editableElement = element?.closest('.annotation-inline-editable');
+      if (editableElement instanceof HTMLElement) {
+        const elementRef = store.ensureElementRef(editableElement);
+        annotationUI.inlineActiveElementRef = elementRef;
+        return elementRef;
+      }
+    }
+
+    return '';
+  }
+
+  function handleInlineToolbarClick(event) {
+    if (!annotationUI.inlineMode) return;
+    const button = event.target instanceof HTMLElement
+      ? event.target.closest('button[data-action]')
+      : null;
+    if (!(button instanceof HTMLButtonElement)) return;
+    if (!button.closest('.medium-editor-toolbar')) return;
+
+    const action = `${button.getAttribute('data-action') || ''}`.trim();
+    if (!EXPLICIT_FORMATTING_TOOLBAR_ACTIONS.has(action)) return;
+
+    const activeElementRef = getActiveInlineEditableElementRef();
+    if (!activeElementRef) return;
+    markInlineElementAsFormattingIntent(activeElementRef);
+  }
+
+  function attachInlineToolbarTracking() {
+    if (annotationUI.inlineToolbarClickHandler) return;
+    annotationUI.inlineToolbarClickHandler = (event) => {
+      handleInlineToolbarClick(event);
+    };
+    document.addEventListener('click', annotationUI.inlineToolbarClickHandler, true);
+  }
+
+  function detachInlineToolbarTracking() {
+    if (!annotationUI.inlineToolbarClickHandler) return;
+    document.removeEventListener('click', annotationUI.inlineToolbarClickHandler, true);
+    annotationUI.inlineToolbarClickHandler = null;
+  }
+
   async function trackInlineEditChange(element) {
     if (!(element instanceof HTMLElement) || !annotationUI.mainEl) return;
     const elementRef = store.ensureElementRef(element);
@@ -136,6 +220,16 @@ export default function createInlineEditingController({
     const didTextChange = currentText.trim() !== snapshot.originalText.trim();
     const didHtmlChange = currentHtml !== snapshot.originalHtml;
     if (!didTextChange && !didHtmlChange) return;
+    const hasExplicitFormattingIntent = annotationState.explicitFormattingElementRefs
+      .has(elementRef);
+    if (!didTextChange && didHtmlChange && !hasExplicitFormattingIntent) {
+      annotationUI.inlineElementSnapshot.set(elementRef, {
+        originalHtml: currentHtml,
+        originalText: currentText,
+      });
+      clearExplicitFormattingIntent(elementRef);
+      return;
+    }
 
     const editAnchor = store.buildEditElementAnchor(element, annotationUI.mainEl);
     const easyEditElementPath = editAnchor.elementPath;
@@ -179,6 +273,7 @@ export default function createInlineEditingController({
       originalHtml: currentHtml,
       originalText: currentText,
     });
+    clearExplicitFormattingIntent(elementRef);
   }
 
   function getSelectedImageForMediumEditor() {
@@ -468,6 +563,7 @@ export default function createInlineEditingController({
   function resetInlineEditModeState() {
     annotationUI.inlineMode = false;
     document.body.classList.remove('annotation-inline-edit-mode');
+    detachInlineToolbarTracking();
 
     if (annotationUI.mediumEditorInstance) {
       annotationUI.mediumEditorInstance.destroy();
@@ -476,7 +572,13 @@ export default function createInlineEditingController({
 
     annotationUI.editableElements.forEach((element) => {
       const elementRef = element.dataset.annotationRef;
+      const focusHandler = elementRef ? annotationUI.inlineFocusHandlers.get(elementRef) : null;
       const handler = elementRef ? annotationUI.inlineBlurHandlers.get(elementRef) : null;
+      if (focusHandler) {
+        element.removeEventListener('focus', focusHandler, true);
+        element.removeEventListener('click', focusHandler, true);
+        annotationUI.inlineFocusHandlers.delete(elementRef);
+      }
       if (handler) {
         element.removeEventListener('blur', handler, true);
         annotationUI.inlineBlurHandlers.delete(elementRef);
@@ -491,6 +593,8 @@ export default function createInlineEditingController({
     annotationUI.editableImages = [];
     annotationUI.inlineElementSnapshot.clear();
     annotationUI.inlineImageAltSnapshot.clear();
+    annotationUI.inlineActiveElementRef = '';
+    annotationState.explicitFormattingElementRefs.clear();
     detachInlineImageSelectionHandler();
     closeInlineAltPopup();
   }
@@ -515,6 +619,7 @@ export default function createInlineEditingController({
     annotationUI.editableElements = getInlineEditableElements();
     annotationUI.editableImages = getInlineEditableImages();
     annotationUI.mediumEditorInstance = createMediumEditorInstance(annotationUI.editableElements);
+    attachInlineToolbarTracking();
     attachInlineImageSelectionHandler();
 
     annotationUI.editableElements.forEach((element) => {
@@ -527,8 +632,14 @@ export default function createInlineEditingController({
       const blurHandler = () => {
         trackInlineEditChange(element);
       };
+      const focusHandler = () => {
+        setActiveInlineEditableElement(element);
+      };
       annotationUI.inlineBlurHandlers.set(elementRef, blurHandler);
+      annotationUI.inlineFocusHandlers.set(elementRef, focusHandler);
       element.addEventListener('blur', blurHandler, true);
+      element.addEventListener('focus', focusHandler, true);
+      element.addEventListener('click', focusHandler, true);
     });
 
     annotationUI.editableImages.forEach((imageElement) => {

--- a/streamlibs/operations/annotation/inline-editing.js
+++ b/streamlibs/operations/annotation/inline-editing.js
@@ -197,9 +197,7 @@ export default function createInlineEditingController({
 
   function attachInlineToolbarTracking() {
     if (annotationUI.inlineToolbarClickHandler) return;
-    annotationUI.inlineToolbarClickHandler = (event) => {
-      handleInlineToolbarClick(event);
-    };
+    annotationUI.inlineToolbarClickHandler = handleInlineToolbarClick;
     document.addEventListener('click', annotationUI.inlineToolbarClickHandler, true);
   }
 
@@ -227,7 +225,6 @@ export default function createInlineEditingController({
         originalHtml: currentHtml,
         originalText: currentText,
       });
-      clearExplicitFormattingIntent(elementRef);
       return;
     }
 
@@ -362,13 +359,12 @@ export default function createInlineEditingController({
 
     const popup = document.createElement('div');
     popup.className = 'annotation-inline-alt-popup';
-    const currentAlt = imageElement.getAttribute('alt') || '';
     popup.innerHTML = `
       <div class="annotation-inline-alt-popup__header">
         <h4>Edit image alt text</h4>
         <button type="button" class="annotation-inline-alt-popup__close" data-action="close" aria-label="Close">x</button>
       </div>
-      <textarea class="annotation-inline-alt-popup__input" data-input="alt" placeholder="Describe the image for accessibility...">${currentAlt}</textarea>
+      <textarea class="annotation-inline-alt-popup__input" data-input="alt" placeholder="Describe the image for accessibility..."></textarea>
       <div class="annotation-inline-alt-popup__actions">
         <button type="button" class="annotation-inline-alt-popup__btn" data-action="cancel">Cancel</button>
         <button type="button" class="annotation-inline-alt-popup__btn annotation-inline-alt-popup__btn--primary" data-action="save">Save</button>
@@ -392,6 +388,7 @@ export default function createInlineEditingController({
 
     const input = popup.querySelector('[data-input="alt"]');
     if (input instanceof HTMLTextAreaElement) {
+      input.value = imageElement.getAttribute('alt') || '';
       input.focus();
       input.setSelectionRange(input.value.length, input.value.length);
       input.addEventListener('keydown', (event) => {
@@ -550,16 +547,6 @@ export default function createInlineEditingController({
     await Promise.all(pendingUpdates);
   }
 
-  function flushPendingInlineChangesInBackground(pendingTasks = []) {
-    if (!pendingTasks.length) return;
-
-    Promise.allSettled(pendingTasks).then(() => {
-      store.saveAnnotationStore();
-      renderThreadMarkers({ resolveTargets: true });
-      renderCommentsPanel();
-    });
-  }
-
   function resetInlineEditModeState() {
     annotationUI.inlineMode = false;
     document.body.classList.remove('annotation-inline-edit-mode');
@@ -656,18 +643,16 @@ export default function createInlineEditingController({
   async function disableInlineEditMode() {
     if (!annotationUI.inlineMode) return;
 
-    const pendingInlineChangeTasks = [
-      ...annotationUI.editableElements.map((element) => trackInlineEditChange(element)),
-      syncImageAltChanges(),
-    ];
+    await Promise.all(
+      annotationUI.editableElements.map((element) => trackInlineEditChange(element)),
+    );
+    await syncImageAltChanges();
+    store.saveAnnotationStore();
 
     resetInlineEditModeState();
-
     store.applyEasyEditsToDom();
-    store.saveAnnotationStore();
     renderThreadMarkers();
     renderCommentsPanel();
-    flushPendingInlineChangesInBackground(pendingInlineChangeTasks);
   }
 
   async function syncInlineEditsBeforePersist() {

--- a/streamlibs/operations/annotation/state.js
+++ b/streamlibs/operations/annotation/state.js
@@ -1,6 +1,11 @@
 export function createAnnotationState() {
   return {
-    store: { threads: [], easyEdits: [], assets: [], localAssets: [] },
+    store: {
+      threads: [],
+      easyEdits: [],
+      assets: [],
+      localAssets: [],
+    },
     selectedElement: null,
     selectedElementPath: '',
     selectedElementRef: '',
@@ -8,6 +13,7 @@ export function createAnnotationState() {
     activeMessageId: '',
     activeEditId: '',
     mediumEditorLoadPromise: null,
+    explicitFormattingElementRefs: new Set(),
     latestSavedEditsUpdatedAt: null,
     latestSelfSavedEditsHash: '',
     latestSelfSavedEditsCount: 0,
@@ -52,6 +58,9 @@ export function createAnnotationUI() {
     inlineElementSnapshot: new Map(),
     inlineImageAltSnapshot: new Map(),
     inlineBlurHandlers: new Map(),
+    inlineFocusHandlers: new Map(),
+    inlineActiveElementRef: '',
+    inlineToolbarClickHandler: null,
     inlineSelectedImageEl: null,
     inlineImageSelectHandler: null,
     inlineAltPopupEl: null,


### PR DESCRIPTION
JIRA: https://jira.corp.adobe.com/browse/MWPW-192811

Prevents false or lost inline edits by waiting for pending text/image-alt changes before tearing down inline edit mode. Also fixes an XSS issue in the image alt popup by avoiding raw alt text injection into innerHTML, and keeps the active inline element intact when ignoring HTML-only changes without explicit formatting intent.

<img width="2341" height="1063" alt="Screenshot 2026-04-23 at 4 21 12 PM" src="https://github.com/user-attachments/assets/7d8252ab-c028-4183-adf9-6f0011eae47f" />


Test URLs:
- Before: https://main--{repo}--{owner}.aem.live/
- After: https://<branch>--{repo}--{owner}.aem.live/
