### PR TITLE
[MWPW-193928] Fix: Asset upload in one block appears in another

### DIFF
--- a/streamlibs/operations/annotation.js
+++ b/streamlibs/operations/annotation.js
@@ -137,19 +137,54 @@ function findAssetElement(doc, elementPath, elementProps, originalSrc) {
     const withoutParams = originalSrc.split('?')[0]?.split('#')[0] ?? '';
     const filename = withoutParams.split('/').pop() || '';
 
+    const candidates = [];
     for (const img of allImages) {
       const src = img.getAttribute('src') || '';
       if (src && withoutParams && src.includes(withoutParams)) {
-        return img.closest('picture') || img;
+        candidates.push(img);
       }
     }
-    if (filename) {
+    if (candidates.length === 0 && filename) {
       for (const img of allImages) {
         const src = (img.getAttribute('src') || '').split('?')[0]?.split('#')[0] ?? '';
         if (src.split('/').pop() === filename) {
-          return img.closest('picture') || img;
+          candidates.push(img);
         }
       }
+    }
+
+    if (candidates.length === 1) {
+      return candidates[0].closest('picture') || candidates[0];
+    }
+
+    if (candidates.length > 1 && elementProps) {
+      const sectionIndex = typeof elementProps.sectionIndex === 'number' ? elementProps.sectionIndex : -1;
+      const blockClass = typeof elementProps.blockClass === 'string' ? elementProps.blockClass : '';
+      const blockIndex = typeof elementProps.blockIndex === 'number' ? elementProps.blockIndex : 0;
+
+      if (sectionIndex >= 0) {
+        const sections = Array.from(main.children).filter((el) => el.tagName === 'DIV');
+        const section = sections[sectionIndex];
+        if (section) {
+          let block = null;
+          if (blockClass) {
+            const matching = Array.from(section.querySelectorAll(`:scope > div.${blockClass}`));
+            block = matching[blockIndex] ?? matching[0] ?? null;
+          }
+          if (!block) {
+            const divs = Array.from(section.children).filter((el) => el.tagName === 'DIV');
+            block = divs[blockIndex] ?? null;
+          }
+          if (block) {
+            const blockCandidate = candidates.find((img) => block.contains(img));
+            if (blockCandidate) return blockCandidate.closest('picture') || blockCandidate;
+          }
+        }
+      }
+    }
+
+    if (candidates.length > 0) {
+      return candidates[0].closest('picture') || candidates[0];
     }
   }
 
@@ -333,18 +368,21 @@ export async function saveAnnotationChanges(reportProgress = () => {}) {
     }
   }
 
-  const assetReplacements = [];
+  const latestByPath = new Map();
   for (const asset of (annotationState.store.assets || [])) {
-    if (asset.originalSrc && asset.daUrl) {
-      assetReplacements.push({
-        elementPath: asset.elementPath,
-        elementProps: asset.elementProps,
-        originalSrc: asset.originalSrc,
-        daUrl: asset.daUrl,
-        targetUrl: asset.daUrl,
-      });
+    if (!asset.originalSrc || !asset.daUrl) continue;
+    const existing = latestByPath.get(asset.elementPath);
+    if (!existing || (asset.createdAt && new Date(asset.createdAt) > new Date(existing.createdAt || 0))) {
+      latestByPath.set(asset.elementPath, asset);
     }
   }
+  const assetReplacements = Array.from(latestByPath.values()).map((asset) => ({
+    elementPath: asset.elementPath,
+    elementProps: asset.elementProps,
+    originalSrc: asset.originalSrc,
+    daUrl: asset.daUrl,
+    targetUrl: asset.daUrl,
+  }));
 
   const { easyEdits, daCompatibleHtml } = buildHtmlWithEditsAndAssets(assetReplacements);
 


### PR DESCRIPTION
## Summary

- **Asset deduplication in `saveAnnotationChanges`**: `annotationState.store.assets` accumulates all assets across saves, including old accepted ones. When re-uploading the same image to the same element, both assets shared the same `elementPath`, causing `buildHtmlWithEditsAndAssets` to apply them in order — new first, old last — reverting to the old URL in the final `postData` push. Fixed by deduplicating with a `Map` keyed by `elementPath`, keeping only the asset with the latest `createdAt`.
- **Duplicate image disambiguation in `findAssetElement`**: The `originalSrc` fallback used to return the first `<img>` matching the src/filename, always picking the first DOM occurrence regardless of which element the asset was uploaded for. Fixed by collecting all candidates and using `elementProps` (sectionIndex, blockClass, blockIndex) to identify the correct block when multiple elements share the same image.

