### PR TITLE
[MWPW-195128] Fix: Duplicate block when creating fragment in Edit with Figma

### DIFF
--- a/streamlibs/utils/block-action-modal.js
+++ b/streamlibs/utils/block-action-modal.js
@@ -399,7 +399,10 @@ async function replaceBlocksInPreview(fragmentPath, options = {}) {
       const targetEl = findActualBlock(idEl);
       stripBlockChromeAndDetachIds(idEl, targetEl);
       if (idx === 0) firstEl = targetEl;
-      else targetEl.remove();
+      else {
+        targetEl.remove();
+        if (idEl !== targetEl) idEl.remove();
+      }
     });
 
     const fragmentEl = document.createElement('div');
@@ -432,8 +435,12 @@ async function replaceBlocksInPreview(fragmentPath, options = {}) {
 
     sectionEl.appendChild(targetEl.cloneNode(true));
 
-    if (!firstEl) firstEl = targetEl;
-    else targetEl.remove();
+    if (!firstEl) {
+      firstEl = targetEl;
+    } else {
+      targetEl.remove();
+      if (idEl !== targetEl) idEl.remove();
+    }
   });
 
   fragmentEl.appendChild(sectionEl);


### PR DESCRIPTION
When creating a fragment from multiple selected blocks, the outer DA panel wrapper for each removed block was left behind in the DOM. This caused `buildCombinedHtml` to pick it up and serialize the block after the fragment twice in the push-html payload.

Fix: Remove the outer panel row along with its inner content for all non-first selected blocks during replacement.