### PR TITLE
MWPW-195251 | Fix to have da html in clean cache

### DIFF
--- a/streamlibs/operations/annotation.js
+++ b/streamlibs/operations/annotation.js
@@ -510,7 +510,17 @@ export async function annotationOperationOnHostPage(options = {}) {
   }
 
   if (!cachedCleanHtml || refreshBaselineHtml) {
-    cachedCleanHtml = mainEl.innerHTML || baselineHtml || '';
+    if (window.streamConfig?.source === 'da') {
+      try {
+        const daMain = await fetchDAContent(window.streamConfig.contentUrl);
+        cachedCleanHtml = daMain?.innerHTML || '';
+      } catch (err) {
+        console.warn('[annotation] Failed to fetch DA baseline HTML, falling back to live DOM:', err);
+        cachedCleanHtml = '';
+      }
+    } else {
+      cachedCleanHtml = baselineHtml || mainEl.innerHTML || '';
+    }
   }
 
   await finishAnnotationSession(mainEl, {

--- a/streamlibs/operations/annotation.js
+++ b/streamlibs/operations/annotation.js
@@ -482,9 +482,6 @@ export async function annotationOperation(options = {}) {
   });
 }
 
-/**
- * Annotation on an existing decorated page (tenant AEM): uses current <main>, no miloLoadArea / preview replacement.
- */
 export async function annotationOperationOnHostPage(options = {}) {
   const {
     preserveRemoteEditState = false,


### PR DESCRIPTION
Push to DA was sending fully-rendered browser DOM instead of raw DA DOM on the very first open of the collab after SEO page generation. This was caused by the annotation baseline being captured from the decorated page rather than fetched fresh from DA source. 
This PR fixes to use DA dom at the start to stop sending rendered dom to da.