### PR TITLE
[MWPW-194558] Fix: Show correct uploader name on asset cards in collab panel

### DIFF
--- a/streamlibs/operations/annotation/assets-panel.js
+++ b/streamlibs/operations/annotation/assets-panel.js
@@ -147,7 +147,7 @@ export default function createAssetsPanelController({
 
     const username = document.createElement('p');
     username.className = 'annotation-panel-comment-user';
-    username.textContent = window.streamConfig?.username || 'Collaborator';
+    username.textContent = asset.username || 'Collaborator';
     card.appendChild(username);
 
     const text = document.createElement('p');


### PR DESCRIPTION
## Problem
In the assets panel, every remote asset card showed the **current viewer's** name as the uploader, regardless of who actually replaced the image. This was because `buildRemoteAssetCard` hardcoded `window.streamConfig?.username` instead of reading the uploader from the asset data.

## Solution
Use `asset.username` (now returned by the service API) to display the correct uploader on each card. Falls back to `'Collaborator'` if the field is absent for any reason.