### PR TITLE
Mwpw 193909 masonary section metadata

### DIFF
--- a/streamlibs/blocks/masonry.js
+++ b/streamlibs/blocks/masonry.js
@@ -93,7 +93,7 @@ export default async function mapBlockContent(sectionWrapper, blockContent, figC
     const mappingData = await safeJsonFetch('brick.json');
     properties.masonryArrangement = [];
     properties.bricks.forEach((brick) => {
-      if (!brick.brickType) return;
+      if (!brick.brickType || !brick.spanLayout) return;
       const blockTemplate = blockContent.cloneNode(true);
       if (brick.colorTheme) blockTemplate.classList.add(brick.colorTheme);
       properties.masonryArrangement.push(brick.spanLayout.toLowerCase());
@@ -145,7 +145,7 @@ export default async function mapBlockContent(sectionWrapper, blockContent, figC
     blockContent.classList.add('to-remove');
     sectionWrapper.querySelectorAll('.to-remove').forEach((el) => el.remove());
     const allBricks = sectionWrapper.querySelectorAll('.brick');
-    handleMasonrysWithSectionMetadata(sectionWrapper, allBricks[allBricks.length - 1], properties.masonryArrangement);
+    if (allBricks.length) handleMasonrysWithSectionMetadata(sectionWrapper, allBricks[allBricks.length - 1], properties.masonryArrangement);
     if (properties.background) handleBackgroundWithSectionMetadata(sectionWrapper, blockContent, properties.background);
     handleVariants(sectionWrapper, blockContent, properties);
   } catch (error) {

--- a/streamlibs/components/components.js
+++ b/streamlibs/components/components.js
@@ -321,54 +321,23 @@ function parseArrangement(arrangement) {
   const parts = arrangement.split(' ');
   if (parts.length < 2) {
     // eslint-disable-next-line no-console
-    console.warn(`[masonry] skipping unrecognized token: "${arrangement}"`);
+    console.warn(`[masonry] skipping unrecognized span: "${arrangement}"`);
     return null;
   }
-  const intPart = parseInt(parts[1].trim(), 10);
-  if (Number.isNaN(intPart) || intPart < 1 || intPart > 12) {
+  const spanValue = parseInt(parts[1].trim(), 10);
+  if (Number.isNaN(spanValue) || spanValue < 1 || spanValue > 12) {
     // eslint-disable-next-line no-console
     console.warn(`[masonry] skipping invalid span value in: "${arrangement}"`);
     return null;
   }
-  return { token: arrangement.toLowerCase(), intPart };
-}
-
-function buildMasonryRows(masonryArrangement) {
-  const rows = [];
-  let current = '';
-  let sum = 0;
-  masonryArrangement.map(parseArrangement).filter(Boolean).forEach(({ token, intPart }) => {
-    sum += intPart;
-    if (sum < 12) {
-      current += `${token}, `;
-    } else if (sum > 12) {
-      if (current) rows.push(current.replace(/, $/, ''));
-      current = `${token}, `;
-      sum = intPart;
-    } else if (intPart === 12) {
-      if (current) rows.push(current.replace(/, $/, ''));
-      rows.push('full-width');
-      current = '';
-      sum = 0;
-    } else {
-      rows.push(`${current}${token}`);
-      current = '';
-      sum = 0;
-    }
-  });
-  if (current) rows.push(current.replace(/, $/, ''));
-  return rows;
+  return { span: spanValue === 12 ? 'full-width' : arrangement.toLowerCase(), spanValue };
 }
 
 export function handleMasonrysWithSectionMetadata(secEl, blockEl, masonryArrangement) {
   const styleLoc = addOrUpdateSectionMetadata(secEl, blockEl, 'masonry');
-  const rows = buildMasonryRows(masonryArrangement);
-  const children = [];
-  rows.forEach((r, i) => {
-    if (i > 0) children.push(document.createTextNode('\n'));
-    const p = document.createElement('p');
-    p.textContent = r;
-    children.push(p);
-  });
-  styleLoc.replaceChildren(...children);
+  const spans = masonryArrangement.map(parseArrangement).filter(Boolean).map(({ span }) => span);
+  if (!spans.length) { styleLoc.replaceChildren(); return; }
+  const p = document.createElement('p');
+  p.textContent = spans.join(', ');
+  styleLoc.replaceChildren(p);
 }

--- a/streamlibs/components/components.js
+++ b/streamlibs/components/components.js
@@ -317,27 +317,58 @@ export function handleProductLockup(value, areaEl) {
   if (productName) areaEl.innerHTML += productName;
 }
 
-export function handleMasonrysWithSectionMetadata(secEl, blockEl, masonryArrangement) {
-  const styleLoc = addOrUpdateSectionMetadata(secEl, blockEl, 'masonry');
+function parseArrangement(arrangement) {
+  const parts = arrangement.split(' ');
+  if (parts.length < 2) {
+    // eslint-disable-next-line no-console
+    console.warn(`[masonry] skipping unrecognized token: "${arrangement}"`);
+    return null;
+  }
+  const intPart = parseInt(parts[1].trim(), 10);
+  if (Number.isNaN(intPart) || intPart < 1 || intPart > 12) {
+    // eslint-disable-next-line no-console
+    console.warn(`[masonry] skipping invalid span value in: "${arrangement}"`);
+    return null;
+  }
+  return { token: arrangement.toLowerCase(), intPart };
+}
+
+function buildMasonryRows(masonryArrangement) {
+  const rows = [];
+  let current = '';
   let sum = 0;
-  let masonryStyle = '';
-  // eslint-disable-next-line no-restricted-syntax
-  for (const arrangement of masonryArrangement) {
-    const a = arrangement.toLowerCase();
-    const intPart = parseInt(arrangement.split(' ')[1].trim(), 10);
+  masonryArrangement.map(parseArrangement).filter(Boolean).forEach(({ token, intPart }) => {
     sum += intPart;
     if (sum < 12) {
-      masonryStyle += `${a}, `;
+      current += `${token}, `;
     } else if (sum > 12) {
-      masonryStyle += `\n${a}`;
+      if (current) rows.push(current.replace(/, $/, ''));
+      current = `${token}, `;
+      sum = intPart;
+    } else if (intPart === 12) {
+      if (current) rows.push(current.replace(/, $/, ''));
+      rows.push('full-width');
+      current = '';
       sum = 0;
-    } else if (sum === 12 && intPart === 12) {
-      masonryStyle += 'full-width\n';
-      sum = 0;
-    } else if (sum === 12) {
-      masonryStyle += `${a}\n`;
+    } else {
+      rows.push(`${current}${token}`);
+      current = '';
       sum = 0;
     }
-  }
-  styleLoc.innerHTML = masonryStyle;
+  });
+  if (current) rows.push(current.replace(/, $/, ''));
+  return rows;
+}
+
+export function handleMasonrysWithSectionMetadata(secEl, blockEl, masonryArrangement) {
+  const styleLoc = addOrUpdateSectionMetadata(secEl, blockEl, 'masonry');
+  const rows = buildMasonryRows(masonryArrangement);
+  const children = [];
+  rows.forEach((r, i) => {
+    if (i > 0) children.push(document.createTextNode('\n'));
+    const p = document.createElement('p');
+    p.textContent = r;
+    children.push(p);
+  });
+  styleLoc.replaceChildren(...children);
 }

--- a/streamlibs/sources/da.js
+++ b/streamlibs/sources/da.js
@@ -55,11 +55,27 @@ async function getDAContent(path = false) {
   return html;
 }
 
+function restoreNewlinesInMasonryCell(doc) {
+  doc.querySelectorAll('.section-metadata > div').forEach((row) => {
+    const propertyCell = row.children[0];
+    const valueCell = row.children[1];
+    if (!propertyCell || !valueCell) return;
+    if (propertyCell.textContent.trim().toLowerCase() !== 'masonry') return;
+    [...valueCell.querySelectorAll(':scope > p')].forEach((p, i) => {
+      if (i === 0) return;
+      const prev = p.previousSibling;
+      const hasNewline = prev && prev.nodeType === Node.TEXT_NODE && prev.textContent.includes('\n');
+      if (!hasNewline) valueCell.insertBefore(document.createTextNode('\n'), p);
+    });
+  });
+}
+
 // eslint-disable-next-line import/prefer-default-export
 export async function fetchDAContent(path = false) {
   const doc = await getDAContent(path);
   const parser = new DOMParser();
   const html = parser.parseFromString(doc, 'text/html');
+  restoreNewlinesInMasonryCell(html);
   return html.querySelector('main');
 }
 

--- a/streamlibs/sources/da.js
+++ b/streamlibs/sources/da.js
@@ -65,7 +65,7 @@ function restoreNewlinesInMasonryCell(doc) {
       if (i === 0) return;
       const prev = p.previousSibling;
       const hasNewline = prev && prev.nodeType === Node.TEXT_NODE && prev.textContent.includes('\n');
-      if (!hasNewline) valueCell.insertBefore(document.createTextNode('\n'), p);
+      if (!hasNewline) valueCell.insertBefore(doc.createTextNode('\n'), p);
     });
   });
 }


### PR DESCRIPTION
Replace the multi-row p tag-per-row encoding with a single p tag containing
all span descriptors comma-joined (e.g. "full-width, span 6, span 6").

Milo's handleMasonry flattens rows into a flat span list immediately, so
\n row separators had no effect on output — visual row breaks are handled
entirely by CSS Grid auto-flow. The old multi-<p> encoding broke on DA
round-trips because target/da.js strips \n before pushing, causing
cell.textContent to concatenate rows on collab re-renders.

Also adds restoreNewlinesInMasonryCell to sources/da.js so legacy or
manually-authored pages with multi-<p> masonry cells still render
correctly after a DA fetch.

Additional fixes:
- span 12 now maps to "full-width" (correct Milo CSS class)
- Guard against empty spans writing a malformed <p> to the masonry cell
- Null-guard brick.spanLayout before .toLowerCase() in masonry.js
- Guard allBricks.length before calling handleMasonrysWithSectionMetadata

JIRA ID: https://jira.corp.adobe.com/browse/MWPW-193909

Test URLs:
- Before: https://main--da-cc-sandbox--adobecom.aem.live/drafts/pavan/premier-page
- After: https://main--da-cc-sandbox--adobecom.aem.live/drafts/ssircar/premier-page
