### PR TITLE
MWPW-195127 | Add operation check for regeneration buttons

### DIFF
--- a/streamlibs/standalone/html-review.js
+++ b/streamlibs/standalone/html-review.js
@@ -188,6 +188,7 @@ function ensureRegenButton() {
 }
 
 function showRegenBtn(el) {
+  if (window.streamConfig.operation !== 'htmlRendererStandaloneAnnotation') return;
   cancelHideRegenBtn();
   regenState.target = el;
   const btn = ensureRegenButton();
@@ -489,6 +490,7 @@ function openImgPromptOverlay(img) {
 }
 
 function showImgRegenBtn(img) {
+  if (window.streamConfig.operation !== 'htmlRendererStandaloneAnnotation') return;
   ensureImgRegenElements();
   cancelHideImgRegenBtn();
   imgRegenState.target = img;

--- a/streamlibs/standalone/html-review.js
+++ b/streamlibs/standalone/html-review.js
@@ -303,6 +303,7 @@ async function urlToBase64(url) {
   }
 }
 
+// eslint-disable-next-line no-unused-vars
 function restoreRegenImages() {
   document.querySelectorAll('img[data-regen-src]').forEach((img) => {
     img.src = img.dataset.regenSrc;


### PR DESCRIPTION
Operation check to show regenerate buttons in annotation mode only and not in the page preview mode.

<img width="1503" height="804" alt="Screenshot 2026-05-13 at 8 19 57 PM" src="https://github.com/user-attachments/assets/a4ce1ee9-6a47-4317-a59f-a2197c7b51a7" />


