### PR TITLE
Adding fix for allowing drag drop in case the da panel is empty

### DIFF
--- a/streamlibs/operations/edit/drag-drop.js
+++ b/streamlibs/operations/edit/drag-drop.js
@@ -41,6 +41,7 @@ export default function createEditDragDropController({
 
     event.preventDefault();
     currentDropContainer.classList.add('da-drop-active');
+    const dropPlaceholder = ensureDropPlaceholder();
 
     const pointElement = document.elementFromPoint(event.clientX, event.clientY);
     let targetBlock = pointElement && pointElement.closest('[data-source="da"], [data-source="figma"]');
@@ -49,12 +50,18 @@ export default function createEditDragDropController({
     }
 
     if (targetBlock && currentDropContainer.contains(targetBlock)) {
-      const dropPlaceholder = ensureDropPlaceholder();
       const rect = targetBlock.getBoundingClientRect();
       const shouldInsertBefore = event.clientY < rect.top + rect.height / 2;
-      if (!shouldInsertBefore && targetBlock.nextSibling !== dropPlaceholder) {
+      if (shouldInsertBefore && targetBlock.previousSibling !== dropPlaceholder) {
+        currentDropContainer.insertBefore(dropPlaceholder, targetBlock);
+      } else if (!shouldInsertBefore && targetBlock.nextSibling !== dropPlaceholder) {
         currentDropContainer.insertBefore(dropPlaceholder, targetBlock.nextSibling);
       }
+      return;
+    }
+
+    if (dropPlaceholder.parentNode !== currentDropContainer || dropPlaceholder !== currentDropContainer.lastChild) {
+      currentDropContainer.appendChild(dropPlaceholder);
     }
   }
 


### PR DESCRIPTION
MWPW-194061 | Allowing drag and drop to da panel in edit case when the page is empty

<img width="1190" height="858" alt="Screenshot 2026-04-30 at 12 44 56 PM" src="https://github.com/user-attachments/assets/e0dd3544-0929-4a5a-a30a-96cb1d1fe621" />



<img width="1188" height="870" alt="Screenshot 2026-04-30 at 12 45 03 PM" src="https://github.com/user-attachments/assets/5af92e72-c646-44db-81c7-00343bfc78cd" />
