### PR TITLE
MWPW-196249 | Add auto comment apply option on stream comments in annotation mode

### DIFF
--- a/streamlibs/operations/aiSeoAnnotation/ai-seo-annotation.css
+++ b/streamlibs/operations/aiSeoAnnotation/ai-seo-annotation.css
@@ -1,6 +1,7 @@
-/* ── Text regeneration button ─────────────────────────────────────────────── */
+/* ── Regeneration buttons (text + image) ──────────────────────────────────── */
 
-.stream-regen-btn {
+.stream-regen-btn,
+.stream-img-regen-btn {
   position: fixed;
   display: none;
   align-items: center;
@@ -8,60 +9,33 @@
   width: 28px;
   height: 28px;
   border-radius: 50%;
-  background: #1473e6;
+  background: #1d4ed8;
   border: none;
   cursor: pointer;
   z-index: 2147483500;
-  box-shadow: 0 2px 6px rgb(0 0 0 / 30%);
+  box-shadow: 0 2px 8px rgb(29 78 216 / 35%);
   padding: 0;
   transition: transform 0.1s, background 0.15s;
 }
 
-.stream-regen-btn:hover {
+.stream-regen-btn:hover,
+.stream-img-regen-btn:hover {
   transform: scale(1.12);
-  background: #0d66d0;
+  background: #1e40af;
 }
 
-.stream-regen-btn.stream-regen-visible { display: flex; }
-
-.stream-regen-btn.stream-regen-loading {
-  background: #888;
+.stream-regen-btn.stream-regen-loading,
+.stream-img-regen-btn.stream-img-regen-loading {
+  background: #64748b;
   cursor: wait;
   pointer-events: none;
 }
 
-.stream-regen-btn svg {
-  width: 15px;
-  height: 15px;
-  fill: #fff;
-}
-
-/* ── Image regeneration button ────────────────────────────────────────────── */
-
-.stream-img-regen-btn {
-  position: fixed;
-  display: none;
-  align-items: center;
-  justify-content: center;
-  width: 32px;
-  height: 32px;
-  border-radius: 50%;
-  background: #1473e6;
-  border: none;
-  cursor: pointer;
-  z-index: 2147483500;
-  box-shadow: 0 2px 8px rgb(0 0 0 / 35%);
-  padding: 0;
-  transition: transform 0.1s, background 0.15s;
-}
-
-.stream-img-regen-btn:hover {
-  transform: scale(1.1);
-  background: #0d66d0;
-}
+.stream-regen-btn.stream-regen-visible { display: flex; }
 
 .stream-img-regen-btn.stream-img-regen-visible { display: flex; }
 
+.stream-regen-btn svg,
 .stream-img-regen-btn svg {
   width: 16px;
   height: 16px;
@@ -86,11 +60,39 @@
 
 .stream-img-prompt-overlay.stream-img-prompt-visible { display: flex; }
 
+.stream-img-prompt-close {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  width: 24px;
+  height: 24px;
+  border: none;
+  background: none;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 4px;
+  color: #888;
+  padding: 0;
+}
+
+.stream-img-prompt-close:hover {
+  background: #f0f0f0;
+  color: #222;
+}
+
+.stream-img-prompt-close svg {
+  width: 14px;
+  height: 14px;
+}
+
 .stream-img-prompt-overlay label {
   font-size: 13px;
   font-weight: 600;
   color: #222;
   margin: 0;
+  padding-right: 20px;
 }
 
 .stream-img-prompt-input {
@@ -106,7 +108,7 @@
   line-height: 1.4;
 }
 
-.stream-img-prompt-input:focus { border-color: #1473e6; }
+.stream-img-prompt-input:focus { border-color: #1d4ed8; }
 
 .stream-img-prompt-actions {
   display: flex;
@@ -114,32 +116,30 @@
   justify-content: flex-end;
 }
 
-.stream-img-prompt-cancel {
-  padding: 6px 14px;
-  border-radius: 6px;
-  border: 1px solid #ccc;
-  background: #fff;
-  cursor: pointer;
-  font-size: 13px;
-  color: #555;
-}
-
-.stream-img-prompt-cancel:hover { background: #f4f4f4; }
-
 .stream-img-prompt-submit {
+  display: flex;
+  align-items: center;
+  gap: 6px;
   padding: 6px 14px;
   border-radius: 6px;
   border: none;
-  background: #1473e6;
+  background: #1d4ed8;
   color: #fff;
   cursor: pointer;
   font-size: 13px;
   font-weight: 600;
 }
 
+.stream-img-prompt-submit svg {
+  width: 13px;
+  height: 13px;
+  fill: #fff;
+  flex-shrink: 0;
+}
+
 .stream-img-prompt-submit:disabled {
-  background: #888;
+  background: #64748b;
   cursor: wait;
 }
 
-.stream-img-prompt-submit:hover:not(:disabled) { background: #0d66d0; }
+.stream-img-prompt-submit:hover:not(:disabled) { background: #1e40af; }

--- a/streamlibs/operations/aiSeoAnnotation/ai-seo-annotation.js
+++ b/streamlibs/operations/aiSeoAnnotation/ai-seo-annotation.js
@@ -34,7 +34,7 @@ function hideRegenBtn() {
 }
 
 function scheduleHideRegenBtn() {
-  regenState.hideTimer = setTimeout(hideRegenBtn, 180);
+  regenState.hideTimer = setTimeout(hideRegenBtn, 350);
 }
 
 function cancelHideRegenBtn() {
@@ -111,11 +111,13 @@ function showRegenBtn(el) {
   if (op !== 'aiSeoAnnotation') return;
   if (!document.body.classList.contains('annotation-inline-edit-mode')) return;
   cancelHideRegenBtn();
-  regenState.target = el;
   const btn = ensureRegenButton();
-  const r = el.getBoundingClientRect();
-  btn.style.top = `${Math.max(4, r.top + 2)}px`;
-  btn.style.left = `${r.right - 32}px`;
+  if (regenState.target !== el) {
+    regenState.target = el;
+    const r = el.getBoundingClientRect();
+    btn.style.top = `${Math.max(0, r.top - 14)}px`;
+    btn.style.left = `${r.right + 4}px`;
+  }
   btn.classList.add('stream-regen-visible');
 }
 
@@ -183,15 +185,17 @@ function hideImgPromptOverlay() {
 function positionOverlayNearImage(overlay, img) {
   const r = img.getBoundingClientRect();
   const ow = overlay.offsetWidth || 300;
-  const oh = overlay.offsetHeight || 160;
-  const vw = window.innerWidth;
-  const vh = window.innerHeight;
+  const oh = overlay.offsetHeight || 200;
+  const panelEl = document.querySelector('.annotation-panel');
+  const panelRect = panelEl?.getBoundingClientRect();
+  const maxRight = panelRect ? Math.max(24, panelRect.left - 12) : window.innerWidth - 12;
 
-  let left = r.left + (r.width - ow) / 2;
-  let top = r.top + (r.height - oh) / 2;
+  let left = r.right + 12;
+  if (left + ow > maxRight) left = r.left - ow - 12;
+  left = Math.max(12, Math.min(left, maxRight - ow));
 
-  left = Math.max(8, Math.min(left, vw - ow - 8));
-  top = Math.max(8, Math.min(top, vh - oh - 8));
+  let { top } = r;
+  top = Math.max(12, Math.min(top, window.innerHeight - oh - 12));
 
   overlay.style.left = `${left}px`;
   overlay.style.top = `${top}px`;
@@ -227,15 +231,22 @@ function ensureImgRegenElements() {
   // Prompt overlay
   const overlay = document.createElement('div');
   overlay.className = 'stream-img-prompt-overlay';
-  overlay.innerHTML = '<label>Describe the new image</label>'
+  overlay.innerHTML = '<button class="stream-img-prompt-close" type="button" aria-label="Close">'
+    + '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round">'
+    + '<path d="M18 6 6 18M6 6l12 12"/>'
+    + '</svg></button>'
+    + '<label>Describe the new image</label>'
     + '<textarea class="stream-img-prompt-input" placeholder="e.g. a vibrant teal forest at dusk…" rows="3"></textarea>'
     + '<div class="stream-img-prompt-actions">'
-    + '<button class="stream-img-prompt-cancel" type="button">Cancel</button>'
-    + '<button class="stream-img-prompt-submit" type="button">Generate</button>'
+    + '<button class="stream-img-prompt-submit" type="button">'
+    + '<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">'
+    + '<path d="M12 2l2.09 6.26L20 10l-5.91 1.74L12 18l-2.09-6.26L4 10l5.91-1.74Z"/>'
+    + '<path d="M19 15l1.09 2.91L23 19l-2.91 1.09L19 23l-1.09-2.91L15 19l2.91-1.09Z"/>'
+    + '</svg>Generate</button>'
     + '</div>';
   document.body.appendChild(overlay);
 
-  overlay.querySelector('.stream-img-prompt-cancel').addEventListener('click', hideImgPromptOverlay);
+  overlay.querySelector('.stream-img-prompt-close').addEventListener('click', hideImgPromptOverlay);
 
   overlay.querySelector('.stream-img-prompt-submit').addEventListener('click', async () => {
     const img = imgRegenState.target;
@@ -246,7 +257,7 @@ function ensureImgRegenElements() {
 
     const submitBtn = overlay.querySelector('.stream-img-prompt-submit');
     submitBtn.disabled = true;
-    submitBtn.textContent = 'Generating…';
+    submitBtn.lastChild.textContent = 'Generating…';
 
     try {
       const token = (window.streamConfig && window.streamConfig.token) || '';
@@ -268,7 +279,7 @@ function ensureImgRegenElements() {
       console.error('[ai-seo-annotation] image-generation failed', err);
     } finally {
       submitBtn.disabled = false;
-      submitBtn.textContent = 'Generate';
+      submitBtn.lastChild.textContent = 'Generate';
       hideImgPromptOverlay();
     }
   });
@@ -301,8 +312,8 @@ function showImgRegenBtn(img) {
   imgRegenState.target = img;
   const { btn } = imgRegenState;
   const r = img.getBoundingClientRect();
-  btn.style.top = `${Math.max(4, r.top + 6)}px`;
-  btn.style.left = `${r.right - 38}px`;
+  btn.style.top = `${Math.max(0, r.top - 14)}px`;
+  btn.style.left = `${r.right + 4}px`;
   btn.classList.add('stream-img-regen-visible');
 }
 
@@ -323,12 +334,6 @@ function attachImageRegenHandlers() {
     if (imgRegenState.btn && (to === imgRegenState.btn || imgRegenState.btn.contains(to))) return;
     scheduleHideImgRegenBtn();
   });
-
-  // Close overlay on outside click
-  document.addEventListener('click', (e) => {
-    if (!imgRegenState.overlay?.classList.contains('stream-img-prompt-visible')) return;
-    if (!imgRegenState.overlay.contains(e.target)) hideImgPromptOverlay();
-  }, true);
 
   window.addEventListener('scroll', () => {
     hideImgRegenBtn();

--- a/streamlibs/operations/aiSeoAnnotation/ai-seo-annotation.js
+++ b/streamlibs/operations/aiSeoAnnotation/ai-seo-annotation.js
@@ -272,8 +272,9 @@ function ensureImgRegenElements() {
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const json = await res.json();
       const newUrl = json?.response?.imageUrl || json?.response?.url || json.url || json.image_url || json.imageUrl || '';
+      const newAlt = json?.response?.alt || json.alt || 'Image Alt text';
       if (newUrl && img.isConnected) {
-        await recordImageRegenAsLocalAsset(img, newUrl);
+        await recordImageRegenAsLocalAsset(img, newUrl, newAlt);
       }
     } catch (err) {
       console.error('[ai-seo-annotation] image-generation failed', err);

--- a/streamlibs/operations/aiSeoAnnotation/ai-seo-annotation.js
+++ b/streamlibs/operations/aiSeoAnnotation/ai-seo-annotation.js
@@ -317,6 +317,11 @@ function showImgRegenBtn(img) {
   btn.classList.add('stream-img-regen-visible');
 }
 
+function isSvgImage(img) {
+  const src = img.getAttribute('src') || '';
+  return /\.svg(\?.*)?$/i.test(src) || src.startsWith('data:image/svg');
+}
+
 function attachImageRegenHandlers() {
   const main = document.querySelector('main');
   if (!main) return;
@@ -324,6 +329,7 @@ function attachImageRegenHandlers() {
   main.addEventListener('mouseover', (e) => {
     const img = e.target.closest('img');
     if (!img) return;
+    if (isSvgImage(img)) return;
     if (imgRegenState.overlay?.classList.contains('stream-img-prompt-visible')) return;
     showImgRegenBtn(img);
   });

--- a/streamlibs/operations/annotation.js
+++ b/streamlibs/operations/annotation.js
@@ -28,12 +28,45 @@ const assetsPanel = createAssetsPanelController({
   store,
   assetService,
 });
+export async function recordImageRegenAsLocalAsset(imgEl, generatedUrl, pendingAlt = '') {
+  if (!(imgEl instanceof HTMLImageElement) || !generatedUrl) return;
+
+  const rawToken = window.streamConfig?.streamMapper?.daToken || window.streamConfig?.token || '';
+  const authToken = rawToken && !rawToken.startsWith('Bearer ') ? `Bearer ${rawToken}` : rawToken;
+
+  let blob;
+  try {
+    const fetchOpts = authToken ? { headers: { Authorization: authToken } } : {};
+    const res = await fetch(generatedUrl, fetchOpts);
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    blob = await res.blob();
+  } catch (err) {
+    console.warn('[annotation] Could not fetch generated image', err);
+    return;
+  }
+
+  const mimeType = blob.type || 'image/jpeg';
+  const ext = mimeType.split('/')[1]?.split('+')[0] || 'jpg';
+  const file = new File([blob], `generated-${Date.now()}.${ext}`, { type: mimeType });
+
+  const base64Data = await new Promise((resolve) => {
+    const reader = new FileReader();
+    reader.onloadend = () => resolve(reader.result);
+    reader.onerror = () => resolve(null);
+    reader.readAsDataURL(blob);
+  });
+  if (!base64Data) return;
+
+  await assetsPanel.registerLocalAssetFromRegen(imgEl, file, base64Data, pendingAlt);
+}
+
 const commentsPanel = createCommentsPanelController({
   annotationState,
   annotationUI,
   store,
   assetsPanel,
 });
+commentsPanel.setImageRegenHandler(recordImageRegenAsLocalAsset);
 const inlineEditing = createInlineEditingController({
   annotationState,
   annotationUI,
@@ -669,38 +702,6 @@ export function registerRegenReplacement(originalSrc, newUrl) {
   const existing = regenReplacements.findIndex((r) => r.originalSrc === originalSrc);
   if (existing >= 0) regenReplacements[existing].targetUrl = newUrl;
   else regenReplacements.push({ originalSrc, targetUrl: newUrl });
-}
-
-export async function recordImageRegenAsLocalAsset(imgEl, generatedUrl) {
-  if (!(imgEl instanceof HTMLImageElement) || !generatedUrl) return;
-
-  const rawToken = window.streamConfig?.streamMapper?.daToken || window.streamConfig?.token || '';
-  const authToken = rawToken && !rawToken.startsWith('Bearer ') ? `Bearer ${rawToken}` : rawToken;
-
-  let blob;
-  try {
-    const fetchOpts = authToken ? { headers: { Authorization: authToken } } : {};
-    const res = await fetch(generatedUrl, fetchOpts);
-    if (!res.ok) throw new Error(`HTTP ${res.status}`);
-    blob = await res.blob();
-  } catch (err) {
-    console.warn('[annotation] Could not fetch generated image', err);
-    return;
-  }
-
-  const mimeType = blob.type || 'image/jpeg';
-  const ext = mimeType.split('/')[1]?.split('+')[0] || 'jpg';
-  const file = new File([blob], `generated-${Date.now()}.${ext}`, { type: mimeType });
-
-  const base64Data = await new Promise((resolve) => {
-    const reader = new FileReader();
-    reader.onloadend = () => resolve(reader.result);
-    reader.onerror = () => resolve(null);
-    reader.readAsDataURL(blob);
-  });
-  if (!base64Data) return;
-
-  await assetsPanel.registerLocalAssetFromRegen(imgEl, file, base64Data);
 }
 
 export function preparePendingRemoteEditsRefresh() {

--- a/streamlibs/operations/annotation.js
+++ b/streamlibs/operations/annotation.js
@@ -28,34 +28,47 @@ const assetsPanel = createAssetsPanelController({
   store,
   assetService,
 });
+async function fetchImageAsBase64(url) {
+  const rawToken = window.streamConfig?.streamMapper?.daToken || window.streamConfig?.token || '';
+  const authToken = rawToken && !rawToken.startsWith('Bearer ') ? `Bearer ${rawToken}` : rawToken;
+  try {
+    const res = await fetch(url, authToken ? { headers: { Authorization: authToken } } : {});
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const blob = await res.blob();
+    return new Promise((resolve) => {
+      const reader = new FileReader();
+      reader.onloadend = () => resolve(reader.result);
+      reader.onerror = () => resolve(null);
+      reader.readAsDataURL(blob);
+    });
+  } catch (err) {
+    console.warn('[annotation] Could not fetch image as base64', err);
+    return null;
+  }
+}
+
+const previewUrlCache = new Map();
+
+async function resolvePreviewUrl(url) {
+  if (!url || !url.includes('content.da.live')) return url;
+  if (previewUrlCache.has(url)) return previewUrlCache.get(url);
+  const b64 = await fetchImageAsBase64(url);
+  if (b64) previewUrlCache.set(url, b64);
+  return b64 || url;
+}
+
 export async function recordImageRegenAsLocalAsset(imgEl, generatedUrl, pendingAlt = '') {
   if (!(imgEl instanceof HTMLImageElement) || !generatedUrl) return;
 
-  const rawToken = window.streamConfig?.streamMapper?.daToken || window.streamConfig?.token || '';
-  const authToken = rawToken && !rawToken.startsWith('Bearer ') ? `Bearer ${rawToken}` : rawToken;
-
-  let blob;
-  try {
-    const fetchOpts = authToken ? { headers: { Authorization: authToken } } : {};
-    const res = await fetch(generatedUrl, fetchOpts);
-    if (!res.ok) throw new Error(`HTTP ${res.status}`);
-    blob = await res.blob();
-  } catch (err) {
-    console.warn('[annotation] Could not fetch generated image', err);
-    return;
-  }
-
-  const mimeType = blob.type || 'image/jpeg';
-  const ext = mimeType.split('/')[1]?.split('+')[0] || 'jpg';
-  const file = new File([blob], `generated-${Date.now()}.${ext}`, { type: mimeType });
-
-  const base64Data = await new Promise((resolve) => {
-    const reader = new FileReader();
-    reader.onloadend = () => resolve(reader.result);
-    reader.onerror = () => resolve(null);
-    reader.readAsDataURL(blob);
-  });
+  const base64Data = await fetchImageAsBase64(generatedUrl);
   if (!base64Data) return;
+
+  const mimeType = base64Data.split(';')[0].split(':')[1] || 'image/jpeg';
+  const ext = mimeType.split('/')[1]?.split('+')[0] || 'jpg';
+  const binaryStr = atob(base64Data.split(',')[1]);
+  const bytes = new Uint8Array(binaryStr.length);
+  for (let i = 0; i < binaryStr.length; i += 1) bytes[i] = binaryStr.charCodeAt(i);
+  const file = new File([bytes], `generated-${Date.now()}.${ext}`, { type: mimeType });
 
   await assetsPanel.registerLocalAssetFromRegen(imgEl, file, base64Data, pendingAlt);
 }
@@ -67,6 +80,7 @@ const commentsPanel = createCommentsPanelController({
   assetsPanel,
 });
 commentsPanel.setImageRegenHandler(recordImageRegenAsLocalAsset);
+
 const inlineEditing = createInlineEditingController({
   annotationState,
   annotationUI,
@@ -297,8 +311,11 @@ function buildHtmlWithEditsAndAssets(assetReplacements) {
           if (filenameCandidates.includes(extractFilename(img.getAttribute('src') || ''))) {
             img.setAttribute('src', asset.targetUrl);
             if (img.hasAttribute('srcset')) img.setAttribute('srcset', asset.targetUrl);
+            const picture = img.closest('picture');
+            if (picture) {
+              picture.querySelectorAll('source').forEach((s) => s.setAttribute('srcset', asset.targetUrl));
+            }
             matched = true;
-            break;
           }
         }
       }
@@ -307,7 +324,10 @@ function buildHtmlWithEditsAndAssets(assetReplacements) {
           if ((img.getAttribute('src') || '') === asset.daUrl) {
             img.setAttribute('src', asset.targetUrl);
             if (img.hasAttribute('srcset')) img.setAttribute('srcset', asset.targetUrl);
-            break;
+            const picture = img.closest('picture');
+            if (picture) {
+              picture.querySelectorAll('source').forEach((s) => s.setAttribute('srcset', asset.targetUrl));
+            }
           }
         }
       }
@@ -395,8 +415,9 @@ async function finishAnnotationSession(mainEl, {
       includeEdits: false,
     });
   }
+  store.setPreviewUrlResolver(resolvePreviewUrl);
   store.rebindEasyEditsToCurrentDom();
-  store.applyEasyEditsToDom();
+  await store.applyEasyEditsToDom();
   store.saveAnnotationStore();
   if (shouldRestoreInlineMode) {
     const didEnableInlineMode = await inlineEditing.enableInlineEditMode();
@@ -408,6 +429,7 @@ async function finishAnnotationSession(mainEl, {
     commentsPanel.renderThreadMarkers({ resolveTargets: true });
     commentsPanel.renderCommentsPanel();
   }
+  await store.applyEasyEditsToDom();
 }
 
 // ── Asset / edit processing (shared by persist and save) ──────────────────────
@@ -629,10 +651,7 @@ export async function saveAnnotationChanges(reportProgress = () => {}) {
   await uploadAndDecideAssets();
 
   const assetReplacements = buildAssetReplacementsAndEdits((asset) => asset.daUrl);
-  const { easyEdits, daCompatibleHtml } = buildHtmlWithEditsAndAssets(assetReplacements);
-
-  await postData(window.streamConfig.targetUrl, daCompatibleHtml, { suppressErrorPage: true });
-  reportProgress('htmlSaved');
+  const { easyEdits } = buildHtmlWithEditsAndAssets(assetReplacements);
 
   if (annotationService.isAvailable()) {
     const persistedEditSnapshot = await annotationService.saveEdits(easyEdits);

--- a/streamlibs/operations/annotation/annotation.css
+++ b/streamlibs/operations/annotation/annotation.css
@@ -234,8 +234,8 @@ body.annotation-mode main::-webkit-scrollbar {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 28px;
-  height: 28px;
+  width: 25px;
+  height: 25px;
   padding: 0;
   border: 1px solid #cbd5f5;
   background: #fff;
@@ -277,6 +277,12 @@ body.annotation-mode main::-webkit-scrollbar {
   background: #10b981;
   border-color: #059669;
   color: #fff;
+}
+
+.annotation-mode-btn-visibility[aria-pressed="true"] {
+  background: #e2e8f0;
+  border-color: #94a3b8;
+  color: #475569;
 }
 
 @container comments-panel (max-width: 260px) {
@@ -801,11 +807,19 @@ body.annotation-mode main::-webkit-scrollbar {
   fill: currentcolor;
 }
 
-.annotation-card-auto-apply-btn:hover {
+.annotation-card-auto-apply-btn:hover:not(:disabled) {
   background: #eff6ff;
   border-color: #93c5fd;
   color: #1d4ed8;
   transform: translateY(-1px);
+}
+
+.annotation-card-auto-apply-btn:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+  border-color: #e2e8f0;
+  background: #f8fafc;
+  color: #94a3b8;
 }
 
 .annotation-panel-edit-btn {
@@ -843,8 +857,13 @@ body.annotation-mode main::-webkit-scrollbar {
 .annotation-panel-edit-form {
   display: flex;
   flex-direction: column;
-  gap: 8px;
-  margin-top: 2px;
+  gap: 10px;
+  margin-top: 8px;
+  padding: 10px 12px 12px;
+  background: #f0f6ff;
+  border: 1px solid #dbeafe;
+  border-left: 3px solid #3b82f6;
+  border-radius: 10px;
 }
 
 .annotation-panel-edit-form-reply {
@@ -853,28 +872,30 @@ body.annotation-mode main::-webkit-scrollbar {
 
 .annotation-panel-edit-input {
   width: 100%;
-  min-height: 84px;
-  resize: vertical;
-  border: 1px solid #93c5fd;
-  border-radius: 10px;
+  min-height: 76px;
+  resize: none;
+  border: 1px solid #cbd5e1;
+  border-radius: 7px;
   background: #fff;
   color: #111827;
-  padding: 9px 10px;
+  padding: 9px 11px;
   font-family: inherit;
-  font-size: 12px;
-  line-height: 1.5;
+  font-size: 12.5px;
+  line-height: 1.6;
+  box-sizing: border-box;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
 }
 
 .annotation-panel-edit-input:focus {
   outline: none;
   border-color: #3b82f6;
-  box-shadow: 0 0 0 2px rgb(59 130 246 / 15%);
+  box-shadow: 0 0 0 3px rgb(59 130 246 / 12%);
 }
 
 .annotation-panel-edit-actions {
   display: flex;
   justify-content: flex-end;
-  gap: 8px;
+  gap: 6px;
 }
 
 .annotation-panel-edit-save-btn,
@@ -882,49 +903,65 @@ body.annotation-mode main::-webkit-scrollbar {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 28px;
   height: 28px;
-  min-width: 28px;
-  padding: 0;
-  border-radius: 8px;
+  padding: 0 12px;
+  border-radius: 6px;
+  font-family: inherit;
+  font-size: 11.5px;
+  font-weight: 600;
+  letter-spacing: 0.01em;
   cursor: pointer;
-  transition: opacity 0.18s ease, transform 0.18s ease, background-color 0.18s ease, color 0.18s ease;
+  transition: background-color 0.15s ease, box-shadow 0.15s ease, transform 0.12s ease;
+  gap: 5px;
 }
 
 .annotation-panel-edit-save-btn svg,
 .annotation-panel-edit-cancel-btn svg {
-  width: 14px;
-  height: 14px;
+  width: 13px;
+  height: 13px;
+  flex-shrink: 0;
   fill: none;
   stroke: currentcolor;
   stroke-linecap: round;
   stroke-linejoin: round;
-  stroke-width: 2.4;
-}
-
-.annotation-panel-edit-save-btn:hover,
-.annotation-panel-edit-cancel-btn:hover {
-  transform: translateY(-1px);
+  stroke-width: 2.5;
 }
 
 .annotation-panel-edit-cancel-btn {
   background: #fff;
-  border: 1.5px solid #bfdbfe;
-  color: #27272a;
+  border: 1px solid #d1d5db;
+  color: #4b5563;
+}
+
+.annotation-panel-edit-cancel-btn::after {
+  content: 'Discard';
 }
 
 .annotation-panel-edit-save-btn {
+  background: #2563eb;
   border: 1px solid transparent;
-  background: linear-gradient(135deg, #3b82f6 0%, #1d4ed8 100%);
   color: #fff;
 }
 
+.annotation-panel-edit-save-btn::after {
+  content: 'Save';
+}
+
 .annotation-panel-edit-cancel-btn:hover {
-  background: #eff6ff;
+  background: #f3f4f6;
+  border-color: #9ca3af;
+  transform: translateY(-1px);
 }
 
 .annotation-panel-edit-save-btn:hover {
-  background: linear-gradient(135deg, #2563eb 0%, #1e40af 100%);
+  background: #1d4ed8;
+  box-shadow: 0 2px 8px rgb(37 99 235 / 30%);
+  transform: translateY(-1px);
+}
+
+.annotation-panel-edit-save-btn:active,
+.annotation-panel-edit-cancel-btn:active {
+  transform: translateY(0);
 }
 
 .annotation-panel-edit-form.is-submitting .annotation-panel-edit-input,
@@ -932,6 +969,7 @@ body.annotation-mode main::-webkit-scrollbar {
 .annotation-panel-edit-form.is-submitting .annotation-panel-edit-cancel-btn {
   opacity: 0.55;
   cursor: wait;
+  pointer-events: none;
 }
 
 .annotation-panel-reply-composer {

--- a/streamlibs/operations/annotation/annotation.css
+++ b/streamlibs/operations/annotation/annotation.css
@@ -566,6 +566,26 @@ body.annotation-mode main::-webkit-scrollbar {
   color: #065f46;
 }
 
+.annotation-panel-comment.annotation-panel-asset-item.annotation-asset-rejected {
+  border-color: #e5e7eb;
+  border-left-color: #9ca3af;
+  background: #f9fafb;
+}
+
+.annotation-panel-comment.annotation-panel-asset-item.annotation-asset-rejected .annotation-panel-comment-user {
+  color: #6b7280;
+}
+
+.annotation-panel-comment.annotation-panel-asset-item.annotation-asset-rejected .annotation-panel-comment-text {
+  border-color: #e5e7eb;
+  background: #f3f4f6;
+  color: #6b7280;
+}
+
+.annotation-panel-comment.annotation-panel-asset-item.annotation-asset-rejected .annotation-asset-card-footer {
+  border-top-color: #e5e7eb;
+}
+
 .annotation-panel-comment.is-active {
   border-color: #3b82f6;
   box-shadow: 0 0 0 2px rgb(59 130 246 / 16%);
@@ -1351,350 +1371,51 @@ body.annotation-asset-select-mode main img:hover {
   white-space: nowrap;
 }
 
+.annotation-asset-card-footer {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 6px;
+  margin-top: 8px;
+  padding-top: 6px;
+  border-top: 1px solid #d1fae5;
+}
+
 .annotation-asset-status {
-  display: inline-block;
-  font-size: 10px;
-  font-weight: 600;
-  padding: 1px 6px;
-  border-radius: 4px;
-  text-transform: uppercase;
-  width: fit-content;
-  margin-top: 4px;
-}
-
-.annotation-asset-status-pending {
-  color: #92400e;
-  background: #fef3c7;
-}
-
-.annotation-asset-status-applied {
-  color: #1e40af;
-  background: #dbeafe;
-}
-
-.annotation-asset-status-accepted {
-  color: #065f46;
-  background: #d1fae5;
-}
-
-.annotation-asset-status-rejected {
-  color: #991b1b;
-  background: #fee2e2;
-}
-
-.annotation-asset-status-promoted {
-  color: #5b21b6;
-  background: #ede9fe;
-}
-
-.annotation-asset-status-unsaved {
-  color: #9a3412;
-  background: #ffedd5;
-}
-
-.annotation-asset-card-local {
-  background: #ecfdf5;
-}
-
-.annotation-asset-card-local::before {
-  content: '';
   position: absolute;
   top: 8px;
   right: 8px;
-  width: 8px;
-  height: 8px;
+  width: 10px;
+  height: 10px;
   border-radius: 50%;
-  background: #f97316;
-  box-shadow: 0 0 0 2px rgb(249 115 22 / 25%);
-}
-
-.annotation-asset-from-to {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-  margin-top: 2px;
-}
-
-.annotation-asset-from-to-row {
-  display: flex;
-  align-items: baseline;
-  gap: 4px;
-  font-size: 10px;
-  line-height: 1.3;
-}
-
-.annotation-asset-from-to-label {
-  font-weight: 600;
-  color: #6b7280;
-  flex-shrink: 0;
-}
-
-.annotation-asset-from-to-value {
-  color: #9ca3af;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.annotation-asset-element {
-  font-size: 10px;
-  color: #9ca3af;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.annotation-asset-actions {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-  flex-shrink: 0;
-}
-
-.annotation-asset-action-btn {
-  font-size: 11px;
-  font-weight: 500;
-  padding: 3px 8px;
-  border: 1px solid #d1d5db;
-  border-radius: 4px;
-  background: #fff;
-  color: #374151;
-  cursor: pointer;
-  transition: background 0.1s;
-}
-
-.annotation-asset-action-btn:hover {
-  background: #f3f4f6;
-}
-
-.annotation-asset-action-delete {
-  color: #dc2626;
-  border-color: #fecaca;
-}
-
-.annotation-asset-action-delete:hover {
-  background: #fef2f2;
-}
-
-/* Visual indicator on replaced images */
-.annotation-asset-pending-indicator {
-  outline: 3px dashed #2563eb !important;
-  outline-offset: 2px;
-}
-
-.annotation-asset-pending-badge {
-  position: absolute;
-  top: 4px;
-  left: 4px;
-  font-size: 10px;
-  font-weight: 700;
-  color: #fff;
-  background: #2563eb;
-  padding: 2px 8px;
-  border-radius: 4px;
-  z-index: 10;
-  pointer-events: none;
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
-}
-
-/* Attach asset button in reply composer */
-.annotation-panel-attach-btn {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 28px;
-  height: 28px;
+  font-size: 0;
   padding: 0;
-  border: 1px solid #d1d5db;
-  border-radius: 4px;
-  background: #fff;
-  cursor: pointer;
-  font-size: 14px;
-  flex-shrink: 0;
-  transition: background 0.1s;
-}
-
-.annotation-panel-attach-btn:hover {
-  background: #f3f4f6;
-}
-
-/* Attach asset dropdown */
-.annotation-attach-dropdown {
-  background: #fff;
-  border: 1px solid #e5e7eb;
-  border-radius: 8px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
-  max-height: 200px;
-  overflow-y: auto;
-  min-width: 180px;
-}
-
-.annotation-attach-dropdown-item {
-  display: block;
-  width: 100%;
-  padding: 8px 12px;
-  font-size: 12px;
-  text-align: left;
   border: none;
-  background: none;
-  cursor: pointer;
-  color: #374151;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.annotation-attach-dropdown-item:hover {
-  background: #f3f4f6;
-}
-
-.annotation-attach-dropdown-item + .annotation-attach-dropdown-item {
-  border-top: 1px solid #f3f4f6;
-}
-
-/* ── Assets panel ──────────────────────────────────────────────────── */
-
-.annotation-assets-upload-bar {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  margin-bottom: 10px;
-}
-
-.annotation-assets-select-btn {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 6px;
-  padding: 7px 14px;
-  font-size: 12px;
-  font-weight: 600;
-  color: #fff;
-  background: #2563eb;
-  border: none;
-  border-radius: 6px;
-  cursor: pointer;
-  transition: background 0.15s;
-}
-
-.annotation-assets-select-btn:hover {
-  background: #1d4ed8;
-}
-
-.annotation-assets-select-hint {
-  margin: 0;
-  font-size: 11px;
-  color: #6b7280;
-  line-height: 1.4;
-}
-
-/* Select-element mode: highlight images on hover */
-body.annotation-asset-select-mode main img {
-  cursor: crosshair !important;
-  transition: outline 0.1s;
-}
-
-body.annotation-asset-select-mode main img:hover {
-  outline: 3px solid #2563eb;
-  outline-offset: 2px;
-}
-
-/* Asset list */
-.annotation-assets-list {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-}
-
-.annotation-asset-card {
-  display: flex;
-  gap: 8px;
-  padding: 8px;
-  background: #fff;
-  border: 1px solid #e5e7eb;
-  border-radius: 8px;
-  align-items: flex-start;
-}
-
-.annotation-asset-card:hover {
-  border-color: #93c5fd;
-}
-
-.annotation-asset-thumb {
-  flex-shrink: 0;
-  width: 48px;
-  height: 48px;
-  border-radius: 4px;
-  overflow: hidden;
-  background: #f3f4f6;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.annotation-asset-thumb-img {
-  max-width: 100%;
-  max-height: 100%;
-  object-fit: cover;
-}
-
-.annotation-asset-info {
-  flex: 1;
-  min-width: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-}
-
-.annotation-asset-filename {
-  font-size: 12px;
-  font-weight: 600;
-  color: #111827;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.annotation-asset-status {
-  display: inline-block;
-  font-size: 10px;
-  font-weight: 600;
-  padding: 1px 6px;
-  border-radius: 4px;
-  text-transform: uppercase;
-  width: fit-content;
-  margin-top: 4px;
+  box-shadow: 0 0 0 2px rgb(255 255 255 / 70%);
 }
 
 .annotation-asset-status-pending {
-  color: #92400e;
-  background: #fef3c7;
+  background: #f59e0b;
 }
 
 .annotation-asset-status-applied {
-  color: #1e40af;
-  background: #dbeafe;
+  background: #3b82f6;
 }
 
 .annotation-asset-status-accepted {
-  color: #065f46;
-  background: #d1fae5;
-}
-
-.annotation-asset-status-rejected {
-  color: #991b1b;
-  background: #fee2e2;
+  background: #10b981;
 }
 
 .annotation-asset-status-promoted {
-  color: #5b21b6;
-  background: #ede9fe;
+  background: #7c3aed;
 }
 
 .annotation-asset-status-unsaved {
-  color: #9a3412;
-  background: #ffedd5;
+  background: #f97316;
+}
+
+.annotation-asset-status-rejected {
+  background: #ef4444;
 }
 
 .annotation-asset-card-local {
@@ -1751,7 +1472,7 @@ body.annotation-asset-select-mode main img:hover {
 
 .annotation-asset-actions {
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
   gap: 4px;
   flex-shrink: 0;
 }

--- a/streamlibs/operations/annotation/annotation.css
+++ b/streamlibs/operations/annotation/annotation.css
@@ -675,7 +675,7 @@ body.annotation-mode main::-webkit-scrollbar {
 .annotation-panel-status-select {
   appearance: none;
   border: 1px solid #bfdbfe;
-  border-radius: 999px;
+  border-radius: 6px;
   background: #eff6ff;
   color: #1d4ed8;
   font-size: 10px;
@@ -778,20 +778,50 @@ body.annotation-mode main::-webkit-scrollbar {
   border-top: 1px solid #e5e7eb;
 }
 
-.annotation-panel-edit-btn {
+.annotation-card-auto-apply-btn {
   border: 1px solid #bfdbfe;
   background: #f8fbff;
   color: #1d4ed8;
-  border-radius: 8px;
-  width: 24px;
-  height: 24px;
-  min-width: 24px;
+  border-radius: 6px;
+  width: 22px;
+  height: 22px;
+  min-width: 22px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
   cursor: pointer;
   padding: 0;
-  transition: background-color 0.18s ease, border-color 0.18s ease, transform 0.18s ease;
+  flex-shrink: 0;
+  transition: background-color 0.15s ease, border-color 0.15s ease, transform 0.15s ease;
+}
+
+.annotation-card-auto-apply-btn svg {
+  width: 11px;
+  height: 11px;
+  fill: currentcolor;
+}
+
+.annotation-card-auto-apply-btn:hover {
+  background: #eff6ff;
+  border-color: #93c5fd;
+  color: #1d4ed8;
+  transform: translateY(-1px);
+}
+
+.annotation-panel-edit-btn {
+  border: 1px solid #bfdbfe;
+  background: #f8fbff;
+  color: #1d4ed8;
+  border-radius: 6px;
+  width: 22px;
+  height: 22px;
+  min-width: 22px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  padding: 0;
+  transition: background-color 0.15s ease, border-color 0.15s ease, transform 0.15s ease;
 }
 
 .annotation-panel-edit-btn-reply {
@@ -805,8 +835,8 @@ body.annotation-mode main::-webkit-scrollbar {
 }
 
 .annotation-panel-edit-btn svg {
-  width: 13px;
-  height: 13px;
+  width: 11px;
+  height: 11px;
   fill: currentcolor;
 }
 

--- a/streamlibs/operations/annotation/annotation.css
+++ b/streamlibs/operations/annotation/annotation.css
@@ -174,6 +174,46 @@ body.annotation-mode main::-webkit-scrollbar {
   flex: 0 0 auto;
 }
 
+.annotation-panel-filter-tabs {
+  display: flex;
+  gap: 2px;
+  flex: 0 0 auto;
+  background: #f1f5f9;
+  border-radius: 8px;
+  padding: 3px;
+  margin-top: 10px;
+}
+
+.annotation-panel-filter-tab {
+  flex: 1 1 0;
+  padding: 4px 8px;
+  font-size: 11px;
+  font-weight: 500;
+  border: none;
+  background: transparent;
+  border-radius: 6px;
+  color: #64748b;
+  cursor: pointer;
+  transition: background-color 0.12s ease, color 0.12s ease;
+  white-space: nowrap;
+}
+
+.annotation-panel-filter-tab:hover {
+  color: #1e3a8a;
+  background: rgba(255, 255, 255, 0.6);
+}
+
+.annotation-panel-filter-tab.is-active {
+  background: #fff;
+  color: #1d4ed8;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+}
+
+.annotation-panel-filter-tab:focus-visible {
+  outline: 2px solid rgba(37, 99, 235, 0.35);
+  outline-offset: 1px;
+}
+
 .annotation-comments-content {
   position: relative;
   flex: 1 1 auto;

--- a/streamlibs/operations/annotation/annotation.css
+++ b/streamlibs/operations/annotation/annotation.css
@@ -646,8 +646,18 @@ body.annotation-mode main::-webkit-scrollbar {
   box-shadow: 0 0 0 3px rgb(29 78 216 / 24%);
 }
 
+.annotation-panel-comment-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 6px;
+  margin-bottom: 6px;
+}
+
 .annotation-panel-comment-user {
-  margin: 0 0 4px;
+  margin: 0;
+  flex: 1;
+  min-width: 0;
   color: #1d4ed8;
   font-size: 12px;
   font-weight: 700;
@@ -658,30 +668,44 @@ body.annotation-mode main::-webkit-scrollbar {
 .annotation-panel-status-controls {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  gap: 6px;
-  margin-top: 8px;
-}
-
-.annotation-panel-status-controls .annotation-panel-edit-btn {
-  margin-left: auto;
+  gap: 4px;
+  flex-shrink: 0;
 }
 
 .annotation-panel-status-select {
+  appearance: none;
   border: 1px solid #bfdbfe;
-  border-radius: 6px;
-  background: #fff;
-  color: #1f2937;
+  border-radius: 999px;
+  background: #eff6ff;
+  color: #1d4ed8;
   font-size: 10px;
-  padding: 2px 4px;
-  height: 20px;
-  min-width: 76px;
+  font-weight: 600;
+  padding: 2px 8px;
+  height: auto;
+  min-width: 0;
+  cursor: pointer;
+  line-height: 1.5;
+  transition: background 0.15s, border-color 0.15s;
+}
+
+.annotation-panel-status-select[data-status="Resolved"] {
+  border-color: #a7f3d0;
+  background: #ecfdf5;
+  color: #059669;
+}
+
+.annotation-panel-status-select[data-status="Closed"] {
+  border-color: #d1d5db;
+  background: #f3f4f6;
+  color: #6b7280;
+}
+
+.annotation-panel-status-select:not(:disabled):hover {
+  filter: brightness(0.96);
 }
 
 .annotation-panel-status-select:disabled {
-  background: #f3f4f6;
-  border-color: #d1d5db;
-  color: #6b7280;
+  opacity: 0.7;
   cursor: not-allowed;
 }
 

--- a/streamlibs/operations/annotation/assets-panel.js
+++ b/streamlibs/operations/annotation/assets-panel.js
@@ -92,9 +92,8 @@ export default function createAssetsPanelController({
       list.appendChild(buildLocalAssetCard(localAsset));
     }
 
-    const sorted = [...remoteAssets].sort(
-      (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
-    );
+    const sorted = [...remoteAssets]
+      .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
     for (const asset of sorted) {
       list.appendChild(buildRemoteAssetCard(asset));
     }
@@ -116,15 +115,32 @@ export default function createAssetsPanelController({
     card.appendChild(username);
 
     const text = document.createElement('p');
-    text.className = 'annotation-panel-comment-text';
-    text.textContent = `replaced image "${truncateSrc(localAsset.originalSrc)}" → "${localAsset.filename}"`;
+    text.className = 'annotation-panel-comment-text annotation-panel-asset-links';
+    const fromLink = document.createElement('a');
+    fromLink.href = localAsset.originalSrc || '#';
+    fromLink.textContent = 'From Image';
+    fromLink.target = '_blank';
+    fromLink.rel = 'noopener noreferrer';
+    fromLink.className = 'annotation-asset-link';
+    const arrow = document.createTextNode(' → ');
+    const toLink = document.createElement('a');
+    toLink.href = localAsset.base64Data || localAsset.filename || '#';
+    toLink.textContent = 'To Image';
+    toLink.target = '_blank';
+    toLink.rel = 'noopener noreferrer';
+    toLink.className = 'annotation-asset-link';
+    text.appendChild(fromLink);
+    text.appendChild(arrow);
+    text.appendChild(toLink);
     card.appendChild(text);
 
     const statusBadge = document.createElement('span');
     statusBadge.className = 'annotation-asset-status annotation-asset-status-unsaved';
-    statusBadge.textContent = 'unsaved';
+    statusBadge.title = 'unsaved';
     card.appendChild(statusBadge);
 
+    const footer = document.createElement('div');
+    footer.className = 'annotation-asset-card-footer';
     const actions = document.createElement('div');
     actions.className = 'annotation-asset-actions';
     const deleteBtn = document.createElement('button');
@@ -132,14 +148,15 @@ export default function createAssetsPanelController({
     deleteBtn.textContent = 'Remove';
     deleteBtn.addEventListener('click', () => removeLocalAsset(localAsset.localId));
     actions.appendChild(deleteBtn);
-    card.appendChild(actions);
+    footer.appendChild(actions);
+    card.appendChild(footer);
 
     return card;
   }
 
   function buildRemoteAssetCard(asset) {
     const card = document.createElement('article');
-    card.className = 'annotation-panel-comment annotation-panel-asset-item';
+    card.className = `annotation-panel-comment annotation-panel-asset-item${asset.status === 'rejected' ? ' annotation-asset-rejected' : ''}`;
     card.dataset.assetId = asset.id;
     if (asset.createdAt) card.dataset.createdAt = asset.createdAt;
 
@@ -151,20 +168,40 @@ export default function createAssetsPanelController({
     card.appendChild(username);
 
     const text = document.createElement('p');
-    text.className = 'annotation-panel-comment-text';
-    const fromLabel = truncateSrc(asset.originalSrc || '(none)');
-    const toLabel = truncateSrc(asset.daUrl || asset.filename || '(none)');
-    text.textContent = `replaced image "${fromLabel}" → "${toLabel}"`;
+    text.className = 'annotation-panel-comment-text annotation-panel-asset-links';
+    const fromLink = document.createElement('a');
+    fromLink.href = asset.originalSrc || '#';
+    fromLink.textContent = 'From Image';
+    fromLink.target = '_blank';
+    fromLink.rel = 'noopener noreferrer';
+    fromLink.className = 'annotation-asset-link';
+    const arrow = document.createTextNode(' → ');
+    const toLink = document.createElement('a');
+    toLink.href = asset.daUrl || asset.filename || '#';
+    toLink.textContent = 'To Image';
+    toLink.target = '_blank';
+    toLink.rel = 'noopener noreferrer';
+    toLink.className = 'annotation-asset-link';
+    text.appendChild(fromLink);
+    text.appendChild(arrow);
+    text.appendChild(toLink);
     card.appendChild(text);
 
     const statusBadge = document.createElement('span');
+    const statusTitles = {
+      promoted: 'Pushed to DA',
+      accepted: 'Saved to collab',
+    };
     statusBadge.className = `annotation-asset-status annotation-asset-status-${asset.status}`;
-    statusBadge.textContent = asset.status;
+    statusBadge.title = statusTitles[asset.status] || asset.status;
     if (isApplied && asset.status === 'pending') {
-      statusBadge.textContent = 'applied';
+      statusBadge.title = 'applied';
       statusBadge.className = 'annotation-asset-status annotation-asset-status-applied';
     }
     card.appendChild(statusBadge);
+
+    const footer = document.createElement('div');
+    footer.className = 'annotation-asset-card-footer';
 
     const actions = document.createElement('div');
     actions.className = 'annotation-asset-actions';
@@ -186,15 +223,10 @@ export default function createAssetsPanelController({
       actions.appendChild(deleteBtn);
     }
 
-    card.appendChild(actions);
+    footer.appendChild(actions);
+    card.appendChild(footer);
 
     return card;
-  }
-
-  function truncateSrc(src) {
-    if (!src || src.length <= 50) return src;
-    // Show last 47 chars
-    return `...${src.slice(-47)}`;
   }
 
   function enterSelectMode() {

--- a/streamlibs/operations/annotation/assets-panel.js
+++ b/streamlibs/operations/annotation/assets-panel.js
@@ -240,6 +240,8 @@ export default function createAssetsPanelController({
       if (!img) return;
       if (img.closest('.annotation-comments-panel') || img.closest('.annotation-asset-pending-badge')) return;
       if (img.closest('[data-class="fragment"]')) return;
+      const src = img.getAttribute('src') || '';
+      if (/\.svg(\?.*)?$/i.test(src) || src.startsWith('data:image/svg')) return;
 
       event.preventDefault();
       event.stopPropagation();

--- a/streamlibs/operations/annotation/assets-panel.js
+++ b/streamlibs/operations/annotation/assets-panel.js
@@ -657,7 +657,7 @@ export default function createAssetsPanelController({
     annotationUI.appliedAssets.clear();
   }
 
-  async function registerLocalAssetFromRegen(targetImg, file, base64Data) {
+  async function registerLocalAssetFromRegen(targetImg, file, base64Data, pendingAlt = '') {
     if (!targetImg || !file || !base64Data) return null;
 
     const anchorTarget = targetImg.closest('picture') || targetImg;
@@ -701,6 +701,35 @@ export default function createAssetsPanelController({
 
     annotationState.store.localAssets.push(localAsset);
     applyAssetPreviewToImg(targetImg, base64Data, localAsset);
+
+    if (pendingAlt) {
+      const originalAlt = targetImg.getAttribute('alt') || '';
+      const imgRef = store.ensureElementRef(targetImg);
+      const imgAnchor = store.buildEditElementAnchor(targetImg);
+
+      targetImg.dataset.pendingAlt = pendingAlt;
+      targetImg.alt = pendingAlt;
+
+      const { elementPath: altPath, elementProps: altProps } = imgAnchor;
+      const existingAltEdit = store.getEasyEditByElement(imgRef, altPath, altProps);
+      if (!existingAltEdit || existingAltEdit.editType === 'image-alt') {
+        store.upsertEasyEdit({
+          ...(existingAltEdit || {}),
+          id: existingAltEdit?.id || store.generateId('easy-edit'),
+          editType: 'image-alt',
+          attrName: 'alt',
+          elementPath: imgAnchor.elementPath,
+          elementProps: imgAnchor.elementProps,
+          elementRef: imgRef,
+          from: existingAltEdit?.from ?? originalAlt,
+          to: pendingAlt,
+          fromHtml: '',
+          toHtml: '',
+          updatedAt: new Date().toISOString(),
+        });
+      }
+    }
+
     notifyAssetsChanged();
     return {
       elementPath, elementProps, elementRef, originalSrc,

--- a/streamlibs/operations/annotation/comments-panel.js
+++ b/streamlibs/operations/annotation/comments-panel.js
@@ -1818,37 +1818,19 @@ export default function createCommentsPanelController({
     const value = input.value.trim();
     if (!value) return;
 
-    let thread = store.getCommentThreadByElement(annotationState.selectedElement);
-    const isReply = Boolean(thread);
-    if (isReply && isThreadClosed(thread)) {
-      showGlobalSnackbar(ANNOTATION_MESSAGES.closedThreadRestricted);
-      return;
-    }
     let didPersistToService = false;
-    let didHydrateThread = false;
+    let thread = null;
     setPopupSubmitPending(true);
     try {
-      if (!thread) {
-        const remoteThread = await annotationService.createThread({
-          elementPath: annotationState.selectedElementPath,
-          body: value,
-          quotedText: annotationState.selectedElement.textContent?.trim() || null,
-        });
-        if (remoteThread) {
-          store.upsertThread(remoteThread);
-          thread = store.getThreadById(remoteThread.id);
-          didPersistToService = true;
-        }
-      } else {
-        const result = await annotationService.createReply(thread.id, value);
-        if (result?.persisted) {
-          didPersistToService = true;
-        }
-        if (result?.thread) {
-          store.upsertThread(result.thread);
-          thread = store.getThreadById(result.thread.id);
-          didHydrateThread = true;
-        }
+      const remoteThread = await annotationService.createThread({
+        elementPath: annotationState.selectedElementPath,
+        body: value,
+        quotedText: annotationState.selectedElement.textContent?.trim() || null,
+      });
+      if (remoteThread) {
+        store.upsertThread(remoteThread);
+        thread = store.getThreadById(remoteThread.id);
+        didPersistToService = true;
       }
     } catch (error) {
       // eslint-disable-next-line no-console
@@ -1856,11 +1838,7 @@ export default function createCommentsPanelController({
     }
 
     if (!didPersistToService || !thread) {
-      showGlobalSnackbar(
-        isReply
-          ? ANNOTATION_MESSAGES.sendReplyError
-          : ANNOTATION_MESSAGES.postCommentError,
-      );
+      showGlobalSnackbar(ANNOTATION_MESSAGES.postCommentError);
       setPopupSubmitPending(false);
       return;
     }
@@ -1871,17 +1849,11 @@ export default function createCommentsPanelController({
     annotationState.activeThreadId = thread.id;
     setPopupSubmitPending(false);
     closePopupAndSelection();
-    if (didHydrateThread || !isReply) {
-      store.saveAnnotationStore();
-      renderThreadMarkers({ resolveTargets: true });
-      renderCommentsPanel();
-      scrollCommentsPanelToBottom();
-    } else {
-      store.pushThreadMessage(thread, value, 'reply');
-      store.saveAnnotationStore();
-      renderCommentsPanel();
-    }
-    requestParentCollabRefresh(isReply ? 'reply-created' : 'comment-created');
+    store.saveAnnotationStore();
+    renderThreadMarkers({ resolveTargets: true });
+    renderCommentsPanel();
+    scrollCommentsPanelToBottom();
+    requestParentCollabRefresh('comment-created');
   }
 
   function attachPopupEvents() {
@@ -1975,7 +1947,7 @@ export default function createCommentsPanelController({
 
     const title = document.createElement('h3');
     title.className = 'annotation-popup-title';
-    title.textContent = thread ? 'Reply' : 'Comment';
+    title.textContent = 'Comment';
 
     const closeBtn = document.createElement('button');
     closeBtn.type = 'button';
@@ -1996,8 +1968,8 @@ export default function createCommentsPanelController({
     composer.className = 'annotation-reply-composer';
     const popupFieldId = `annotation-popup-input-${thread?.id || 'new'}`;
     composer.innerHTML = `
-      <textarea id="${popupFieldId}" name="${popupFieldId}" class="annotation-reply-input" placeholder="${thread ? 'Write a reply...' : 'Write a comment...'}"></textarea>
-      <button type="button" class="annotation-reply-btn" aria-label="${thread ? 'Send reply' : 'Send comment'}">
+      <textarea id="${popupFieldId}" name="${popupFieldId}" class="annotation-reply-input" placeholder="Write a comment..."></textarea>
+      <button type="button" class="annotation-reply-btn" aria-label="Send comment">
         <span aria-hidden="true">➤</span>
       </button>
     `;
@@ -2148,9 +2120,7 @@ export default function createCommentsPanelController({
       if (target === mainEl) return;
       if (target.closest('a')) event.preventDefault();
       event.stopPropagation();
-      if (!store.getCommentThreadByElement(target)) {
-        openPopupForElement(target);
-      }
+      openPopupForElement(target);
     };
     mainEl.addEventListener('click', annotationState.mainClickHandler, true);
 

--- a/streamlibs/operations/annotation/comments-panel.js
+++ b/streamlibs/operations/annotation/comments-panel.js
@@ -124,6 +124,29 @@ export default function createCommentsPanelController({
               <path d="M21 19V5c0-1.1-.9-2-2-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2zM8.5 13.5l2.5 3.01L14.5 12l4.5 6H5l3.5-4.5z"></path>
             </svg>
           </button>
+          <button
+            type="button"
+            class="annotation-mode-btn annotation-mode-btn-visibility"
+            aria-pressed="false"
+            aria-label="Toggle annotation visibility"
+            title="Toggle annotation visibility"
+          >
+            <svg class="annotation-visibility-icon-show" width="18" height="18" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+              <path fill-rule="evenodd" clip-rule="evenodd" d="M12.306 4.28999C11.2818 3.76572 10.1505 3.48445 9 3.46799C4.668 3.46799 1.125 7.78099 1.125 9.17999C1.125 10.68 4.854 14.532 8.968 14.532C13.116 14.532 16.875 10.679 16.875 9.17999C16.875 7.99999 14.768 5.50999 12.306 4.28999ZM9 13.612C8.08783 13.612 7.19615 13.3415 6.43771 12.8347C5.67927 12.328 5.08814 11.6077 4.73907 10.7649C4.39 9.92219 4.29866 8.99487 4.47662 8.10023C4.65457 7.20559 5.09382 6.38381 5.73882 5.73881C6.38382 5.09381 7.2056 4.65456 8.10024 4.47661C8.99488 4.29865 9.9222 4.38998 10.7649 4.73905C11.6077 5.08813 12.328 5.67926 12.8347 6.4377C13.3415 7.19614 13.612 8.08782 13.612 8.99999C13.6117 10.2231 13.1257 11.396 12.2609 12.2609C11.396 13.1257 10.2231 13.6117 9 13.612Z" fill="currentColor"/>
+              <path fill-rule="evenodd" clip-rule="evenodd" d="M10.333 9.04199C10.1579 9.04199 9.98444 9.00748 9.82265 8.94043C9.66085 8.87338 9.51386 8.7751 9.39007 8.65121C9.26627 8.52733 9.16811 8.38026 9.10118 8.21842C9.03425 8.05658 8.99986 7.88313 9 7.70799C9.0026 7.47626 9.06641 7.24933 9.18494 7.05019C9.30348 6.85105 9.47254 6.68677 9.675 6.57399C9.45606 6.50737 9.22882 6.47202 9 6.46899C8.49941 6.46899 8.01007 6.61743 7.59385 6.89554C7.17763 7.17365 6.85322 7.56894 6.66166 8.03142C6.47009 8.4939 6.41997 9.0028 6.51763 9.49377C6.61529 9.98473 6.85634 10.4357 7.21031 10.7897C7.56427 11.1436 8.01526 11.3847 8.50622 11.4824C8.99719 11.58 9.50609 11.5299 9.96857 11.3383C10.431 11.1468 10.8263 10.8224 11.1044 10.4061C11.3826 9.98992 11.531 9.50058 11.531 8.99999C11.5278 8.79709 11.4986 8.59544 11.444 8.39999C11.3292 8.59311 11.1668 8.75355 10.9723 8.86595C10.7777 8.97836 10.5576 9.03897 10.333 9.04199Z" fill="currentColor"/>
+            </svg>
+            <svg class="annotation-visibility-icon-hide" width="18" height="18" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" style="display:none">
+              <g clip-path="url(#clip0_visibility_hide)">
+                <path fill-rule="evenodd" clip-rule="evenodd" d="M7.286 4.71999C8.12397 4.3827 9.04261 4.29921 9.92766 4.47988C10.8127 4.66055 11.6251 5.09741 12.2638 5.73615C12.9026 6.37488 13.3394 7.18728 13.5201 8.07233C13.7008 8.95738 13.6173 9.87602 13.28 10.714L14.752 12.186C16.052 11.092 16.875 9.87999 16.875 9.17999C16.875 7.99799 14.768 5.50999 12.307 4.28999C11.2823 3.76588 10.1508 3.48462 9 3.46799C8.147 3.47595 7.3022 3.63543 6.505 3.93899L7.286 4.71999Z" fill="currentColor"/>
+                <path fill-rule="evenodd" clip-rule="evenodd" d="M16.9 16.029L11.164 10.3C11.4029 9.90839 11.5299 9.45875 11.531 9.00001C11.5278 8.7971 11.4986 8.59545 11.444 8.40001C11.329 8.59275 11.1664 8.75279 10.9719 8.86484C10.7774 8.97688 10.5575 9.03719 10.333 9.04001C9.97965 9.04001 9.64074 8.8997 9.39079 8.64993C9.14083 8.40016 9.00027 8.06137 9.00001 7.70801C9.00261 7.47627 9.06642 7.24934 9.18495 7.0502C9.30349 6.85106 9.47255 6.68678 9.67501 6.57401C9.45608 6.50738 9.22883 6.47203 9.00001 6.46901C8.54126 6.47014 8.09162 6.59708 7.70001 6.83601L1.97101 1.10001C1.93302 1.06194 1.88789 1.03174 1.83822 1.01113C1.78854 0.990526 1.73529 0.979919 1.68151 0.979919C1.62773 0.979919 1.57447 0.990526 1.5248 1.01113C1.47512 1.03174 1.43 1.06194 1.39201 1.10001L1.10001 1.39201C1.06194 1.43 1.03174 1.47512 1.01113 1.5248C0.990526 1.57447 0.979919 1.62773 0.979919 1.68151C0.979919 1.73529 0.990526 1.78854 1.01113 1.83822C1.03174 1.88789 1.06194 1.93302 1.10001 1.97101L4.27601 5.14401C2.36901 6.51401 1.12501 8.35301 1.12501 9.18001C1.12501 10.68 4.85401 14.532 8.96801 14.532C10.2683 14.5059 11.5439 14.1717 12.69 13.557L16.029 16.897C16.067 16.9351 16.1121 16.9653 16.1618 16.9859C16.2115 17.0065 16.2647 17.0171 16.3185 17.0171C16.3723 17.0171 16.4255 17.0065 16.4752 16.9859C16.5249 16.9653 16.57 16.9351 16.608 16.897L16.897 16.608C16.9353 16.5702 16.9657 16.5252 16.9866 16.4757C17.0074 16.4261 17.0183 16.3729 17.0186 16.3191C17.0189 16.2653 17.0085 16.212 16.9882 16.1623C16.9678 16.1125 16.9379 16.0672 16.9 16.029ZM9.00001 13.612C8.1405 13.6141 7.2976 13.3754 6.56685 12.9229C5.83611 12.4704 5.24676 11.8222 4.86563 11.0518C4.4845 10.2814 4.32683 9.41966 4.4105 8.56424C4.49417 7.70881 4.81583 6.89394 5.33901 6.21201L6.83901 7.71201C6.54568 8.19402 6.42276 8.76059 6.48995 9.32082C6.55714 9.88106 6.81055 10.4025 7.20954 10.8015C7.60852 11.2005 8.12995 11.4539 8.69019 11.5211C9.25042 11.5883 9.81699 11.4653 10.299 11.172L11.799 12.672C10.9956 13.2861 10.0113 13.6167 9.00001 13.612Z" fill="currentColor"/>
+              </g>
+              <defs>
+                <clipPath id="clip0_visibility_hide">
+                  <rect width="18" height="18" fill="white"/>
+                </clipPath>
+              </defs>
+            </svg>
+          </button>
         </div>
       </div>
       <div class="annotation-panel-filter-tabs" role="tablist" aria-label="Filter annotations">
@@ -143,6 +166,27 @@ export default function createCommentsPanelController({
     annotationUI.inlineToggleEl = panel.querySelector('.annotation-mode-btn-edit');
     annotationUI.inlineAssetsToggleEl = panel.querySelector('.annotation-mode-btn-assets');
     annotationUI.inlineCommentsToggleEl = null;
+    annotationUI.visibilityToggleEl = panel.querySelector('.annotation-mode-btn-visibility');
+
+    annotationUI.visibilityToggleEl.addEventListener('click', () => {
+      const layer = document.querySelector('.annotation-floating-layer');
+      const isHidden = annotationUI.visibilityToggleEl.getAttribute('aria-pressed') === 'true';
+      const showIcon = annotationUI.visibilityToggleEl.querySelector('.annotation-visibility-icon-show');
+      const hideIcon = annotationUI.visibilityToggleEl.querySelector('.annotation-visibility-icon-hide');
+      if (isHidden) {
+        if (layer) layer.style.display = '';
+        annotationUI.visibilityToggleEl.setAttribute('aria-pressed', 'false');
+        annotationUI.visibilityToggleEl.title = 'Toggle annotation visibility';
+        if (showIcon) showIcon.style.display = '';
+        if (hideIcon) hideIcon.style.display = 'none';
+      } else {
+        if (layer) layer.style.display = 'none';
+        annotationUI.visibilityToggleEl.setAttribute('aria-pressed', 'true');
+        annotationUI.visibilityToggleEl.title = 'Hide annotations';
+        if (showIcon) showIcon.style.display = 'none';
+        if (hideIcon) hideIcon.style.display = '';
+      }
+    });
 
     panel.querySelector('.annotation-panel-filter-tabs').addEventListener('click', (event) => {
       const tab = event.target.closest('.annotation-panel-filter-tab');
@@ -1200,21 +1244,113 @@ export default function createCommentsPanelController({
         cardHeader.append(username);
         if (statusControls) cardHeader.append(statusControls);
 
-        if (window.streamConfig?.operation === 'aiSeoAnnotation') {
+        if (isCommentThread && window.streamConfig?.operation === 'aiSeoAnnotation') {
+          const normalizedStatus = store.normalizeCommentStatus(thread.status);
+          const isAutoApplyEnabled = normalizedStatus === 'Resolved' || normalizedStatus === 'Accepted';
           const autoApplyBtn = document.createElement('button');
           autoApplyBtn.type = 'button';
           autoApplyBtn.className = 'annotation-card-auto-apply-btn';
+          autoApplyBtn.disabled = !isAutoApplyEnabled;
           autoApplyBtn.setAttribute('aria-label', 'Auto apply comment');
-          autoApplyBtn.title = 'Auto apply comment';
+          autoApplyBtn.title = isAutoApplyEnabled
+            ? 'Auto apply comment'
+            : 'Resolve the comment to enable auto apply';
           autoApplyBtn.innerHTML = `<svg viewBox="0 0 24 24" aria-hidden="true">
             <path d="M12 2l2.09 6.26L20 10l-5.91 1.74L12 18l-2.09-6.26L4 10l5.91-1.74Z"/>
             <path d="M19 15l1.09 2.91L23 19l-2.91 1.09L19 23l-1.09-2.91L15 19l2.91-1.09Z"/>
           </svg>`;
-          autoApplyBtn.addEventListener('click', (e) => {
+          autoApplyBtn.addEventListener('click', async (e) => {
             e.stopPropagation();
-            store.applyEasyEditsToDom();
-            store.saveAnnotationStore();
-            renderCommentsPanel();
+
+            const targetEl = store.getElementForThread(thread);
+            if (!targetEl) return;
+
+            const TEXT_TAGS = new Set(['P', 'H1', 'H2', 'H3', 'H4', 'H5', 'H6', 'LI', 'BLOCKQUOTE', 'TD', 'TH']);
+            const isTextEl = TEXT_TAGS.has(targetEl.tagName);
+            const targetImg = targetEl.tagName === 'IMG' ? targetEl : targetEl.querySelector('img');
+
+            if (isTextEl) {
+              const elementText = targetEl.textContent.trim();
+              if (!elementText) return;
+
+              const allGroups = buildCommentGroups(thread);
+              const commentLines = [];
+              allGroups.forEach((g) => {
+                if (g.comment?.text) commentLines.push(`- ${g.comment.text}`);
+                g.replies.forEach((reply) => {
+                  if (reply?.text) commentLines.push(`- ${reply.text}`);
+                });
+              });
+
+              const payloadText = `${elementText}\nRegenerate based on following comments\n${commentLines.join('\n')}`;
+              const token = window.streamConfig?.token || '';
+              const endpoint = `${window.streamConfig?.streamMapper?.serviceEP || ''}/api/content-regeneration`;
+              const threadId = window.streamConfig?.threadId || '';
+
+              let blockName = '';
+              let cur = targetEl;
+              while (cur && cur !== document.body) {
+                const parent = cur.parentElement;
+                if (parent?.classList.contains('section')) { blockName = cur.classList[0] || ''; break; }
+                cur = parent;
+              }
+
+              autoApplyBtn.disabled = true;
+              autoApplyBtn.classList.add('is-loading');
+              try {
+                const res = await fetch(endpoint, {
+                  method: 'POST',
+                  headers: {
+                    'content-type': 'application/json',
+                    ...(token ? { Authorization: `Bearer ${token}` } : {}),
+                  },
+                  // eslint-disable-next-line max-len
+                  body: JSON.stringify({ text: payloadText, block: blockName, thread_id: threadId }),
+                });
+                if (!res.ok) throw new Error(`HTTP ${res.status}`);
+                const json = await res.json();
+                const newText = json?.response?.text || json.text || json.content || json.result || '';
+                if (newText && targetEl.isConnected) {
+                  const fromText = targetEl.textContent.trim();
+                  const fromHtml = targetEl.innerHTML;
+                  targetEl.textContent = newText;
+                  const elementRef = store.ensureElementRef(targetEl);
+                  const snapshot = annotationUI.inlineElementSnapshot?.get(elementRef);
+                  const baselineText = snapshot?.originalText || fromText;
+                  const baselineHtml = snapshot?.originalHtml || fromHtml;
+                  const editAnchor = store.buildEditElementAnchor(targetEl, annotationUI.mainEl);
+                  const segments = store.getChangedSegments(baselineText, newText);
+                  const { elementPath, elementProps } = editAnchor;
+                  // eslint-disable-next-line max-len
+                  const existing = store.getEasyEditByElement(elementRef, elementPath, elementProps);
+                  store.upsertEasyEdit({
+                    id: existing?.id || store.generateId('easy-edit'),
+                    editType: 'text',
+                    attrName: '',
+                    elementPath: editAnchor.elementPath,
+                    elementProps: editAnchor.elementProps,
+                    elementRef,
+                    from: baselineText,
+                    to: newText,
+                    fromHtml: baselineHtml,
+                    toHtml: newText,
+                    changedFrom: segments.changedFrom,
+                    changedTo: segments.changedTo,
+                    updatedAt: new Date().toISOString(),
+                  });
+                  store.saveAnnotationStore();
+                  renderThreadMarkers({ resolveTargets: true });
+                  renderCommentsPanel();
+                }
+              } catch (err) {
+                console.error('[auto-apply] content-regeneration failed', err);
+              } finally {
+                autoApplyBtn.disabled = false;
+                autoApplyBtn.classList.remove('is-loading');
+              }
+            } else if (targetImg) {
+              // Image element - placeholder (implementation TBD)
+            }
           });
           if (statusControls) {
             statusControls.append(autoApplyBtn);

--- a/streamlibs/operations/annotation/comments-panel.js
+++ b/streamlibs/operations/annotation/comments-panel.js
@@ -49,6 +49,7 @@ export default function createCommentsPanelController({
   const panelReplyDrafts = new Map();
   const pendingReplyComposerKeys = new Set();
   const pendingCommentEditIds = new Set();
+  const pendingAutoApplyThreadIds = new Set();
 
   function setInlineModeHandlers(handlers) {
     enableInlineEditMode = handlers.enableInlineEditMode;
@@ -1251,7 +1252,8 @@ export default function createCommentsPanelController({
 
         if (isCommentThread && window.streamConfig?.operation === 'aiSeoAnnotation') {
           const normalizedStatus = store.normalizeCommentStatus(thread.status);
-          const isAutoApplyEnabled = normalizedStatus === 'Resolved' || normalizedStatus === 'Accepted';
+          const isAutoApplyEnabled = (normalizedStatus === 'Resolved' || normalizedStatus === 'Accepted')
+            && !pendingAutoApplyThreadIds.has(thread.id);
           const autoApplyBtn = document.createElement('button');
           autoApplyBtn.type = 'button';
           autoApplyBtn.className = 'annotation-card-auto-apply-btn';
@@ -1313,6 +1315,7 @@ export default function createCommentsPanelController({
                 cur = parent;
               }
 
+              pendingAutoApplyThreadIds.add(thread.id);
               autoApplyBtn.disabled = true;
               autoApplyBtn.classList.add('is-loading');
               try {
@@ -1363,6 +1366,7 @@ export default function createCommentsPanelController({
               } catch (err) {
                 console.error('[auto-apply] content-regeneration failed', err);
               } finally {
+                pendingAutoApplyThreadIds.delete(thread.id);
                 autoApplyBtn.disabled = false;
                 autoApplyBtn.classList.remove('is-loading');
               }
@@ -1383,6 +1387,7 @@ export default function createCommentsPanelController({
                 const token = window.streamConfig?.token || '';
                 const endpoint = `${window.streamConfig?.streamMapper?.serviceEP || ''}/api/image-generation`;
 
+                pendingAutoApplyThreadIds.add(thread.id);
                 autoApplyBtn.disabled = true;
                 autoApplyBtn.classList.add('is-loading');
                 try {
@@ -1404,6 +1409,7 @@ export default function createCommentsPanelController({
                 } catch (err) {
                   console.error('[auto-apply] image-generation failed', err);
                 } finally {
+                  pendingAutoApplyThreadIds.delete(thread.id);
                   autoApplyBtn.disabled = false;
                   autoApplyBtn.classList.remove('is-loading');
                 }

--- a/streamlibs/operations/annotation/comments-panel.js
+++ b/streamlibs/operations/annotation/comments-panel.js
@@ -1352,6 +1352,66 @@ export default function createCommentsPanelController({
     return annotationUI.panelEl.querySelector('.annotation-comments-content');
   }
 
+  function scrollAssetInPanel(elementPath) {
+    if (!annotationUI.panelEl || !annotationUI.panelListEl || !elementPath) return;
+
+    if (activePanelFilter === 'comment' || activePanelFilter === 'edit') {
+      activePanelFilter = 'asset';
+      annotationUI.panelEl.querySelectorAll('.annotation-panel-filter-tab').forEach((btn) => {
+        const isActive = btn.dataset.filter === activePanelFilter;
+        btn.classList.toggle('is-active', isActive);
+        btn.setAttribute('aria-selected', `${isActive}`);
+      });
+    }
+
+    renderCommentsPanel();
+
+    const runScroll = () => {
+      const scrollContainer = getCommentsScrollContainer();
+
+      // Collect all assets for this elementPath and sort newest first
+      const candidates = [];
+      (annotationState.store.localAssets || []).forEach((asset) => {
+        if (asset.elementPath === elementPath) {
+          candidates.push({
+            selector: `[data-local-asset-id="${asset.localId}"]`,
+            ts: assetsPanel ? assetsPanel.getAssetTimestamp(asset) : 0,
+          });
+        }
+      });
+      (annotationState.store.assets || []).forEach((asset) => {
+        if (asset.elementPath === elementPath) {
+          candidates.push({
+            selector: `[data-asset-id="${asset.id}"]`,
+            ts: assetsPanel ? assetsPanel.getAssetTimestamp(asset) : 0,
+          });
+        }
+      });
+      candidates.sort((a, b) => (b.ts || 0) - (a.ts || 0));
+
+      const target = candidates.reduce((found, candidate) => {
+        if (found) return found;
+        const card = annotationUI.panelListEl.querySelector(candidate.selector);
+        return card instanceof HTMLElement ? card : null;
+      }, null);
+
+      if (!(target instanceof HTMLElement) || !scrollContainer) return;
+
+      const targetTop = target.offsetTop + annotationUI.panelListEl.offsetTop - 16;
+      scrollContainer.scrollTo({ top: Math.max(0, targetTop), behavior: 'smooth' });
+
+      annotationUI.panelListEl.querySelectorAll('.annotation-panel-comment-focus')
+        .forEach((el) => el.classList.remove('annotation-panel-comment-focus'));
+      target.classList.add('annotation-panel-comment-focus');
+      target.setAttribute('tabindex', '-1');
+      target.focus({ preventScroll: true });
+      window.setTimeout(() => { target.classList.remove('annotation-panel-comment-focus'); }, 1200);
+    };
+
+    window.requestAnimationFrame(runScroll);
+    window.setTimeout(runScroll, 60);
+  }
+
   function scrollThreadInPanel(threadId, messageId = '', commentIndex = 0) {
     if (!annotationUI.panelEl || !annotationUI.panelListEl || !threadId) return;
     const thread = store.getThreadById(threadId);
@@ -2088,7 +2148,9 @@ export default function createCommentsPanelController({
       if (target === mainEl) return;
       if (target.closest('a')) event.preventDefault();
       event.stopPropagation();
-      openPopupForElement(target);
+      if (!store.getCommentThreadByElement(target)) {
+        openPopupForElement(target);
+      }
     };
     mainEl.addEventListener('click', annotationState.mainClickHandler, true);
 
@@ -2097,13 +2159,7 @@ export default function createCommentsPanelController({
       if (!(target instanceof Element)) return;
       const assetMarker = target.closest('.annotation-asset-marker');
       if (assetMarker instanceof HTMLButtonElement) {
-        const elementPath = assetMarker.dataset.elementPath || '';
-        if (elementPath && annotationUI.mainEl) {
-          const el = annotationUI.mainEl.querySelector(elementPath);
-          if (el instanceof HTMLElement) {
-            el.scrollIntoView({ block: 'center', behavior: 'smooth' });
-          }
-        }
+        scrollAssetInPanel(assetMarker.dataset.elementPath || '');
         return;
       }
       const editMarker = target.closest('.annotation-edit-marker');

--- a/streamlibs/operations/annotation/comments-panel.js
+++ b/streamlibs/operations/annotation/comments-panel.js
@@ -40,6 +40,7 @@ export default function createCommentsPanelController({
   let flushPendingCommentsPanelRefresh = () => {};
   let renderCommentsPanel = () => {};
   let popupSubmitPending = false;
+  let activePanelFilter = 'all';
   let activeCommentEditor = null;
   let popupDraft = '';
   let popupDraftKey = '';
@@ -125,6 +126,12 @@ export default function createCommentsPanelController({
           </button>
         </div>
       </div>
+      <div class="annotation-panel-filter-tabs" role="tablist" aria-label="Filter annotations">
+        <button type="button" role="tab" class="annotation-panel-filter-tab is-active" data-filter="all" aria-selected="true">All</button>
+        <button type="button" role="tab" class="annotation-panel-filter-tab" data-filter="comment" aria-selected="false">Comments</button>
+        <button type="button" role="tab" class="annotation-panel-filter-tab" data-filter="edit" aria-selected="false">Edits</button>
+        <button type="button" role="tab" class="annotation-panel-filter-tab" data-filter="asset" aria-selected="false">Assets</button>
+      </div>
       <div class="annotation-comments-content">
         <div class="annotation-comments-list"></div>
         <div class="annotation-comments-disabled-overlay">Edit mode is on. Switch it off to add comments.</div>
@@ -136,6 +143,18 @@ export default function createCommentsPanelController({
     annotationUI.inlineToggleEl = panel.querySelector('.annotation-mode-btn-edit');
     annotationUI.inlineAssetsToggleEl = panel.querySelector('.annotation-mode-btn-assets');
     annotationUI.inlineCommentsToggleEl = null;
+
+    panel.querySelector('.annotation-panel-filter-tabs').addEventListener('click', (event) => {
+      const tab = event.target.closest('.annotation-panel-filter-tab');
+      if (!(tab instanceof HTMLButtonElement)) return;
+      activePanelFilter = tab.dataset.filter || 'all';
+      panel.querySelectorAll('.annotation-panel-filter-tab').forEach((btn) => {
+        const isActive = btn.dataset.filter === activePanelFilter;
+        btn.classList.toggle('is-active', isActive);
+        btn.setAttribute('aria-selected', `${isActive}`);
+      });
+      renderCommentsPanel();
+    });
 
     updateModeButtonStates();
     applyOwnerOnlyToggleState();
@@ -1072,12 +1091,30 @@ export default function createCommentsPanelController({
       return;
     }
 
-    const unifiedItems = buildUnifiedItems();
+    annotationUI.panelEl?.querySelectorAll('.annotation-panel-filter-tab').forEach((btn) => {
+      const isActive = btn.dataset.filter === activePanelFilter;
+      btn.classList.toggle('is-active', isActive);
+      btn.setAttribute('aria-selected', `${isActive}`);
+    });
+
+    const allItems = buildUnifiedItems();
+    const unifiedItems = activePanelFilter === 'all' ? allItems : allItems.filter((item) => {
+      if (activePanelFilter === 'comment') return item.kind === 'comment';
+      if (activePanelFilter === 'edit') return item.kind === 'edit';
+      if (activePanelFilter === 'asset') return item.kind === 'asset-local' || item.kind === 'asset-remote';
+      return true;
+    });
 
     if (!unifiedItems.length) {
       const empty = document.createElement('p');
       empty.className = 'annotation-comments-empty';
-      empty.textContent = 'No annotations yet. Add comments, make inline edits, or replace images to populate this feed.';
+      const emptyMessages = {
+        comment: 'No comments yet.',
+        edit: 'No inline edits yet.',
+        asset: 'No asset replacements yet.',
+        all: 'No annotations yet. Add comments, make inline edits, or replace images to populate this feed.',
+      };
+      empty.textContent = emptyMessages[activePanelFilter] || emptyMessages.all;
       annotationUI.panelListEl.appendChild(empty);
       finalizeFragmentHints();
       return;

--- a/streamlibs/operations/annotation/comments-panel.js
+++ b/streamlibs/operations/annotation/comments-panel.js
@@ -37,6 +37,7 @@ export default function createCommentsPanelController({
   const isInlineEditingAllowed = () => window.streamConfig?.inlineEditingAllowed !== false || window.streamConfig?.collabRole === 'owner';
   let enableInlineEditMode = async () => {};
   let disableInlineEditMode = () => {};
+  let recordImageRegenAsLocalAsset = null;
   let flushPendingCommentsPanelRefresh = () => {};
   let renderCommentsPanel = () => {};
   let popupSubmitPending = false;
@@ -52,6 +53,10 @@ export default function createCommentsPanelController({
   function setInlineModeHandlers(handlers) {
     enableInlineEditMode = handlers.enableInlineEditMode;
     disableInlineEditMode = handlers.disableInlineEditMode;
+  }
+
+  function setImageRegenHandler(fn) {
+    recordImageRegenAsLocalAsset = fn;
   }
 
   function setSelectedElement(element) {
@@ -1262,13 +1267,26 @@ export default function createCommentsPanelController({
           autoApplyBtn.addEventListener('click', async (e) => {
             e.stopPropagation();
 
-            const targetEl = store.getElementForThread(thread);
-            if (!targetEl) return;
+            let targetEl = store.getElementForThread(thread);
+            if (!targetEl) {
+              const ep = thread.elementPath;
+              const fallbackSelector = (typeof ep === 'object' ? ep?.selector : null)
+                || (typeof ep === 'string' ? (() => { try { return JSON.parse(ep)?.selector; } catch { return null; } })() : null);
+              if (fallbackSelector && annotationUI.mainEl) {
+                targetEl = annotationUI.mainEl.querySelector(fallbackSelector);
+              }
+            }
+            if (!targetEl) {
+              return;
+            }
 
             const TEXT_TAGS = new Set(['P', 'H1', 'H2', 'H3', 'H4', 'H5', 'H6', 'LI', 'BLOCKQUOTE', 'TD', 'TH']);
             const isTextEl = TEXT_TAGS.has(targetEl.tagName);
-            const targetImg = targetEl.tagName === 'IMG' ? targetEl : targetEl.querySelector('img');
-
+            let targetImg = targetEl.tagName === 'IMG' ? targetEl : targetEl.querySelector('img');
+            if (!targetImg && targetEl.parentElement) {
+              targetImg = targetEl.parentElement.querySelector('img');
+            }
+            // eslint-disable-next-line max-len
             if (isTextEl) {
               const elementText = targetEl.textContent.trim();
               if (!elementText) return;
@@ -1349,7 +1367,47 @@ export default function createCommentsPanelController({
                 autoApplyBtn.classList.remove('is-loading');
               }
             } else if (targetImg) {
-              // Image element - placeholder (implementation TBD)
+              const imgSrc = targetImg.getAttribute('src') || '';
+              const isSvg = /\.svg(\?.*)?$/i.test(imgSrc) || imgSrc.startsWith('data:image/svg');
+              if (!isSvg && typeof recordImageRegenAsLocalAsset === 'function') {
+                const altText = targetImg.alt || '';
+                const allGroups = buildCommentGroups(thread);
+                const commentLines = [];
+                allGroups.forEach((g) => {
+                  if (g.comment?.text) commentLines.push(`- ${g.comment.text}`);
+                  g.replies.forEach((reply) => {
+                    if (reply?.text) commentLines.push(`- ${reply.text}`);
+                  });
+                });
+                const prompt = `Change the image generated for ${altText}\nTo have following changes\n${commentLines.join('\n')}`;
+                const token = window.streamConfig?.token || '';
+                const endpoint = `${window.streamConfig?.streamMapper?.serviceEP || ''}/api/image-generation`;
+
+                autoApplyBtn.disabled = true;
+                autoApplyBtn.classList.add('is-loading');
+                try {
+                  const res = await fetch(endpoint, {
+                    method: 'POST',
+                    headers: {
+                      'content-type': 'application/json',
+                      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+                    },
+                    body: JSON.stringify({ prompt }),
+                  });
+                  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+                  const json = await res.json();
+                  const newUrl = json?.response?.imageUrl || json?.response?.url || json.url || json.image_url || json.imageUrl || '';
+                  const newAlt = json?.response?.alt || json.alt || 'Image Alt text';
+                  if (newUrl && targetImg.isConnected) {
+                    await recordImageRegenAsLocalAsset(targetImg, newUrl, newAlt);
+                  }
+                } catch (err) {
+                  console.error('[auto-apply] image-generation failed', err);
+                } finally {
+                  autoApplyBtn.disabled = false;
+                  autoApplyBtn.classList.remove('is-loading');
+                }
+              }
             }
           });
           if (statusControls) {
@@ -2648,6 +2706,7 @@ export default function createCommentsPanelController({
     removePopup,
     renderCommentsPanel,
     renderThreadMarkers,
+    setImageRegenHandler,
     setInlineModeHandlers,
     setupAnnotationUI,
   };

--- a/streamlibs/operations/annotation/comments-panel.js
+++ b/streamlibs/operations/annotation/comments-panel.js
@@ -1170,6 +1170,7 @@ export default function createCommentsPanelController({
             option.selected = thread.status === status;
             statusSelect.appendChild(option);
           });
+          statusSelect.dataset.status = store.normalizeCommentStatus(thread.status);
           statusControls.append(statusSelect);
           if (canEditRootComment) {
             const editThreadBtn = document.createElement('button');
@@ -1194,12 +1195,18 @@ export default function createCommentsPanelController({
           || thread.username
           || ANNOTATION_DEFAULT_USERNAME;
 
+        const cardHeader = document.createElement('div');
+        cardHeader.className = 'annotation-panel-comment-header';
+        cardHeader.append(username);
+        if (statusControls) cardHeader.append(statusControls);
+        card.append(cardHeader);
+
         const rootCommentKey = `${thread.id}::${group.comment.id || ''}`;
         const isEditingRootComment = canEditRootComment
           && isEditingComment(thread.id, group.comment.id || '');
         if (isEditingRootComment) {
           if (preservedEditForm && !preservedIsReply && preservedEditKey === rootCommentKey) {
-            card.append(username, preservedEditForm);
+            card.append(preservedEditForm);
             preservedEditForm = null;
             didReuseEditForm = true;
           } else {
@@ -1208,15 +1215,14 @@ export default function createCommentsPanelController({
               group.comment.id || '',
               activeCommentEditor?.draft || '',
             );
-            card.append(username, editForm);
+            card.append(editForm);
           }
         } else {
           const text = document.createElement('p');
           text.className = 'annotation-panel-comment-text';
           text.innerHTML = linkifyText(group.comment.text);
-          card.append(username, text);
+          card.append(text);
         }
-        if (statusControls) card.append(statusControls);
 
         const repliesWrap = document.createElement('div');
         repliesWrap.className = 'annotation-panel-replies-list';

--- a/streamlibs/operations/annotation/comments-panel.js
+++ b/streamlibs/operations/annotation/comments-panel.js
@@ -1199,6 +1199,33 @@ export default function createCommentsPanelController({
         cardHeader.className = 'annotation-panel-comment-header';
         cardHeader.append(username);
         if (statusControls) cardHeader.append(statusControls);
+
+        if (window.streamConfig?.operation === 'aiSeoAnnotation') {
+          const autoApplyBtn = document.createElement('button');
+          autoApplyBtn.type = 'button';
+          autoApplyBtn.className = 'annotation-card-auto-apply-btn';
+          autoApplyBtn.setAttribute('aria-label', 'Auto apply comment');
+          autoApplyBtn.title = 'Auto apply comment';
+          autoApplyBtn.innerHTML = `<svg viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M12 2l2.09 6.26L20 10l-5.91 1.74L12 18l-2.09-6.26L4 10l5.91-1.74Z"/>
+            <path d="M19 15l1.09 2.91L23 19l-2.91 1.09L19 23l-1.09-2.91L15 19l2.91-1.09Z"/>
+          </svg>`;
+          autoApplyBtn.addEventListener('click', (e) => {
+            e.stopPropagation();
+            store.applyEasyEditsToDom();
+            store.saveAnnotationStore();
+            renderCommentsPanel();
+          });
+          if (statusControls) {
+            statusControls.append(autoApplyBtn);
+          } else {
+            const controls = document.createElement('div');
+            controls.className = 'annotation-panel-status-controls';
+            controls.append(autoApplyBtn);
+            cardHeader.append(controls);
+          }
+        }
+
         card.append(cardHeader);
 
         const rootCommentKey = `${thread.id}::${group.comment.id || ''}`;

--- a/streamlibs/operations/annotation/store.js
+++ b/streamlibs/operations/annotation/store.js
@@ -12,6 +12,12 @@ export function normalizeCommentStatus(status) {
 }
 
 export function createAnnotationStore({ annotationState, annotationUI }) {
+  let previewUrlResolverFn = null;
+
+  function setPreviewUrlResolver(fn) {
+    previewUrlResolverFn = fn;
+  }
+
   function generateId(prefix) {
     return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
   }
@@ -1021,16 +1027,40 @@ export function createAnnotationStore({ annotationState, annotationUI }) {
     rebuildEditThreadsFromEasyEdits();
   }
 
-  function applyEasyEditsToDom() {
+  async function applyEasyEditsToDom() {
     if (!annotationUI.mainEl) return;
     removeEasyEditHighlights(annotationUI.mainEl);
+
+    const resolvedUrls = new Map();
+    if (previewUrlResolverFn) {
+      await Promise.all(
+        annotationState.store.easyEdits
+          .filter((edit) => edit?.editType === 'image-src' && edit.to?.includes('content.da.live'))
+          .map(async (edit) => {
+            const b64 = await previewUrlResolverFn(edit.to);
+            if (b64) resolvedUrls.set(edit.to, b64);
+          }),
+      );
+    }
 
     annotationState.store.easyEdits.forEach((edit) => {
       const target = getElementForEdit(edit);
       if (!(target instanceof HTMLElement)) return;
       if (target.closest('[data-class="fragment"]')) return;
 
-      if (edit.editType === 'image-src') return;
+      if (edit.editType === 'image-src') {
+        const displayUrl = resolvedUrls.get(edit.to) || edit.to || '';
+        const imgEl = target.tagName === 'IMG' ? target : target.querySelector('img');
+        if (imgEl) {
+          imgEl.setAttribute('src', displayUrl);
+          if (imgEl.hasAttribute('srcset')) imgEl.setAttribute('srcset', displayUrl);
+        }
+        const picture = (imgEl || target).closest('picture');
+        if (picture) {
+          picture.querySelectorAll('source').forEach((s) => s.setAttribute('srcset', displayUrl));
+        }
+        return;
+      }
 
       if (edit.editType === 'image-alt') {
         target.setAttribute('alt', edit.to || '');
@@ -1059,6 +1089,7 @@ export function createAnnotationStore({ annotationState, annotationUI }) {
   return {
     applyEasyEditsToDom,
     applyEasyEditsToHtmlString,
+    setPreviewUrlResolver,
     buildElementPath,
     buildCommentElementPath,
     buildEditElementAnchor,

--- a/streamlibs/previewer.js
+++ b/streamlibs/previewer.js
@@ -410,12 +410,6 @@ export async function saveChanges() {
     hideDOMElements([document.querySelector('main')]);
     if (isAnnotationOperation) {
       await saveAnnotationChanges((stage) => {
-        if (stage === 'htmlSaved') {
-          updateLoader({
-            message: LOADER_STEP_MESSAGES.SAVE_HTML_DONE,
-            percentage: LOADER_PROGRESS_STEPS.SAVE_HTML_DONE,
-          });
-        }
         if (stage === 'editsSaved') {
           updateLoader({
             message: LOADER_STEP_MESSAGES.SAVE_METADATA_DONE,


### PR DESCRIPTION
- Introduces an auto apply option on comment threads, allowing suggested text or image changes to be applied directly from the comment panel without manual inline editing.
- Adds text regeneration and asset (image) regeneration through the auto apply flow, letting reviewers trigger content regeneration and immediately reapply results as a new comment suggestion.
- Adds an edit type filter to the comments panel so users can filter between text edits and image edits.
- Restricts image update actions to permitted image types only — SVG assets are now excluded from the update flow.
- Fixes multiple comment threading bugs: users can now add multiple comments on a section and reply to existing comments (previously only a single comment was allowed per section).
- Fixes comment marker focus behavior so clicking a thread marker correctly focuses the right thread.
- Cleans up comment controls UX - layout, spacing, and button states polished across the panel.
- Fixes asset display in the annotation and AI SEO annotation panels - simplifies and consolidates panel CSS, removes redundant styles.
- Fixes a display issue for updated images after an asset replacement is applied, ensuring the preview reflects the new image immediately.

<img width="1026" height="654" alt="Screenshot 2026-05-27 at 2 07 20 AM" src="https://github.com/user-attachments/assets/de13a343-c21f-4f68-bc95-d447c34ad1ff" />

