### PR TITLE
[MWPW-195969] Fix: in SEO flow, rejecting second image replacement reverts to default image

### DIFF
--- a/streamlibs/operations/annotation/assets-panel.js
+++ b/streamlibs/operations/annotation/assets-panel.js
@@ -571,6 +571,7 @@ export default function createAssetsPanelController({
           });
           if (applied.targetImg && asset.daUrl) {
             applied.targetImg.dataset.streamOriginalSrc = asset.daUrl;
+            applied.targetImg.dataset.originalSrc = asset.daUrl;
           }
         }
 


### PR DESCRIPTION
In uploadLocalAssets, after a successful upload, refresh dataset.originalSrc to the saved asset's daUrl. The next replacement+remove now reverts to the most recently saved asset.