### PR TITLE
Fixing the push to da and save fix in normal collab

### DIFF
--- a/streamlibs/operations/annotation.js
+++ b/streamlibs/operations/annotation.js
@@ -596,10 +596,7 @@ export async function saveAnnotationChanges(reportProgress = () => {}) {
   await uploadAndDecideAssets();
 
   const assetReplacements = buildAssetReplacementsAndEdits((asset) => asset.daUrl);
-  const { easyEdits, daCompatibleHtml } = buildHtmlWithEditsAndAssets(assetReplacements);
-
-  await postData(window.streamConfig.targetUrl, daCompatibleHtml, { suppressErrorPage: true });
-  reportProgress('htmlSaved');
+  const { easyEdits } = buildHtmlWithEditsAndAssets(assetReplacements);
 
   if (annotationService.isAvailable()) {
     const persistedEditSnapshot = await annotationService.saveEdits(easyEdits);

--- a/streamlibs/previewer.js
+++ b/streamlibs/previewer.js
@@ -410,12 +410,6 @@ export async function saveChanges() {
     hideDOMElements([document.querySelector('main')]);
     if (isAnnotationOperation) {
       await saveAnnotationChanges((stage) => {
-        if (stage === 'htmlSaved') {
-          updateLoader({
-            message: LOADER_STEP_MESSAGES.SAVE_HTML_DONE,
-            percentage: LOADER_PROGRESS_STEPS.SAVE_HTML_DONE,
-          });
-        }
         if (stage === 'editsSaved') {
           updateLoader({
             message: LOADER_STEP_MESSAGES.SAVE_METADATA_DONE,


### PR DESCRIPTION
saveAnnotationChanges was calling postData to push HTML to DA using asset.daUrl from the annotation service. We need the persistAnnotationChangesToDA to call batchPromote() first to get the final content.da.live URLs to replace data urls and then push to DA
Both operations in normal and collab seo went through the same saveAnnotationChanges which had the postData call, so both were making push-html calls on save. we only need edit calls on save and no push html  Push html is only required in push to da.