### PR TITLE
[MWPW-194622] [MWPW-194629] Add asset navigation and fix 413 error 

### DIFF
--- a/streamlibs/operations/annotation.js
+++ b/streamlibs/operations/annotation.js
@@ -326,6 +326,13 @@ export async function annotationOperation(options = {}) {
     mainEl.querySelectorAll(':scope > div').forEach((div) => {
       if (!div.dataset.source) div.dataset.source = 'da';
     });
+  }
+
+  if (!cachedCleanHtml) {
+    cachedCleanHtml = mainEl.innerHTML || '';
+  }
+
+  if (window.streamConfig?.source === 'da') {
     const insertedFragments = await hydrateFragmentLinksInDaBlocks(mainEl);
     for (const root of insertedFragments) {
       // eslint-disable-next-line no-await-in-loop
@@ -333,9 +340,6 @@ export async function annotationOperation(options = {}) {
     }
   }
 
-  if (!cachedCleanHtml) {
-    cachedCleanHtml = mainEl.innerHTML || '';
-  }
   await miloLoadArea();
 
   // initialize page metadata

--- a/streamlibs/operations/annotation/comments-panel.js
+++ b/streamlibs/operations/annotation/comments-panel.js
@@ -2096,6 +2096,24 @@ export default function createCommentsPanelController({
       const card = target.closest('.annotation-panel-comment');
 
       if (card instanceof HTMLElement && card.classList.contains('annotation-panel-asset-item')) {
+        if (target.closest('.annotation-asset-actions')) return;
+        let elementPath = null;
+        const { localAssetId, assetId } = card.dataset;
+        if (localAssetId) {
+          const local = (annotationState.store.localAssets || []).find((a) => a.localId === localAssetId);
+          if (local?.targetImg instanceof HTMLElement) {
+            local.targetImg.scrollIntoView({ block: 'center', behavior: 'smooth' });
+            return;
+          }
+          elementPath = local?.elementPath || null;
+        } else if (assetId) {
+          const asset = (annotationState.store.assets || []).find((a) => String(a.id) === String(assetId));
+          elementPath = asset?.elementPath || null;
+        }
+        if (elementPath && annotationUI.mainEl) {
+          const el = annotationUI.mainEl.querySelector(elementPath);
+          if (el instanceof HTMLElement) el.scrollIntoView({ block: 'center', behavior: 'smooth' });
+        }
         return;
       }
 


### PR DESCRIPTION
**Fix 1: Base64 image in push-html payload (413 error)** [MWPW-194629](https://jira.corp.adobe.com/browse/MWPW-194629)

Pages with DA fragment links trigger miloLoadArea() once per fragment during annotation initialization. Each call runs transformImages() globally, converting content.da.live image URLs to base64 data URLs across the entire document. Because cachedCleanHtml was captured after this loop, it contained base64 images that were then included verbatim in the push-html payload, causing a 413 Content Too Large error from DA. Fixed by moving the cachedCleanHtml capture to before the fragment hydration loop, so it always stores the original DA-compatible HTML.

**Fix 2: Asset panel items not navigating to their element on click** [MWPW-194622](https://jira.corp.adobe.com/browse/MWPW-194622)

Clicking an asset card in the annotation side panel did nothing — the panel click handler had an unconditional early return for all .annotation-panel-asset-item elements. Updated the handler to mirror the existing edit-item behavior: action button clicks (Apply, Delete, Remove) are excluded, local asset cards scroll directly to the live targetImg reference, and remote asset cards query annotationUI.mainEl by elementPath — the same approach already used by the on-page asset marker click handler.