### PR TITLE
MWPW-194635 | Removing empty parent sections of removed metadata elements

### DIFF
--- a/streamlibs/operations/annotation.js
+++ b/streamlibs/operations/annotation.js
@@ -277,7 +277,6 @@ function buildHtmlWithEditsAndAssets(assetReplacements) {
   const pageMetadataDom = document.body.querySelector('main .page-metadata');
   if (pageMetadataDom) {
     cachedPageMetadataHtml = pageMetadataDom.innerHTML;
-    
     mainEl.querySelectorAll('.metadata').forEach((el) => {
       const parentSection = el.closest('div');
       el.remove();

--- a/streamlibs/operations/annotation.js
+++ b/streamlibs/operations/annotation.js
@@ -277,9 +277,11 @@ function buildHtmlWithEditsAndAssets(assetReplacements) {
   const pageMetadataDom = document.body.querySelector('main .page-metadata');
   if (pageMetadataDom) {
     cachedPageMetadataHtml = pageMetadataDom.innerHTML;
-
+    
     mainEl.querySelectorAll('.metadata').forEach((el) => {
+      const parentSection = el.closest('div');
       el.remove();
+      if (parentSection.children.length === 0) parentSection.remove();
     });
     const metadataDiv = document.createElement('div');
     metadataDiv.className = 'metadata';

--- a/streamlibs/operations/annotation.js
+++ b/streamlibs/operations/annotation.js
@@ -278,7 +278,7 @@ function buildHtmlWithEditsAndAssets(assetReplacements) {
   if (pageMetadataDom) {
     cachedPageMetadataHtml = pageMetadataDom.innerHTML;
     mainEl.querySelectorAll('.metadata').forEach((el) => {
-      const parentSection = el.closest('div');
+      const parentSection = el.parentElement;
       el.remove();
       if (parentSection.children.length === 0) parentSection.remove();
     });

--- a/streamlibs/operations/annotation.js
+++ b/streamlibs/operations/annotation.js
@@ -463,8 +463,10 @@ export async function saveAnnotationChanges(reportProgress = () => {}) {
 
   const latestByPath = new Map();
   for (const asset of (annotationState.store.assets || [])) {
+    // eslint-disable-next-line no-continue
     if (!asset.originalSrc || !asset.daUrl) continue;
     const existing = latestByPath.get(asset.elementPath);
+    // eslint-disable-next-line max-len
     if (!existing || (asset.createdAt && new Date(asset.createdAt) > new Date(existing.createdAt || 0))) {
       latestByPath.set(asset.elementPath, asset);
     }


### PR DESCRIPTION
Removing empty parent sections of removed metadata elements.
When metadata is pushed it is collated into a new section. This leads to the addition of empty sections on the page. Removing empty sections as the metadata is removed to be readed with user changes.