### PR TITLE
MWPW-194556  Unable to Delete Added Row in Metadata

### DIFF
--- a/streamlibs/operations/annotation.js
+++ b/streamlibs/operations/annotation.js
@@ -50,6 +50,8 @@ assetsPanel.setOnAssetsChanged(() => {
 
 /** User-added metadata rows: extra wrapper + delete control (stripped on persist). */
 const METADATA_USER_ROW_CLASS = 'stream-metadata-user-row';
+/** Set on rows added in this session only; cleared after save/push to DA (then edit-only). */
+const METADATA_ROW_DELETABLE_DATASET = 'streamMetadataRowDeletable';
 const METADATA_USER_ROW_INNER_CLASS = 'stream-metadata-user-row-inner';
 const METADATA_USER_VALUE_CELL_CLASS = 'stream-metadata-user-value-cell';
 const METADATA_USER_VALUE_EDITABLE_CLASS = 'stream-metadata-user-value-editable';
@@ -247,6 +249,9 @@ function findAssetElement(doc, elementPath, elementProps, originalSrc) {
 /** Remove Stream-only metadata row chrome so pushed HTML matches DA metadata shape. */
 function sanitizeMetadataDivForPersist(metadataDiv) {
   if (!(metadataDiv instanceof HTMLElement)) return;
+  metadataDiv.querySelectorAll('[data-stream-metadata-row-deletable]').forEach((el) => {
+    el.removeAttribute('data-stream-metadata-row-deletable');
+  });
   metadataDiv.querySelectorAll('.stream-annotation-delete-metadata-row').forEach((b) => b.remove());
   /* Native rows: delete sits in .stream-metadata-user-value-chrome; strip empty wrappers so DA HTML stays clean. */
   metadataDiv.querySelectorAll(`.${METADATA_USER_VALUE_CHROME_CLASS}`).forEach((chrome) => {
@@ -337,7 +342,6 @@ function buildHtmlWithEditsAndAssets(assetReplacements) {
 
   const pageMetadataDom = document.body.querySelector('main .page-metadata');
   if (pageMetadataDom) {
-    cachedPageMetadataHtml = pageMetadataDom.innerHTML;
     mainEl.querySelectorAll('.metadata').forEach((el) => {
       const parentSection = el.parentElement;
       el.remove();
@@ -347,6 +351,7 @@ function buildHtmlWithEditsAndAssets(assetReplacements) {
     metadataDiv.className = 'metadata';
     metadataDiv.innerHTML = pageMetadataDom.innerHTML;
     sanitizeMetadataDivForPersist(metadataDiv);
+    cachedPageMetadataHtml = metadataDiv.innerHTML;
     metadataDiv.querySelectorAll('p').forEach((p) => {
       [...p.attributes].forEach((attr) => p.removeAttribute(attr.name));
     });
@@ -487,17 +492,49 @@ function normalizePersistUrlForDaApi(raw) {
   return s;
 }
 
-function isNativePageMetadataRow(row) {
-  if (!(row instanceof HTMLElement) || row.tagName !== 'DIV') return false;
-  if (row.classList.contains(METADATA_USER_ROW_CLASS)) return false;
-  return Boolean(row.parentElement?.classList?.contains('page-metadata'));
+function getPageMetadataContainer() {
+  return annotationUI.mainEl?.querySelector('.page-metadata')
+    || document.querySelector('main .page-metadata')
+    || document.querySelector('.page-metadata');
+}
+
+function isSessionDeletableMetadataRow(row) {
+  return row instanceof HTMLElement
+    && row.dataset.streamUserAddedMetadataRow === 'true'
+    && row.dataset[METADATA_ROW_DELETABLE_DATASET] === 'true';
+}
+
+function stripMetadataRowDeleteControls(row) {
+  if (!(row instanceof HTMLElement)) return;
+  row.querySelectorAll('.stream-annotation-delete-metadata-row').forEach((b) => b.remove());
+  row.querySelectorAll(`.${METADATA_USER_VALUE_CHROME_CLASS}`).forEach((chrome) => {
+    if (!(chrome instanceof HTMLElement)) return;
+    if (chrome.childElementCount === 0 && !(chrome.textContent || '').trim()) {
+      chrome.remove();
+    }
+  });
+}
+
+/** After save/push: metadata on DA is editable only (no delete). */
+function markPageMetadataRowsPersistedToDa() {
+  const metadataDom = getPageMetadataContainer();
+  if (!metadataDom) return;
+
+  const cacheClone = document.createElement('div');
+  cacheClone.className = 'metadata';
+  cacheClone.innerHTML = metadataDom.innerHTML;
+  sanitizeMetadataDivForPersist(cacheClone);
+  cachedPageMetadataHtml = cacheClone.innerHTML;
+
+  metadataDom.querySelectorAll(':scope > div').forEach((row) => {
+    stripMetadataRowDeleteControls(row);
+    delete row.dataset[METADATA_ROW_DELETABLE_DATASET];
+    delete row.dataset.streamUserAddedMetadataRow;
+  });
 }
 
 async function removeMetadataRow(row) {
-  if (!(row instanceof HTMLElement)) return;
-  const isUser = row.dataset.streamUserAddedMetadataRow === 'true';
-  const isNative = isNativePageMetadataRow(row);
-  if (!isUser && !isNative) return;
+  if (!isSessionDeletableMetadataRow(row)) return;
   if (!annotationUI.mainEl?.contains(row)) return;
 
   commentsPanel.removePopup();
@@ -524,54 +561,16 @@ async function removeMetadataRow(row) {
   }
 }
 
-function appendNativeMetadataRowDeleteButton(row) {
-  if (!isNativePageMetadataRow(row)) return;
-  if (row.querySelector('.stream-annotation-delete-metadata-row')) return;
-  const cells = row.querySelectorAll(':scope > div');
-  if (cells.length < 2) return;
-  const valueCell = cells[cells.length - 1];
-  if (!(valueCell instanceof HTMLElement)) return;
-
-  const deleteBtn = document.createElement('button');
-  deleteBtn.type = 'button';
-  deleteBtn.className = 'stream-annotation-delete-metadata-row';
-  deleteBtn.setAttribute('aria-label', 'Remove this metadata row');
-  deleteBtn.innerHTML = METADATA_ROW_DELETE_ICON_SVG;
-  deleteBtn.addEventListener('click', (ev) => {
-    ev.preventDefault();
-    ev.stopPropagation();
-    void removeMetadataRow(row);
-  });
-
-  let chrome = valueCell.querySelector(`:scope > .${METADATA_USER_VALUE_CHROME_CLASS}`);
-  if (!chrome) {
-    chrome = document.createElement('div');
-    chrome.className = METADATA_USER_VALUE_CHROME_CLASS;
-    valueCell.appendChild(chrome);
-  }
-  chrome.appendChild(deleteBtn);
-}
-
-function ensureNativeMetadataRowDeleteButton(row) {
-  if (!isNativePageMetadataRow(row)) return;
-  appendNativeMetadataRowDeleteButton(row);
-}
-
 async function refreshPageMetadataDeleteButtons() {
-  const metadataDom = annotationUI.mainEl?.querySelector('.page-metadata')
-    || document.querySelector('main .page-metadata')
-    || document.querySelector('.page-metadata');
+  const metadataDom = getPageMetadataContainer();
   if (!metadataDom) return;
   metadataDom.querySelectorAll(':scope > div').forEach((row) => {
-    if (row.classList.contains(METADATA_USER_ROW_CLASS)) {
-      ensureUserMetadataRowDeleteButton(row);
-    } else {
-      ensureNativeMetadataRowDeleteButton(row);
-    }
+    ensureUserMetadataRowDeleteButton(row);
   });
 }
 
 function appendUserMetadataRowDeleteButton(row, inner) {
+  if (!isSessionDeletableMetadataRow(row)) return;
   if (!(row instanceof HTMLElement) || !(inner instanceof HTMLElement)) return;
   if (row.querySelector('.stream-annotation-delete-metadata-row')) return;
 
@@ -609,7 +608,7 @@ function appendUserMetadataRowDeleteButton(row, inner) {
 
 /** Medium Editor `addElements` can reshape metadata cells; re-attach delete if missing. */
 function ensureUserMetadataRowDeleteButton(row) {
-  if (!(row instanceof HTMLElement) || row.dataset.streamUserAddedMetadataRow !== 'true') return;
+  if (!isSessionDeletableMetadataRow(row)) return;
   const inner = row.querySelector(`:scope > .${METADATA_USER_ROW_INNER_CLASS}`);
   if (!inner) return;
   appendUserMetadataRowDeleteButton(row, inner);
@@ -670,6 +669,7 @@ export async function annotationOperation(options = {}) {
   addTextBtn.addEventListener('click', () => {
     const row = document.createElement('div');
     row.dataset.streamUserAddedMetadataRow = 'true';
+    row.dataset[METADATA_ROW_DELETABLE_DATASET] = 'true';
     row.classList.add(METADATA_USER_ROW_CLASS);
     const inner = document.createElement('div');
     inner.classList.add(METADATA_USER_ROW_INNER_CLASS);
@@ -685,6 +685,7 @@ export async function annotationOperation(options = {}) {
   addImageBtn.addEventListener('click', () => {
     const row = document.createElement('div');
     row.dataset.streamUserAddedMetadataRow = 'true';
+    row.dataset[METADATA_ROW_DELETABLE_DATASET] = 'true';
     row.classList.add(METADATA_USER_ROW_CLASS);
     const inner = document.createElement('div');
     inner.classList.add(METADATA_USER_ROW_INNER_CLASS);
@@ -767,6 +768,7 @@ export async function persistAnnotationChangesToDA() {
   await postData(normalizePersistUrlForDaApi(rawPushUrl) || rawPushUrl, daCompatibleHtml, {
     suppressErrorPage: true,
   });
+  markPageMetadataRowsPersistedToDa();
 }
 
 export async function saveAnnotationChanges(reportProgress = () => {}) {
@@ -778,6 +780,7 @@ export async function saveAnnotationChanges(reportProgress = () => {}) {
 
   await postData(window.streamConfig.targetUrl, daCompatibleHtml, { suppressErrorPage: true });
   reportProgress('htmlSaved');
+  markPageMetadataRowsPersistedToDa();
 
   if (annotationService.isAvailable()) {
     const persistedEditSnapshot = await annotationService.saveEdits(easyEdits);

--- a/streamlibs/operations/annotation.js
+++ b/streamlibs/operations/annotation.js
@@ -43,15 +43,20 @@ const inlineEditing = createInlineEditingController({
   removePopup: commentsPanel.removePopup,
 });
 
-commentsPanel.setInlineModeHandlers({
-  enableInlineEditMode: inlineEditing.enableInlineEditMode,
-  disableInlineEditMode: inlineEditing.disableInlineEditMode,
-});
-
 assetsPanel.setOnAssetsChanged(() => {
   commentsPanel.renderThreadMarkers({ resolveTargets: true });
   commentsPanel.renderCommentsPanel();
 });
+
+/** User-added metadata rows: extra wrapper + delete control (stripped on persist). */
+const METADATA_USER_ROW_CLASS = 'stream-metadata-user-row';
+const METADATA_USER_ROW_INNER_CLASS = 'stream-metadata-user-row-inner';
+const METADATA_USER_VALUE_CELL_CLASS = 'stream-metadata-user-value-cell';
+const METADATA_USER_VALUE_EDITABLE_CLASS = 'stream-metadata-user-value-editable';
+const METADATA_USER_VALUE_CHROME_CLASS = 'stream-metadata-user-value-chrome';
+
+/** Trash icon (inline SVG) for user-added metadata row delete. */
+const METADATA_ROW_DELETE_ICON_SVG = '<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/><line x1="10" y1="11" x2="10" y2="17"/><line x1="14" y1="11" x2="14" y2="17"/></svg>';
 
 let cachedCleanHtml = '';
 let cachedPageMetadataHtml = null;
@@ -239,7 +244,27 @@ function findAssetElement(doc, elementPath, elementProps, originalSrc) {
   return null;
 }
 
-// ── HTML export ───────────────────────────────────────────────────────────────
+/** Remove Stream-only metadata row chrome so pushed HTML matches DA metadata shape. */
+function sanitizeMetadataDivForPersist(metadataDiv) {
+  if (!(metadataDiv instanceof HTMLElement)) return;
+  metadataDiv.querySelectorAll('.stream-annotation-delete-metadata-row').forEach((b) => b.remove());
+  /* Native rows: delete sits in .stream-metadata-user-value-chrome; strip empty wrappers so DA HTML stays clean. */
+  metadataDiv.querySelectorAll(`.${METADATA_USER_VALUE_CHROME_CLASS}`).forEach((chrome) => {
+    if (!(chrome instanceof HTMLElement)) return;
+    if (chrome.childElementCount === 0 && !(chrome.textContent || '').trim()) {
+      chrome.remove();
+    }
+  });
+  metadataDiv.querySelectorAll('[data-stream-user-added-metadata-row="true"]').forEach((wrapper) => {
+    const inner = wrapper.querySelector(`:scope > .${METADATA_USER_ROW_INNER_CLASS}`);
+    const plain = document.createElement('div');
+    const cellSource = inner || wrapper;
+    while (cellSource.firstChild) {
+      plain.appendChild(cellSource.firstChild);
+    }
+    wrapper.replaceWith(plain);
+  });
+}
 
 function buildHtmlWithEditsAndAssets(assetReplacements) {
   const easyEdits = annotationState.store.easyEdits || [];
@@ -321,6 +346,7 @@ function buildHtmlWithEditsAndAssets(assetReplacements) {
     const metadataDiv = document.createElement('div');
     metadataDiv.className = 'metadata';
     metadataDiv.innerHTML = pageMetadataDom.innerHTML;
+    sanitizeMetadataDivForPersist(metadataDiv);
     metadataDiv.querySelectorAll('p').forEach((p) => {
       [...p.attributes].forEach((attr) => p.removeAttribute(attr.name));
     });
@@ -461,6 +487,143 @@ function normalizePersistUrlForDaApi(raw) {
   return s;
 }
 
+function isNativePageMetadataRow(row) {
+  if (!(row instanceof HTMLElement) || row.tagName !== 'DIV') return false;
+  if (row.classList.contains(METADATA_USER_ROW_CLASS)) return false;
+  return Boolean(row.parentElement?.classList?.contains('page-metadata'));
+}
+
+async function removeMetadataRow(row) {
+  if (!(row instanceof HTMLElement)) return;
+  const isUser = row.dataset.streamUserAddedMetadataRow === 'true';
+  const isNative = isNativePageMetadataRow(row);
+  if (!isUser && !isNative) return;
+  if (!annotationUI.mainEl?.contains(row)) return;
+
+  commentsPanel.removePopup();
+
+  const hadInline = annotationUI.inlineMode;
+  try {
+    if (hadInline) {
+      await inlineEditing.syncInlineEditsBeforePersist();
+    }
+    store.removeAnnotationStateForSubtree(row);
+    if (hadInline) {
+      inlineEditing.resetInlineEditModeState();
+    }
+    row.remove();
+    if (hadInline) {
+      await inlineEditing.enableInlineEditMode();
+    }
+    store.saveAnnotationStore();
+    commentsPanel.renderThreadMarkers({ resolveTargets: true });
+    commentsPanel.renderCommentsPanel();
+    await refreshPageMetadataDeleteButtons();
+  } catch (err) {
+    console.error('[annotation] removeMetadataRow failed:', err);
+  }
+}
+
+function appendNativeMetadataRowDeleteButton(row) {
+  if (!isNativePageMetadataRow(row)) return;
+  if (row.querySelector('.stream-annotation-delete-metadata-row')) return;
+  const cells = row.querySelectorAll(':scope > div');
+  if (cells.length < 2) return;
+  const valueCell = cells[cells.length - 1];
+  if (!(valueCell instanceof HTMLElement)) return;
+
+  const deleteBtn = document.createElement('button');
+  deleteBtn.type = 'button';
+  deleteBtn.className = 'stream-annotation-delete-metadata-row';
+  deleteBtn.setAttribute('aria-label', 'Remove this metadata row');
+  deleteBtn.innerHTML = METADATA_ROW_DELETE_ICON_SVG;
+  deleteBtn.addEventListener('click', (ev) => {
+    ev.preventDefault();
+    ev.stopPropagation();
+    void removeMetadataRow(row);
+  });
+
+  let chrome = valueCell.querySelector(`:scope > .${METADATA_USER_VALUE_CHROME_CLASS}`);
+  if (!chrome) {
+    chrome = document.createElement('div');
+    chrome.className = METADATA_USER_VALUE_CHROME_CLASS;
+    valueCell.appendChild(chrome);
+  }
+  chrome.appendChild(deleteBtn);
+}
+
+function ensureNativeMetadataRowDeleteButton(row) {
+  if (!isNativePageMetadataRow(row)) return;
+  appendNativeMetadataRowDeleteButton(row);
+}
+
+async function refreshPageMetadataDeleteButtons() {
+  const metadataDom = annotationUI.mainEl?.querySelector('.page-metadata')
+    || document.querySelector('main .page-metadata')
+    || document.querySelector('.page-metadata');
+  if (!metadataDom) return;
+  metadataDom.querySelectorAll(':scope > div').forEach((row) => {
+    if (row.classList.contains(METADATA_USER_ROW_CLASS)) {
+      ensureUserMetadataRowDeleteButton(row);
+    } else {
+      ensureNativeMetadataRowDeleteButton(row);
+    }
+  });
+}
+
+function appendUserMetadataRowDeleteButton(row, inner) {
+  if (!(row instanceof HTMLElement) || !(inner instanceof HTMLElement)) return;
+  if (row.querySelector('.stream-annotation-delete-metadata-row')) return;
+
+  const deleteBtn = document.createElement('button');
+  deleteBtn.type = 'button';
+  deleteBtn.className = 'stream-annotation-delete-metadata-row';
+  deleteBtn.setAttribute('aria-label', 'Remove this metadata row');
+  deleteBtn.innerHTML = METADATA_ROW_DELETE_ICON_SVG;
+  deleteBtn.addEventListener('click', (ev) => {
+    ev.preventDefault();
+    ev.stopPropagation();
+    void removeMetadataRow(row);
+  });
+  const valueCell = inner.querySelector(`:scope > .${METADATA_USER_VALUE_CELL_CLASS}`)
+    || inner.querySelector(':scope > div:last-child');
+  if (valueCell) {
+    let chrome = valueCell.querySelector(`.${METADATA_USER_VALUE_CHROME_CLASS}`);
+    if (!chrome) {
+      const editable = valueCell.querySelector(`:scope > .${METADATA_USER_VALUE_EDITABLE_CLASS}`);
+      if (editable) {
+        chrome = document.createElement('div');
+        chrome.className = METADATA_USER_VALUE_CHROME_CLASS;
+        editable.appendChild(chrome);
+      }
+    }
+    if (chrome) {
+      chrome.appendChild(deleteBtn);
+    } else {
+      valueCell.appendChild(deleteBtn);
+    }
+  } else {
+    row.appendChild(deleteBtn);
+  }
+}
+
+/** Medium Editor `addElements` can reshape metadata cells; re-attach delete if missing. */
+function ensureUserMetadataRowDeleteButton(row) {
+  if (!(row instanceof HTMLElement) || row.dataset.streamUserAddedMetadataRow !== 'true') return;
+  const inner = row.querySelector(`:scope > .${METADATA_USER_ROW_INNER_CLASS}`);
+  if (!inner) return;
+  appendUserMetadataRowDeleteButton(row, inner);
+}
+
+commentsPanel.setInlineModeHandlers({
+  enableInlineEditMode: async () => {
+    const didEnable = await inlineEditing.enableInlineEditMode();
+    await refreshPageMetadataDeleteButtons();
+    return didEnable;
+  },
+  disableInlineEditMode: inlineEditing.disableInlineEditMode,
+});
+
 // ── Public API ────────────────────────────────────────────────────────────────
 
 export async function annotationOperation(options = {}) {
@@ -498,6 +661,7 @@ export async function annotationOperation(options = {}) {
   const addAndRegisterRow = (row) => {
     metadataDom.append(row);
     row.querySelectorAll('p').forEach((p) => inlineEditing.registerNewEditableElement(p));
+    ensureUserMetadataRowDeleteButton(row);
   };
 
   const addTextBtn = document.createElement('button');
@@ -505,7 +669,13 @@ export async function annotationOperation(options = {}) {
   addTextBtn.textContent = '+ Add text/link row';
   addTextBtn.addEventListener('click', () => {
     const row = document.createElement('div');
-    row.innerHTML = '<div><p>add metadata key</p></div><div><p>add text or link value</p></div>';
+    row.dataset.streamUserAddedMetadataRow = 'true';
+    row.classList.add(METADATA_USER_ROW_CLASS);
+    const inner = document.createElement('div');
+    inner.classList.add(METADATA_USER_ROW_INNER_CLASS);
+    inner.innerHTML = `<div><p>add metadata key</p></div><div class="${METADATA_USER_VALUE_CELL_CLASS}"><div class="${METADATA_USER_VALUE_EDITABLE_CLASS}"><p>add text or link value</p><div class="${METADATA_USER_VALUE_CHROME_CLASS}"></div></div></div>`;
+    appendUserMetadataRowDeleteButton(row, inner);
+    row.append(inner);
     addAndRegisterRow(row);
   });
 
@@ -514,7 +684,13 @@ export async function annotationOperation(options = {}) {
   addImageBtn.textContent = '+ Add image row';
   addImageBtn.addEventListener('click', () => {
     const row = document.createElement('div');
-    row.innerHTML = '<div><p>key</p></div><div><picture><img src="https://main--stream-mapper--adobecom.aem.live/assets/media_1bf6f8fe5a340bb3f4e022b300d7013821fe5ff89.png"></picture></div>';
+    row.dataset.streamUserAddedMetadataRow = 'true';
+    row.classList.add(METADATA_USER_ROW_CLASS);
+    const inner = document.createElement('div');
+    inner.classList.add(METADATA_USER_ROW_INNER_CLASS);
+    inner.innerHTML = `<div><p>key</p></div><div class="${METADATA_USER_VALUE_CELL_CLASS}"><div class="${METADATA_USER_VALUE_EDITABLE_CLASS}"><picture><img src="https://main--stream-mapper--adobecom.aem.live/assets/media_1bf6f8fe5a340bb3f4e022b300d7013821fe5ff89.png"></picture><div class="${METADATA_USER_VALUE_CHROME_CLASS}"></div></div></div>`;
+    appendUserMetadataRowDeleteButton(row, inner);
+    row.append(inner);
     addAndRegisterRow(row);
   });
 
@@ -525,6 +701,7 @@ export async function annotationOperation(options = {}) {
   mainEl.append(metadataSeparator);
 
   await finishAnnotationSession(mainEl, { preserveRemoteEditState, shouldRestoreInlineMode });
+  await refreshPageMetadataDeleteButtons();
 }
 
 export async function annotationOperationOnHostPage(options = {}) {
@@ -554,6 +731,7 @@ export async function annotationOperationOnHostPage(options = {}) {
   }
 
   await finishAnnotationSession(mainEl, { preserveRemoteEditState, shouldRestoreInlineMode });
+  await refreshPageMetadataDeleteButtons();
 }
 
 export async function persistAnnotationChangesToDA() {

--- a/streamlibs/operations/annotation/annotation.css
+++ b/streamlibs/operations/annotation/annotation.css
@@ -2604,41 +2604,6 @@ body.editor-mode .figma-panel .has-block-action .block-action-btn.block-action-b
     box-sizing: border-box;
   }
 
-  .annotation-mode .page-metadata > div:not(.stream-metadata-user-row) > div:last-child > .stream-metadata-user-value-chrome {
-    position: absolute;
-    right: 6px;
-    top: 50%;
-    transform: translateY(-50%);
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    line-height: 0;
-    z-index: 2;
-  }
-
-  .annotation-mode .page-metadata > div:not(.stream-metadata-user-row) .stream-annotation-delete-metadata-row {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-  }
-
-  .annotation-mode .page-metadata > div:not(.stream-metadata-user-row) .stream-annotation-delete-metadata-row:hover {
-    background: #fee2e2;
-    border-color: #dc2626;
-    color: #b91c1c;
-  }
-
-  .annotation-mode .page-metadata > div:not(.stream-metadata-user-row) .stream-annotation-delete-metadata-row:focus-visible {
-    outline: 2px solid var(--sm-color-primary, #3b82f6);
-    outline-offset: 2px;
-  }
-
-  .annotation-inline-edit-mode .page-metadata > div:not(.stream-metadata-user-row) .stream-annotation-delete-metadata-row {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-  }
-
   .annotation-inline-edit-mode .stream-annotation-delete-metadata-row {
     display: inline-flex;
     align-items: center;

--- a/streamlibs/operations/annotation/annotation.css
+++ b/streamlibs/operations/annotation/annotation.css
@@ -2441,22 +2441,219 @@ body.editor-mode .figma-panel .has-block-action .block-action-btn.block-action-b
     flex-wrap: wrap;
   }
 
+  /* Equal key/value columns (same visual weight as hosted dev preview). */
   .annotation-mode .page-metadata > div {
-    display: flex;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
     width: 100%;
     box-sizing: border-box;
+    align-items: stretch;
+    column-gap: 0;
   }
 
-  .annotation-mode .page-metadata > div > div:first-child {
+  .annotation-mode .page-metadata > div:not(.stream-metadata-user-row) > div:first-child {
     font-weight: bold;
   }
 
   .annotation-mode .page-metadata > div > div {
-    flex: 1 1 0;
     min-width: 0;
     border: 0.5px solid #cacaca;
     padding: 10px;
     padding-left: 20px;
+    box-sizing: border-box;
+  }
+
+  .annotation-mode .page-metadata > div.stream-metadata-user-row {
+    position: relative;
+    display: block;
+    width: 100%;
+    box-sizing: border-box;
+  }
+
+  .annotation-mode .page-metadata > div.stream-metadata-user-row > .stream-metadata-user-row-inner {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+    align-items: stretch;
+    min-width: 0;
+    width: 100%;
+    box-sizing: border-box;
+  }
+
+  .annotation-mode .page-metadata > div.stream-metadata-user-row > .stream-metadata-user-row-inner > div {
+    min-width: 0;
+    border: 0.5px solid #cacaca;
+    padding: 10px;
+    padding-left: 20px;
+    box-sizing: border-box;
+  }
+
+  .annotation-mode .page-metadata > div.stream-metadata-user-row > .stream-metadata-user-row-inner > div:first-child {
+    font-weight: bold;
+    /* Mirror value column inset so both cells read the same width (chrome sits in this band on the value side). */
+    padding-right: 40px;
+  }
+
+  .annotation-mode .page-metadata > div.stream-metadata-user-row > .stream-metadata-user-row-inner > .stream-metadata-user-value-cell {
+    position: relative;
+    display: flex;
+    align-items: center;
+    min-width: 0;
+    padding-right: 40px;
+  }
+
+  .annotation-mode .page-metadata > div.stream-metadata-user-row > .stream-metadata-user-row-inner > .stream-metadata-user-value-cell > .stream-metadata-user-value-editable {
+    flex: 1 1 auto;
+    min-width: 0;
+    width: 100%;
+    display: flex;
+    flex-direction: row;
+    flex-wrap: nowrap;
+    align-items: center;
+    gap: 0;
+  }
+
+  .annotation-mode .page-metadata > div.stream-metadata-user-row > .stream-metadata-user-row-inner > .stream-metadata-user-value-cell > .stream-metadata-user-value-editable > .stream-metadata-user-value-chrome {
+    position: absolute;
+    right: 6px;
+    top: 50%;
+    transform: translateY(-50%);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    line-height: 0;
+    z-index: 2;
+  }
+
+  .annotation-mode .page-metadata > div.stream-metadata-user-row > .stream-metadata-user-row-inner > .stream-metadata-user-value-cell > .stream-metadata-user-value-editable > p {
+    flex: 1 1 auto;
+    min-width: 0;
+    width: 100%;
+    margin: 0;
+    align-self: center;
+  }
+
+  .annotation-mode .page-metadata > div.stream-metadata-user-row > .stream-metadata-user-row-inner > .stream-metadata-user-value-cell > .stream-metadata-user-value-editable > button {
+    align-self: center;
+    flex-shrink: 0;
+    line-height: 0;
+  }
+
+  .annotation-mode .page-metadata > div.stream-metadata-user-row > .stream-metadata-user-row-inner > .stream-metadata-user-value-cell > .stream-metadata-user-value-editable > picture {
+    flex: 1 1 auto;
+    min-width: 0;
+    width: 100%;
+    align-self: center;
+  }
+  .annotation-mode .page-metadata > div.stream-metadata-user-row .stream-metadata-user-value-chrome .stream-annotation-delete-metadata-row {
+    margin: 0;
+    flex-shrink: 0;
+    line-height: 0;
+  }
+  .annotation-mode .stream-annotation-delete-metadata-row {
+    display: none;
+    flex: 0 0 auto;
+    align-self: center;
+    margin: 0;
+    min-width: 30px;
+    width: 30px;
+    height: 30px;
+    padding: 0;
+    line-height: 1;
+    font-size: 0;
+    font-weight: 600;
+    color: #64748b;
+    background: #fff;
+    border: 1px solid #94a3b8;
+    border-radius: 4px;
+    cursor: pointer;
+  }
+
+  .annotation-mode .stream-annotation-delete-metadata-row svg {
+    display: block;
+    margin: 0 auto;
+  }
+
+  /* User-added rows: show delete in annotation mode (overrides display:none above).
+     Inline-edit toggle unchanged for the rest of the page; JS re-insets button after Medium Editor. */
+  .annotation-mode .page-metadata > div.stream-metadata-user-row .stream-annotation-delete-metadata-row {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .annotation-mode .page-metadata > div.stream-metadata-user-row .stream-annotation-delete-metadata-row:hover {
+    background: #fee2e2;
+    border-color: #dc2626;
+    color: #b91c1c;
+  }
+
+  .annotation-mode .page-metadata > div.stream-metadata-user-row .stream-annotation-delete-metadata-row:focus-visible {
+    outline: 2px solid var(--sm-color-primary, #3b82f6);
+    outline-offset: 2px;
+  }
+
+  /* Native (DA) metadata rows: same delete affordance as user-added rows */
+  .annotation-mode .page-metadata > div:not(.stream-metadata-user-row) > div:first-child {
+    padding-right: 40px;
+    box-sizing: border-box;
+  }
+
+  .annotation-mode .page-metadata > div:not(.stream-metadata-user-row) > div:last-child {
+    position: relative;
+    padding-right: 40px;
+    box-sizing: border-box;
+  }
+
+  .annotation-mode .page-metadata > div:not(.stream-metadata-user-row) > div:last-child > .stream-metadata-user-value-chrome {
+    position: absolute;
+    right: 6px;
+    top: 50%;
+    transform: translateY(-50%);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    line-height: 0;
+    z-index: 2;
+  }
+
+  .annotation-mode .page-metadata > div:not(.stream-metadata-user-row) .stream-annotation-delete-metadata-row {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .annotation-mode .page-metadata > div:not(.stream-metadata-user-row) .stream-annotation-delete-metadata-row:hover {
+    background: #fee2e2;
+    border-color: #dc2626;
+    color: #b91c1c;
+  }
+
+  .annotation-mode .page-metadata > div:not(.stream-metadata-user-row) .stream-annotation-delete-metadata-row:focus-visible {
+    outline: 2px solid var(--sm-color-primary, #3b82f6);
+    outline-offset: 2px;
+  }
+
+  .annotation-inline-edit-mode .page-metadata > div:not(.stream-metadata-user-row) .stream-annotation-delete-metadata-row {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .annotation-inline-edit-mode .stream-annotation-delete-metadata-row {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .annotation-inline-edit-mode .stream-annotation-delete-metadata-row:hover {
+    background: #fee2e2;
+    border-color: #dc2626;
+    color: #b91c1c;
+  }
+
+  .annotation-inline-edit-mode .stream-annotation-delete-metadata-row:focus-visible {
+    outline: 2px solid var(--sm-color-primary, #3b82f6);
+    outline-offset: 2px;
   }
 
   .annotation-mode .page-metadata > div > div img {

--- a/streamlibs/operations/annotation/comments-panel.js
+++ b/streamlibs/operations/annotation/comments-panel.js
@@ -1489,29 +1489,28 @@ export default function createCommentsPanelController({
         if (rect.bottom < 0 || rect.top > window.innerHeight) return;
 
         const groups = buildCommentGroups(thread);
-        groups.forEach((group, idx) => {
-          const marker = document.createElement('button');
-          marker.type = 'button';
-          marker.className = 'annotation-edit-marker';
-          marker.dataset.threadId = thread.id;
-          marker.dataset.messageId = group.comment.id || '';
-          marker.dataset.commentIndex = String(idx);
-          marker.title = `Edit ${idx + 1}`;
-          marker.setAttribute('aria-label', `Open edit ${idx + 1}`);
-          marker.innerHTML = `
+        if (!groups.length) return;
+        // One canvas marker per edit target; full change history stays in the panel.
+        const latestIndex = groups.length - 1;
+        const group = groups[latestIndex];
+        const marker = document.createElement('button');
+        marker.type = 'button';
+        marker.className = 'annotation-edit-marker';
+        marker.dataset.threadId = thread.id;
+        marker.dataset.messageId = group.comment.id || '';
+        marker.dataset.commentIndex = String(latestIndex);
+        marker.title = 'Open edit';
+        marker.setAttribute('aria-label', 'Open edit');
+        marker.innerHTML = `
             <svg class="annotation-edit-marker-icon" viewBox="0 0 24 24" aria-hidden="true">
               <path d="M3 17.25V21h3.75L19.81 7.94l-3.75-3.75z"></path>
             </svg>
           `;
 
-          const position = resolveMarkerPosition(
-            rect.top - 8,
-            rect.right - 8 - (idx * MARKER_STEP),
-          );
-          marker.style.top = `${position.top}px`;
-          marker.style.left = `${position.left}px`;
-          annotationUI.layerEl.appendChild(marker);
-        });
+        const position = resolveMarkerPosition(rect.top - 8, rect.right - 8);
+        marker.style.top = `${position.top}px`;
+        marker.style.left = `${position.left}px`;
+        annotationUI.layerEl.appendChild(marker);
       });
 
     if (assetsPanel) {

--- a/streamlibs/operations/annotation/store.js
+++ b/streamlibs/operations/annotation/store.js
@@ -839,6 +839,74 @@ export function createAnnotationStore({ annotationState, annotationUI }) {
     return null;
   }
 
+  function isDomSubtreeOf(subtreeRoot, node) {
+    return node instanceof Node && subtreeRoot instanceof Node && subtreeRoot.contains(node);
+  }
+
+  function getAssetAnchoredElement(asset) {
+    if (!annotationUI.mainEl || !asset || typeof asset !== 'object') return null;
+    if (asset.elementRef) {
+      const byRef = getElementByRef(asset.elementRef);
+      if (byRef instanceof HTMLElement) return byRef;
+    }
+    const path = `${asset.elementPath || ''}`.trim();
+    if (!path) return null;
+    try {
+      const el = annotationUI.mainEl.querySelector(path);
+      return el instanceof HTMLElement ? el : null;
+    } catch {
+      return null;
+    }
+  }
+
+  function threadAnchoredInSubtree(thread, subtreeRoot) {
+    if (!(subtreeRoot instanceof HTMLElement)) return false;
+    const target = getElementForThread(thread);
+    if (isDomSubtreeOf(subtreeRoot, target)) return true;
+    if (thread.elementRef) {
+      const byRef = getElementByRef(thread.elementRef);
+      if (isDomSubtreeOf(subtreeRoot, byRef)) return true;
+    }
+    return false;
+  }
+
+  /**
+   * Removes easy edits, assets, local assets, and threads tied to DOM inside subtreeRoot.
+   * Call while subtreeRoot is still connected to annotationUI.mainEl.
+   */
+  function removeAnnotationStateForSubtree(subtreeRoot) {
+    if (!(subtreeRoot instanceof HTMLElement) || !annotationUI.mainEl) return;
+    if (!annotationUI.mainEl.contains(subtreeRoot)) return;
+
+    if (annotationState.selectedElement && subtreeRoot.contains(annotationState.selectedElement)) {
+      clearSelectedElement();
+    }
+
+    annotationState.store.easyEdits = annotationState.store.easyEdits.filter((edit) => {
+      if (!edit || typeof edit !== 'object') return false;
+      const target = getElementForEdit(edit);
+      if (isDomSubtreeOf(subtreeRoot, target)) return false;
+      if (edit.elementRef) {
+        const byRef = getElementByRef(edit.elementRef);
+        if (isDomSubtreeOf(subtreeRoot, byRef)) return false;
+      }
+      return true;
+    });
+
+    annotationState.store.assets = (annotationState.store.assets || []).filter(
+      (asset) => !isDomSubtreeOf(subtreeRoot, getAssetAnchoredElement(asset)),
+    );
+    annotationState.store.localAssets = (annotationState.store.localAssets || []).filter(
+      (asset) => !isDomSubtreeOf(subtreeRoot, getAssetAnchoredElement(asset)),
+    );
+
+    rebuildEditThreadsFromEasyEdits();
+    annotationState.store.threads = annotationState.store.threads.filter(
+      (thread) => !threadAnchoredInSubtree(thread, subtreeRoot),
+    );
+    removeEasyEditHighlights(annotationUI.mainEl);
+  }
+
   function pruneNestedTextEasyEdits() {
     const textEditTargets = annotationState.store.easyEdits.map((edit, index) => {
       if (edit?.editType !== 'text') return null;
@@ -1094,6 +1162,7 @@ export function createAnnotationStore({ annotationState, annotationUI }) {
     removeThreadMessage,
     replaceThreadsByType,
     removeEasyEditHighlights,
+    removeAnnotationStateForSubtree,
     saveAnnotationStore,
     upsertThread,
     upsertEasyEdit,


### PR DESCRIPTION
Jira:
https://jira.corp.adobe.com/browse/MWPW-194556 

Summary:

Delete for existing Page Metadata rows: native DA rows (not only “Add text/image” rows) get a trash control and can be removed from the DOM with the same store cleanup as user-added rows.
Delete for user-added rows: unchanged behavior, with re-attach after inline edit / Medium Editor via refreshPageMetadataDeleteButtons.
Persist cleanup: sanitizeMetadataDivForPersist strips delete buttons and removes empty .stream-metadata-user-value-chrome wrappers so saved HTML stays DA-shaped.
Layout/CSS: metadata grid / column styling so key/value cells stay even for user + native rows.
<img width="3456" height="2234" alt="image" src="https://github.com/user-attachments/assets/523f0fc6-733b-4707-bed7-76c71b89eeea" />


