### PR TITLE
Fix(mapper): point stage stream-service to stage02 deploy (d587ab)

### DIFF
--- a/streamlibs/utils/config.js
+++ b/streamlibs/utils/config.js
@@ -26,7 +26,7 @@ export const CONFIG = {
   },
   stage: {
     streamMapper: {
-      serviceEP: 'https://adobe-acom-stream-service-deploy-ethos502-prod-or2-32c93a.cloud.adobe.io',
+      serviceEP: 'https://adobe-acom-stream-service-deploy-ethos501-prod-or2-d587ab.cloud.adobe.io',
       figmaMappingUrl: '/api/fig-comps',
       figmaBlockContentUrl: '/api/fig-comp-details',
       pushToDaUrl: '/api/push-html',


### PR DESCRIPTION
Jira: [MWPW-195864](https://jira.corp.adobe.com/browse/MWPW-195864)

This pull request updates stage-only stream-service routing in stream-mapper by setting CONFIG.stage.streamMapper.serviceEP in streamlibs/utils/config.js to the stream-service stage02 endpoint (https://adobe-acom-stream-service-deploy-ethos501-prod-or2-d587ab.cloud.adobe.io), as confirmed for stage. 
