### PR TITLE
MWPW-196582 | Add start collab with edit url on stream client

### DIFF
--- a/streamlibs/operations/aiSeoAnnotation/ai-seo-annotation.css
+++ b/streamlibs/operations/aiSeoAnnotation/ai-seo-annotation.css
@@ -144,6 +144,12 @@
 
 .stream-img-prompt-submit:hover:not(:disabled) { background: #1e40af; }
 
+main div.fragment {
+    position: relative;
+    pointer-events: none;
+    opacity: 0.78;
+}
+
 main div.fragment::before {
     content: 'Fragment edit blocked';
     position: absolute;
@@ -158,4 +164,6 @@ main div.fragment::before {
     font-weight: 600;
     color: #2330da;
     letter-spacing: 0.03em;
+    pointer-events: none;
+    opacity: 0.78;
 }

--- a/streamlibs/operations/aiSeoAnnotation/ai-seo-annotation.css
+++ b/streamlibs/operations/aiSeoAnnotation/ai-seo-annotation.css
@@ -143,3 +143,19 @@
 }
 
 .stream-img-prompt-submit:hover:not(:disabled) { background: #1e40af; }
+
+main div.fragment::before {
+    content: 'Fragment edit blocked';
+    position: absolute;
+    inset: 0;
+    z-index: 10;
+    cursor: default;
+    background: rgba(107, 114, 128, 50%);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 40px;
+    font-weight: 600;
+    color: #2330da;
+    letter-spacing: 0.03em;
+}

--- a/streamlibs/operations/aiSeoAnnotation/ai-seo-annotation.css
+++ b/streamlibs/operations/aiSeoAnnotation/ai-seo-annotation.css
@@ -147,7 +147,10 @@
 main div.fragment {
     position: relative;
     pointer-events: none;
-    opacity: 0.78;
+}
+
+main div.fragment div {
+    filter: blur(2px);
 }
 
 main div.fragment::before {
@@ -162,8 +165,7 @@ main div.fragment::before {
     justify-content: center;
     font-size: 40px;
     font-weight: 600;
-    color: #2330da;
+    color: #bed9ff;
     letter-spacing: 0.03em;
     pointer-events: none;
-    opacity: 0.78;
 }

--- a/streamlibs/operations/aiSeoAnnotation/ai-seo-annotation.js
+++ b/streamlibs/operations/aiSeoAnnotation/ai-seo-annotation.js
@@ -34,7 +34,7 @@ function hideRegenBtn() {
 }
 
 function scheduleHideRegenBtn() {
-  regenState.hideTimer = setTimeout(hideRegenBtn, 350);
+  regenState.hideTimer = setTimeout(hideRegenBtn, 5000);
 }
 
 function cancelHideRegenBtn() {
@@ -116,7 +116,7 @@ function showRegenBtn(el) {
     regenState.target = el;
     const r = el.getBoundingClientRect();
     btn.style.top = `${Math.max(0, r.top - 14)}px`;
-    btn.style.left = `${r.right + 4}px`;
+    btn.style.left = `${r.right - 8}px`;
   }
   btn.classList.add('stream-regen-visible');
 }
@@ -152,18 +152,23 @@ const imgRegenState = {
   overlay: null,
   target: null,
   hideTimer: null,
+  onImgLeave: null,
 };
 
 function hideImgRegenBtn() {
   imgRegenState.hideTimer = null;
   if (imgRegenState.btn) imgRegenState.btn.classList.remove('stream-img-regen-visible');
   if (!imgRegenState.overlay?.classList.contains('stream-img-prompt-visible')) {
+    if (imgRegenState.target && imgRegenState.onImgLeave) {
+      imgRegenState.target.removeEventListener('mouseleave', imgRegenState.onImgLeave);
+      imgRegenState.onImgLeave = null;
+    }
     imgRegenState.target = null;
   }
 }
 
 function scheduleHideImgRegenBtn() {
-  imgRegenState.hideTimer = setTimeout(hideImgRegenBtn, 200);
+  imgRegenState.hideTimer = setTimeout(hideImgRegenBtn, 5000);
 }
 
 function cancelHideImgRegenBtn() {
@@ -310,11 +315,23 @@ function showImgRegenBtn(img) {
   if (!document.body.classList.contains('annotation-asset-select-mode')) return;
   ensureImgRegenElements();
   cancelHideImgRegenBtn();
-  imgRegenState.target = img;
+  if (imgRegenState.target !== img) {
+    if (imgRegenState.target) {
+      imgRegenState.target.removeEventListener('mouseleave', imgRegenState.onImgLeave);
+    }
+    imgRegenState.target = img;
+    imgRegenState.onImgLeave = (e) => {
+      const to = e.relatedTarget;
+      const { btn } = imgRegenState;
+      if (btn && (to === btn || btn.contains(to))) return;
+      scheduleHideImgRegenBtn();
+    };
+    img.addEventListener('mouseleave', imgRegenState.onImgLeave);
+  }
   const { btn } = imgRegenState;
   const r = img.getBoundingClientRect();
   btn.style.top = `${Math.max(0, r.top - 14)}px`;
-  btn.style.left = `${r.right + 4}px`;
+  btn.style.left = `${r.right - 8}px`;
   btn.classList.add('stream-img-regen-visible');
 }
 
@@ -335,17 +352,26 @@ function attachImageRegenHandlers() {
     showImgRegenBtn(img);
   });
 
-  main.addEventListener('mouseout', (e) => {
-    const to = e.relatedTarget;
-    if (imgRegenState.overlay?.classList.contains('stream-img-prompt-visible')) return;
-    if (imgRegenState.btn && (to === imgRegenState.btn || imgRegenState.btn.contains(to))) return;
-    scheduleHideImgRegenBtn();
-  });
-
   window.addEventListener('scroll', () => {
     hideImgRegenBtn();
     hideImgPromptOverlay();
   }, { passive: true });
+}
+
+function attachModeObserver() {
+  let hadTextMode = document.body.classList.contains('annotation-inline-edit-mode');
+  let hadImgMode = document.body.classList.contains('annotation-asset-select-mode');
+
+  new MutationObserver(() => {
+    const hasTextMode = document.body.classList.contains('annotation-inline-edit-mode');
+    const hasImgMode = document.body.classList.contains('annotation-asset-select-mode');
+
+    if (hadTextMode && !hasTextMode) hideRegenBtn();
+    if (hadImgMode && !hasImgMode) { hideImgRegenBtn(); hideImgPromptOverlay(); }
+
+    hadTextMode = hasTextMode;
+    hadImgMode = hasImgMode;
+  }).observe(document.body, { attributes: true, attributeFilter: ['class'] });
 }
 
 // ---------------------------------------------------------------------------
@@ -355,4 +381,5 @@ function attachImageRegenHandlers() {
 export default function attachRegenHandlers() {
   attachContentRegenHandlers();
   attachImageRegenHandlers();
+  attachModeObserver();
 }

--- a/streamlibs/operations/annotation.js
+++ b/streamlibs/operations/annotation.js
@@ -59,7 +59,7 @@ export async function setupCollabSpace() {
     if (!collabSpaceExists) {
       if (await copyDaPage(window.streamConfig.targetUrl, collabUrl)) {
         window.streamConfig.draftLocation = collabUrl;
-        await new Promise((resolve) => { setTimeout(resolve, 30000); });
+        await new Promise((resolve) => { setTimeout(resolve, 15000); });
       }
     } else {
       window.streamConfig.draftLocation = collabUrl;

--- a/streamlibs/operations/annotation.js
+++ b/streamlibs/operations/annotation.js
@@ -2,10 +2,15 @@
 /* eslint-disable function-paren-newline */
 /* eslint-disable no-restricted-syntax */
 import { fetchFigmaContent } from '../sources/figma.js';
-import { fetchDAContent } from '../sources/da.js';
+import {
+  fetchDAContent,
+  daPageExists,
+  copyDaPage,
+} from '../sources/da.js';
 import { hydrateFragmentLinksInDaBlocks } from './edit/fragment-hydrate.js';
 import { miloLoadArea } from '../utils/utils.js';
 import { getDACompatibleHtml, postData } from '../target/da.js';
+import { fetchImageAsBase64 } from './edit/dom.js';
 import { createAnnotationState, createAnnotationUI } from './annotation/state.js';
 import { createAnnotationStore } from './annotation/store.js';
 import createCommentsPanelController from './annotation/comments-panel.js';
@@ -14,6 +19,7 @@ import createAnnotationServiceClient from './annotation/service.js';
 import createAssetServiceClient from './annotation/asset-service.js';
 import createAssetsPanelController from './annotation/assets-panel.js';
 import requestParentCollabRefresh from './annotation/collab-sync.js';
+import { handleError } from '../utils/error-handler.js';
 
 // ── Module singletons ────────────────────────────────────────────────────────
 
@@ -28,25 +34,6 @@ const assetsPanel = createAssetsPanelController({
   store,
   assetService,
 });
-async function fetchImageAsBase64(url) {
-  const rawToken = window.streamConfig?.streamMapper?.daToken || window.streamConfig?.token || '';
-  const authToken = rawToken && !rawToken.startsWith('Bearer ') ? `Bearer ${rawToken}` : rawToken;
-  try {
-    const res = await fetch(url, authToken ? { headers: { Authorization: authToken } } : {});
-    if (!res.ok) throw new Error(`HTTP ${res.status}`);
-    const blob = await res.blob();
-    return new Promise((resolve) => {
-      const reader = new FileReader();
-      reader.onloadend = () => resolve(reader.result);
-      reader.onerror = () => resolve(null);
-      reader.readAsDataURL(blob);
-    });
-  } catch (err) {
-    console.warn('[annotation] Could not fetch image as base64', err);
-    return null;
-  }
-}
-
 const previewUrlCache = new Map();
 
 async function resolvePreviewUrl(url) {
@@ -55,6 +42,28 @@ async function resolvePreviewUrl(url) {
   const b64 = await fetchImageAsBase64(url);
   if (b64) previewUrlCache.set(url, b64);
   return b64 || url;
+}
+
+export async function setupCollabSpace() {
+  if (
+    !window.streamConfig.draftLocation
+    || (window.streamConfig.draftLocation
+    && window.streamConfig.targetUrl
+    && window.streamConfig.draftLocation === window.streamConfig.targetUrl)
+  ) {
+    const { collabId } = window.streamConfig;
+    if (!collabId) handleError('error', ' with setting up the collab');
+    const targetHierarchy = window.streamConfig.targetUrl.split('/');
+    const collabUrl = `${targetHierarchy[0]}/${targetHierarchy[1]}/drafts/collab/${collabId}/${targetHierarchy[targetHierarchy.length - 1]}`;
+    const collabSpaceExists = await daPageExists(collabUrl);
+    if (!collabSpaceExists) {
+      if (copyDaPage(window.streamConfig.targetUrl, collabUrl)) {
+        window.streamConfig.draftLocation = collabUrl;
+      }
+    } else {
+      window.streamConfig.draftLocation = collabUrl;
+    }
+  }
 }
 
 export async function recordImageRegenAsLocalAsset(imgEl, generatedUrl, pendingAlt = '') {
@@ -124,7 +133,7 @@ async function getDADom() {
   }
   if (source === 'da') {
     const cfg = window.streamConfig;
-    const html = await fetchDAContent(cfg.contentUrl || cfg.draftLocation);
+    const html = await fetchDAContent(cfg.draftLocation || cfg.contentUrl);
     normalizeDAImages(html);
     return html;
   }
@@ -588,6 +597,16 @@ export async function annotationOperationOnHostPage(options = {}) {
     refreshBaselineHtml = false,
     baselineHtml = null,
   } = options;
+
+  await new Promise((resolve) => {
+    const observer = new MutationObserver(() => {
+      if (!document.getElementById('page-load-ok-milo')) return;
+      observer.disconnect();
+      resolve();
+    });
+    observer.observe(document.body, { childList: true });
+  });
+
   const { shouldRestoreInlineMode } = prepareAnnotationSession({ preserveRemoteEditState });
 
   const mainEl = document.querySelector('main');
@@ -597,7 +616,7 @@ export async function annotationOperationOnHostPage(options = {}) {
     if (window.streamConfig?.source === 'da') {
       try {
         const cfg = window.streamConfig;
-        const daMain = await fetchDAContent(cfg.contentUrl || cfg.draftLocation);
+        const daMain = await fetchDAContent(cfg.draftLocation || cfg.contentUrl);
         cachedCleanHtml = daMain?.innerHTML || '';
       } catch (err) {
         console.warn('[annotation] Failed to fetch DA baseline HTML, falling back to live DOM:', err);
@@ -609,6 +628,26 @@ export async function annotationOperationOnHostPage(options = {}) {
   }
 
   await finishAnnotationSession(mainEl, { preserveRemoteEditState, shouldRestoreInlineMode });
+
+  const stripBase64QueryParam = (el) => {
+    const attr = el.tagName === 'SOURCE' ? 'srcset' : 'src';
+    const val = el[attr];
+    if (!val?.includes('base64')) return;
+    const queryIdx = val.indexOf('?');
+    if (queryIdx === -1) return;
+    el[attr] = val.substring(0, queryIdx);
+  };
+
+  const mergedElements = [...document.querySelectorAll('main img, main source')];
+  if (mergedElements.length) {
+    const observer = new MutationObserver((mutations) => {
+      mutations.forEach((m) => stripBase64QueryParam(m.target));
+    });
+    mergedElements.forEach((el) => {
+      stripBase64QueryParam(el);
+      observer.observe(el, { attributes: true, attributeFilter: ['src', 'srcset'] });
+    });
+  }
 }
 
 export async function persistAnnotationChangesToDA() {

--- a/streamlibs/operations/annotation.js
+++ b/streamlibs/operations/annotation.js
@@ -57,8 +57,9 @@ export async function setupCollabSpace() {
     const collabUrl = `${targetHierarchy[0]}/${targetHierarchy[1]}/drafts/collab/${collabId}/${targetHierarchy[targetHierarchy.length - 1]}`;
     const collabSpaceExists = await daPageExists(collabUrl);
     if (!collabSpaceExists) {
-      if (copyDaPage(window.streamConfig.targetUrl, collabUrl)) {
+      if (await copyDaPage(window.streamConfig.targetUrl, collabUrl)) {
         window.streamConfig.draftLocation = collabUrl;
+        await new Promise((resolve) => { setTimeout(resolve, 30000); });
       }
     } else {
       window.streamConfig.draftLocation = collabUrl;

--- a/streamlibs/operations/annotation.js
+++ b/streamlibs/operations/annotation.js
@@ -226,6 +226,23 @@ function resolveBlockInSection(section, blockClass, blockIndex) {
   return divs[blockIndex] ?? null;
 }
 
+function findBlockByGlobalIndex(main, blockClass, blockGlobalIndex) {
+  if (!blockClass || !(blockGlobalIndex >= 0)) return null;
+  const allSimilarBlocks = Array.from(main.children).flatMap((section) => (
+    Array.from(section.children).filter(
+      (child) => child instanceof HTMLElement
+        && Array.from(child.classList || []).find(Boolean) === blockClass,
+    )
+  ));
+  return allSimilarBlocks[blockGlobalIndex] || null;
+}
+
+function findImgInBlock(block) {
+  const pic = block.querySelector('picture');
+  if (pic && pic.querySelector('img')) return pic;
+  return block.querySelector('img');
+}
+
 function findAssetElement(doc, elementPath, elementProps, originalSrc) {
   const main = doc.querySelector('main');
   if (!main) return null;
@@ -243,6 +260,16 @@ function findAssetElement(doc, elementPath, elementProps, originalSrc) {
     ? elementProps.sectionIndex : -1;
   const blockClass = typeof elementProps?.blockClass === 'string' ? elementProps.blockClass : '';
   const blockIndex = typeof elementProps?.blockIndex === 'number' ? elementProps.blockIndex : 0;
+  const blockGlobalIndex = typeof elementProps?.blockGlobalIndex === 'number'
+    ? elementProps.blockGlobalIndex : -1;
+
+  if (blockClass && blockGlobalIndex >= 0) {
+    const block = findBlockByGlobalIndex(main, blockClass, blockGlobalIndex);
+    if (block) {
+      const el = findImgInBlock(block);
+      if (el) return el;
+    }
+  }
 
   if (elementProps && sectionIndex >= 0) {
     const sections = Array.from(main.children).filter((el) => el.tagName === 'DIV');
@@ -304,6 +331,10 @@ function buildHtmlWithEditsAndAssets(assetReplacements) {
   container.innerHTML = `<main>${html}</main>`;
 
   for (const asset of assetReplacements) {
+    // Assets with block+globalIndex were already applied viewport-aware in the string phase
+    const assetBc = asset.elementProps?.blockClass;
+    const assetBgi = asset.elementProps?.blockGlobalIndex;
+    if (assetBc && assetBgi != null) continue; // eslint-disable-line no-continue
     const element = findAssetElement(
       container, asset.elementPath, asset.elementProps, asset.originalSrc,
     );
@@ -347,10 +378,22 @@ function buildHtmlWithEditsAndAssets(assetReplacements) {
   // reliable original src, so they overwrite the assetReplacements pass above.
   const imageSrcEdits = (annotationState.store.easyEdits || [])
     .filter((e) => e?.editType === 'image-src' && e.to);
-  for (const edit of imageSrcEdits) {
-    const element = findAssetElement(container, edit.elementPath, edit.elementProps, edit.from);
-    if (element) replaceAssetUrl(element, edit.to);
-  }
+  // Edits with blockClass+blockGlobalIndex were already applied viewport-aware in the string phase
+  imageSrcEdits
+    .filter((edit) => {
+      const bc = edit.blockClass || edit.elementProps?.blockClass;
+      const bgi = edit.blockGlobalIndex ?? edit.elementProps?.blockGlobalIndex;
+      return !(bc && bgi != null);
+    })
+    .forEach((edit) => {
+      const mergedProps = {
+        ...edit.elementProps,
+        ...(edit.blockClass ? { blockClass: edit.blockClass } : {}),
+        ...(edit.blockGlobalIndex != null ? { blockGlobalIndex: edit.blockGlobalIndex } : {}),
+      };
+      const element = findAssetElement(container, edit.elementPath, mergedProps, edit.from);
+      if (element) replaceAssetUrl(element, edit.to);
+    });
 
   for (const regen of regenReplacements) {
     const regenFilename = extractFilename(regen.originalSrc);

--- a/streamlibs/operations/annotation/asset-service.js
+++ b/streamlibs/operations/annotation/asset-service.js
@@ -1,11 +1,5 @@
 import { hideGlobalSyncIndicator, showGlobalSyncIndicator } from '../../utils/snackbar.js';
-import { normalizeToken } from './service.js';
-
-export function getAnnotationCollabId() {
-  const cfg = window.streamConfig || {};
-  const collabId = cfg.collabId ?? cfg.collab_id;
-  return `${collabId || ''}`.trim();
-}
+import { getAnnotationCollabId, normalizeToken } from './service.js';
 
 export default function createAssetServiceClient() {
   async function assetServiceFetch(path, options = {}) {

--- a/streamlibs/operations/annotation/asset-service.js
+++ b/streamlibs/operations/annotation/asset-service.js
@@ -1,12 +1,7 @@
 import { hideGlobalSyncIndicator, showGlobalSyncIndicator } from '../../utils/snackbar.js';
+import { normalizeToken } from './service.js';
 
-function normalizeToken(token) {
-  const value = `${token || ''}`.trim();
-  if (!value) return '';
-  return value.startsWith('Bearer ') ? value : `Bearer ${value}`;
-}
-
-function getAnnotationCollabId() {
+export function getAnnotationCollabId() {
   const cfg = window.streamConfig || {};
   const collabId = cfg.collabId ?? cfg.collab_id;
   return `${collabId || ''}`.trim();

--- a/streamlibs/operations/annotation/comments-panel.js
+++ b/streamlibs/operations/annotation/comments-panel.js
@@ -1252,16 +1252,21 @@ export default function createCommentsPanelController({
 
         if (isCommentThread && window.streamConfig?.operation === 'aiSeoAnnotation') {
           const normalizedStatus = store.normalizeCommentStatus(thread.status);
-          const isAutoApplyEnabled = (normalizedStatus === 'Resolved' || normalizedStatus === 'Accepted')
+          const isOwner = isCurrentUserCollabOwner();
+          const isAutoApplyEnabled = isOwner
+            && (normalizedStatus === 'Resolved' || normalizedStatus === 'Accepted')
             && !pendingAutoApplyThreadIds.has(thread.id);
           const autoApplyBtn = document.createElement('button');
           autoApplyBtn.type = 'button';
           autoApplyBtn.className = 'annotation-card-auto-apply-btn';
           autoApplyBtn.disabled = !isAutoApplyEnabled;
           autoApplyBtn.setAttribute('aria-label', 'Auto apply comment');
-          autoApplyBtn.title = isAutoApplyEnabled
-            ? 'Auto apply comment'
-            : 'Resolve the comment to enable auto apply';
+          // eslint-disable-next-line no-nested-ternary
+          autoApplyBtn.title = !isOwner
+            ? 'Only the owner can auto apply comments'
+            : isAutoApplyEnabled
+              ? 'Auto apply comment'
+              : 'Resolve the comment to enable auto apply';
           autoApplyBtn.innerHTML = `<svg viewBox="0 0 24 24" aria-hidden="true">
             <path d="M12 2l2.09 6.26L20 10l-5.91 1.74L12 18l-2.09-6.26L4 10l5.91-1.74Z"/>
             <path d="M19 15l1.09 2.91L23 19l-2.91 1.09L19 23l-1.09-2.91L15 19l2.91-1.09Z"/>

--- a/streamlibs/operations/annotation/service.js
+++ b/streamlibs/operations/annotation/service.js
@@ -112,6 +112,7 @@ function normalizeEditRecord(edit) {
     changedTo: `${edit?.changedTo || ''}`,
     updatedAt: edit?.updatedAt || null,
     authorUsername: edit?.authorUsername || edit?.authorName || '',
+    viewport: edit?.viewport || '',
   };
 }
 

--- a/streamlibs/operations/annotation/service.js
+++ b/streamlibs/operations/annotation/service.js
@@ -1,6 +1,7 @@
 import { ANNOTATION_DEFAULT_USERNAME } from '../../utils/constants.js';
 import { hideGlobalSyncIndicator, showGlobalSyncIndicator } from '../../utils/snackbar.js';
 import { normalizeCommentStatus } from './store.js';
+import { getAnnotationCollabId } from './asset-service.js';
 
 const SERVICE_STATUS_BY_COMMENT_STATUS = {
   Open: 'open',
@@ -15,7 +16,7 @@ const COMMENT_STATUS_BY_SERVICE_STATUS = {
   closed: 'Closed',
 };
 
-function normalizeToken(token) {
+export function normalizeToken(token) {
   const value = `${token || ''}`.trim();
   if (!value) return '';
   return value.startsWith('Bearer ') ? value : `Bearer ${value}`;
@@ -37,12 +38,6 @@ function normalizeAnchorElementPath(elementPath) {
   return {
     selector: `${elementPath || ''}`,
   };
-}
-
-function getAnnotationCollabId() {
-  const cfg = window.streamConfig || {};
-  const collabId = cfg.collabId ?? cfg.collab_id;
-  return `${collabId || ''}`.trim();
 }
 
 function sortComments(comments = []) {

--- a/streamlibs/operations/annotation/service.js
+++ b/streamlibs/operations/annotation/service.js
@@ -1,7 +1,6 @@
 import { ANNOTATION_DEFAULT_USERNAME } from '../../utils/constants.js';
 import { hideGlobalSyncIndicator, showGlobalSyncIndicator } from '../../utils/snackbar.js';
 import { normalizeCommentStatus } from './store.js';
-import { getAnnotationCollabId } from './asset-service.js';
 
 const SERVICE_STATUS_BY_COMMENT_STATUS = {
   Open: 'open',
@@ -20,6 +19,12 @@ export function normalizeToken(token) {
   const value = `${token || ''}`.trim();
   if (!value) return '';
   return value.startsWith('Bearer ') ? value : `Bearer ${value}`;
+}
+
+export function getAnnotationCollabId() {
+  const cfg = window.streamConfig || {};
+  const collabId = cfg.collabId ?? cfg.collab_id;
+  return `${collabId || ''}`.trim();
 }
 
 function normalizeAnchorElementPath(elementPath) {

--- a/streamlibs/operations/annotation/store.js
+++ b/streamlibs/operations/annotation/store.js
@@ -1214,6 +1214,9 @@ export function createAnnotationStore({ annotationState, annotationUI }) {
         from: existing.from,
         fromHtml: existing.fromHtml,
         changeHistory: history,
+        // Preserve the viewport from when the edit was first created; don't let a
+        // sync/update re-evaluate window.innerWidth at push time.
+        viewport: editRecord.viewport || existing.viewport || normalizedEditRecord.viewport,
       };
       const didPruneNestedEdits = pruneNestedTextEasyEdits();
       if (!didPruneNestedEdits) rebuildEditThreadsFromEasyEdits();

--- a/streamlibs/operations/annotation/store.js
+++ b/streamlibs/operations/annotation/store.js
@@ -435,14 +435,6 @@ export function createAnnotationStore({ annotationState, annotationUI }) {
     const origWrapper = document.createElement('div');
     origWrapper.innerHTML = `<main>${html || ''}</main>`;
     const origMainEl = origWrapper.querySelector('main');
-
-    // eslint-disable-next-line no-console
-    console.log('[applyEasyEdits] total edits:', easyEdits.length, easyEdits.map((e) => ({
-      type: e?.editType,
-      viewport: e?.viewport,
-      blockClass: e?.blockClass,
-      blockGlobalIndex: e?.blockGlobalIndex,
-    })));
     easyEdits.forEach((edit) => {
       if (!edit || typeof edit !== 'object') return;
 
@@ -456,19 +448,11 @@ export function createAnnotationStore({ annotationState, annotationUI }) {
           ?? edit.elementProps?.blockGlobalIndex
           ?? -1;
 
-        // eslint-disable-next-line no-console
-        console.log('[applyEasyEdits] image-src', {
-          fromSrc, toSrc, imgBlockClass, imgBlockGlobalIndex, viewport: edit.viewport,
-        });
-
         if (imgBlockClass && imgBlockGlobalIndex >= 0) {
           const wrapper = document.createElement('div');
           wrapper.innerHTML = `<main>${updatedHtml}</main>`;
           const mainEl = wrapper.querySelector('main');
           const targetBlock = findBlockInDaHtml(mainEl, imgBlockClass, imgBlockGlobalIndex);
-          // eslint-disable-next-line no-console
-          console.log('[applyEasyEdits] image-src block found:', !!targetBlock);
-
           if (targetBlock) {
             const currentBlockHtml = targetBlock.outerHTML;
 
@@ -488,20 +472,12 @@ export function createAnnotationStore({ annotationState, annotationUI }) {
             if (storedIdx !== null && storedIdx >= 0 && storedIdx < origCandidates.length) {
               origTarget = origCandidates[storedIdx];
               // eslint-disable-next-line no-console
-              console.log('[applyEasyEdits] image-src stored picIndexInBlock:', storedIdx);
             } else {
               const picIdx = getViewportOccurrenceIndex(
                 origCandidates.length || 1,
                 edit.viewport,
               );
               origTarget = origCandidates[picIdx] || null;
-              // eslint-disable-next-line no-console
-              console.log(
-                '[applyEasyEdits] image-src fallback orig count:',
-                origCandidates.length,
-                'picIdx:',
-                picIdx,
-              );
             }
 
             // Map original target → absolute index → picture in current (modified) block
@@ -524,8 +500,6 @@ export function createAnnotationStore({ annotationState, annotationUI }) {
               const newBlk = replaceNthOccurrence(blk, curEl, newEl, nth);
               if (newBlk !== blk) {
                 updatedHtml = replaceFirstOccurrence(updatedHtml, blk, newBlk);
-                // eslint-disable-next-line no-console
-                console.log('[applyEasyEdits] image-src replaced absIdx:', absIdx, 'nth:', nth);
               }
             }
           }
@@ -549,18 +523,11 @@ export function createAnnotationStore({ annotationState, annotationUI }) {
           ?? edit.elementProps?.blockGlobalIndex
           ?? -1;
 
-        // eslint-disable-next-line no-console
-        console.log('[applyEasyEdits] image-alt', {
-          fromAlt, toAlt, altBlockClass, altBlockGlobalIndex,
-        });
-
         if (altBlockClass && altBlockGlobalIndex >= 0) {
           const wrapper = document.createElement('div');
           wrapper.innerHTML = `<main>${updatedHtml}</main>`;
           const mainEl = wrapper.querySelector('main');
           const targetBlock = findBlockInDaHtml(mainEl, altBlockClass, altBlockGlobalIndex);
-          // eslint-disable-next-line no-console
-          console.log('[applyEasyEdits] image-alt block found:', !!targetBlock);
           if (targetBlock) {
             const originalBlockHtml = targetBlock.outerHTML;
             const dqAttr = `alt="${fromAlt}"`;
@@ -573,12 +540,8 @@ export function createAnnotationStore({ annotationState, annotationUI }) {
               const altIdx = getViewportOccurrenceIndex(altCount, edit.viewport);
               const toAttr = attrStr.startsWith('alt="') ? `alt="${toAlt}"` : `alt='${toAlt}'`;
               const newBlockHtml = replaceNthOccurrence(originalBlockHtml, attrStr, toAttr, altIdx);
-              // eslint-disable-next-line no-console
-              console.log('[applyEasyEdits] image-alt count:', altCount, 'idx:', altIdx);
               if (newBlockHtml !== originalBlockHtml) {
                 updatedHtml = replaceFirstOccurrence(updatedHtml, originalBlockHtml, newBlockHtml);
-                // eslint-disable-next-line no-console
-                console.log('[applyEasyEdits] image-alt replaced');
               }
             }
           }
@@ -603,23 +566,11 @@ export function createAnnotationStore({ annotationState, annotationUI }) {
         ?? edit.elementProps?.blockGlobalIndex
         ?? -1;
 
-      // eslint-disable-next-line no-console
-      console.log('[applyEasyEdits] text/html edit', {
-        editType: edit.editType,
-        fromText,
-        toText,
-        fromHtml: fromHtml.slice(0, 80),
-        blockClass,
-        blockGlobalIndex,
-      });
-
       if (blockClass && blockGlobalIndex >= 0) {
         const wrapper = document.createElement('div');
         wrapper.innerHTML = `<main>${updatedHtml}</main>`;
         const mainEl = wrapper.querySelector('main');
         const targetBlock = findBlockInDaHtml(mainEl, blockClass, blockGlobalIndex);
-        // eslint-disable-next-line no-console
-        console.log('[applyEasyEdits] block found:', !!targetBlock, 'fromHtml match:', !!targetBlock && fromHtml ? targetBlock.outerHTML.includes(fromHtml) : false, 'fromText match:', !!targetBlock && fromText ? targetBlock.outerHTML.includes(fromText) : false);
 
         if (targetBlock) {
           const originalBlockHtml = targetBlock.outerHTML;
@@ -629,8 +580,6 @@ export function createAnnotationStore({ annotationState, annotationUI }) {
             const repl = toHtml || fromHtml;
             const newBlockHtml = replaceNthOccurrence(originalBlockHtml, fromHtml, repl, htmlIdx);
             updatedHtml = replaceFirstOccurrence(updatedHtml, originalBlockHtml, newBlockHtml);
-            // eslint-disable-next-line no-console
-            console.log('[applyEasyEdits] replaced via fromHtml in block, count:', htmlCount, 'idx:', htmlIdx);
             return;
           }
           if (fromText && originalBlockHtml.includes(fromText)) {
@@ -638,21 +587,15 @@ export function createAnnotationStore({ annotationState, annotationUI }) {
             const textIdx = getViewportOccurrenceIndex(textCount, edit.viewport);
             const newBlockHtml = replaceNthOccurrence(originalBlockHtml, fromText, toText, textIdx);
             updatedHtml = replaceFirstOccurrence(updatedHtml, originalBlockHtml, newBlockHtml);
-            // eslint-disable-next-line no-console
-            console.log('[applyEasyEdits] replaced via fromText in block, count:', textCount, 'idx:', textIdx);
             return;
           }
         }
-        // eslint-disable-next-line no-console
-        console.log('[applyEasyEdits] block scoped — content not found, skipping');
         return;
       }
 
       // No positional info: fallback string matching
       if (fromHtml) {
         const replaced = replaceFirstOccurrence(updatedHtml, fromHtml, toHtml || fromHtml);
-        // eslint-disable-next-line no-console
-        console.log('[applyEasyEdits] fallback fromHtml match:', replaced !== updatedHtml);
         if (replaced !== updatedHtml) { updatedHtml = replaced; return; }
         // fromHtml didn't match cachedCleanHtml, fall through to fromText
       }

--- a/streamlibs/operations/annotation/store.js
+++ b/streamlibs/operations/annotation/store.js
@@ -158,12 +158,37 @@ export function createAnnotationStore({ annotationState, annotationUI }) {
       return {};
     })();
 
+    const blockClass = `${edit.blockClass
+      || normalizedElementProps.blockClass
+      || parsedElementPath?.blockClass
+      || ''}`;
+    const blockGlobalIndex = edit.blockGlobalIndex
+      ?? normalizedElementProps.blockGlobalIndex
+      ?? parsedElementPath?.blockGlobalIndex
+      ?? null;
+
+    const picIndexInBlock = edit.picIndexInBlock
+      ?? normalizedElementProps.picIndexInBlock
+      ?? parsedElementPath?.picIndexInBlock
+      ?? null;
+
+    const viewport = edit.viewport || (() => {
+      const w = window.innerWidth;
+      if (w < 600) return 'mobile';
+      if (w >= 1200) return 'desktop';
+      return 'tablet';
+    })();
+
     return {
       id: edit.id || generateId('easy-edit'),
       editType: edit.editType || 'text',
       attrName: edit.attrName || '',
       elementPath: `${edit.elementPath || parsedElementPath?.selector || ''}`,
       elementProps: normalizedElementProps,
+      blockClass,
+      blockGlobalIndex,
+      picIndexInBlock,
+      viewport,
       elementRef: edit.elementRef || '',
       from: `${edit.from || ''}`,
       to: `${edit.to || ''}`,
@@ -349,17 +374,167 @@ export function createAnnotationStore({ annotationState, annotationUI }) {
     return `${haystack.slice(0, index)}${toValue || ''}${haystack.slice(index + needle.length)}`;
   }
 
+  function countOccurrences(haystack, needle) {
+    const ndl = `${needle || ''}`;
+    if (!ndl) return 0;
+    let count = 0;
+    let idx = haystack.indexOf(ndl);
+    while (idx !== -1) {
+      count += 1;
+      idx = haystack.indexOf(ndl, idx + ndl.length);
+    }
+    return count;
+  }
+
+  function replaceNthOccurrence(source, needle, replacement, n) {
+    const haystack = `${source || ''}`;
+    const ndl = `${needle || ''}`;
+    if (!ndl) return haystack;
+    let count = 0;
+    let idx = haystack.indexOf(ndl);
+    while (idx !== -1) {
+      if (count === n) {
+        return `${haystack.slice(0, idx)}${replacement || ''}${haystack.slice(idx + ndl.length)}`;
+      }
+      count += 1;
+      idx = haystack.indexOf(ndl, idx + ndl.length);
+    }
+    return haystack;
+  }
+
+  function getViewportOccurrenceIndex(occurrenceCount, viewport) {
+    if (occurrenceCount <= 1) return 0;
+    if (viewport === 'mobile') return 0;
+    if (viewport === 'desktop') return occurrenceCount - 1;
+    if (occurrenceCount === 3) return 1;
+    if (occurrenceCount === 2) return 0;
+    return occurrenceCount - 1;
+  }
+
   function escapeRegExp(value) {
     return `${value || ''}`.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   }
 
+  function findBlockInDaHtml(mainEl, blockClass, blockGlobalIndex) {
+    if (!blockClass || !(blockGlobalIndex >= 0)) return null;
+    const allSimilarBlocks = Array.from(mainEl.children).flatMap((section) => (
+      Array.from(section.children).filter(
+        (child) => child instanceof HTMLElement
+          && Array.from(child.classList || []).find(Boolean) === blockClass,
+      )
+    ));
+    return allSimilarBlocks[blockGlobalIndex] || null;
+  }
+
   function applyEasyEditsToHtmlString(html, easyEdits = []) {
     let updatedHtml = `${html || ''}`;
+
+    // Parse the ORIGINAL html once so that candidate counts stay stable across edits.
+    // Sequential edits shrink same-src lists in updatedHtml; reading from the original
+    // parse keeps getViewportOccurrenceIndex and picIndexInBlock mapping correct.
+    const origWrapper = document.createElement('div');
+    origWrapper.innerHTML = `<main>${html || ''}</main>`;
+    const origMainEl = origWrapper.querySelector('main');
+
+    // eslint-disable-next-line no-console
+    console.log('[applyEasyEdits] total edits:', easyEdits.length, easyEdits.map((e) => ({
+      type: e?.editType,
+      viewport: e?.viewport,
+      blockClass: e?.blockClass,
+      blockGlobalIndex: e?.blockGlobalIndex,
+    })));
     easyEdits.forEach((edit) => {
       if (!edit || typeof edit !== 'object') return;
 
-      // image-src replacements are applied in the DOM phase of buildHtmlWithEditsAndAssets
-      if (edit.editType === 'image-src') return;
+      if (edit.editType === 'image-src') {
+        const fromSrc = `${edit.from || ''}`;
+        const toSrc = `${edit.to || ''}`;
+        if (!fromSrc || !toSrc) return;
+
+        const imgBlockClass = edit.blockClass || edit.elementProps?.blockClass || '';
+        const imgBlockGlobalIndex = edit.blockGlobalIndex
+          ?? edit.elementProps?.blockGlobalIndex
+          ?? -1;
+
+        // eslint-disable-next-line no-console
+        console.log('[applyEasyEdits] image-src', {
+          fromSrc, toSrc, imgBlockClass, imgBlockGlobalIndex, viewport: edit.viewport,
+        });
+
+        if (imgBlockClass && imgBlockGlobalIndex >= 0) {
+          const wrapper = document.createElement('div');
+          wrapper.innerHTML = `<main>${updatedHtml}</main>`;
+          const mainEl = wrapper.querySelector('main');
+          const targetBlock = findBlockInDaHtml(mainEl, imgBlockClass, imgBlockGlobalIndex);
+          // eslint-disable-next-line no-console
+          console.log('[applyEasyEdits] image-src block found:', !!targetBlock);
+
+          if (targetBlock) {
+            const currentBlockHtml = targetBlock.outerHTML;
+
+            // Use original block to resolve absolute picture position.
+            // This keeps the index stable even after prior edits changed picture srcs.
+            const origBlock = findBlockInDaHtml(origMainEl, imgBlockClass, imgBlockGlobalIndex);
+            const origAllPics = origBlock
+              ? Array.from(origBlock.querySelectorAll('picture'))
+              : [];
+            const origCandidates = origAllPics.filter(
+              (pic) => pic.innerHTML.includes(fromSrc),
+            );
+
+            const storedIdx = edit.picIndexInBlock ?? edit.elementProps?.picIndexInBlock ?? null;
+            let origTarget = null;
+
+            if (storedIdx !== null && storedIdx >= 0 && storedIdx < origCandidates.length) {
+              origTarget = origCandidates[storedIdx];
+              // eslint-disable-next-line no-console
+              console.log('[applyEasyEdits] image-src stored picIndexInBlock:', storedIdx);
+            } else {
+              const picIdx = getViewportOccurrenceIndex(
+                origCandidates.length || 1,
+                edit.viewport,
+              );
+              origTarget = origCandidates[picIdx] || null;
+              // eslint-disable-next-line no-console
+              console.log(
+                '[applyEasyEdits] image-src fallback orig count:',
+                origCandidates.length,
+                'picIdx:',
+                picIdx,
+              );
+            }
+
+            // Map original target → absolute index → picture in current (modified) block
+            const absIdx = origTarget ? origAllPics.indexOf(origTarget) : -1;
+            const allCurrentPics = Array.from(targetBlock.querySelectorAll('picture'));
+            const targetEl = absIdx >= 0 && absIdx < allCurrentPics.length
+              ? allCurrentPics[absIdx]
+              : null;
+
+            if (targetEl) {
+              const curEl = targetEl.outerHTML;
+              const newEl = curEl.split(fromSrc).join(toSrc);
+              // Count identical pictures before targetEl so we replace the correct
+              // nth occurrence when multiple pictures share the same outerHTML.
+              const nth = allCurrentPics
+                .slice(0, absIdx)
+                .filter((pic) => pic.outerHTML === curEl)
+                .length;
+              const blk = currentBlockHtml;
+              const newBlk = replaceNthOccurrence(blk, curEl, newEl, nth);
+              if (newBlk !== blk) {
+                updatedHtml = replaceFirstOccurrence(updatedHtml, blk, newBlk);
+                // eslint-disable-next-line no-console
+                console.log('[applyEasyEdits] image-src replaced absIdx:', absIdx, 'nth:', nth);
+              }
+            }
+          }
+          return;
+        }
+
+        updatedHtml = replaceFirstOccurrence(updatedHtml, fromSrc, toSrc);
+        return;
+      }
 
       if (edit.editType === 'image-alt') {
         const fromAlt = `${edit.from || ''}`;
@@ -368,6 +543,48 @@ export function createAnnotationStore({ annotationState, annotationUI }) {
         const escapedFromAlt = escapeRegExp(fromAlt);
         const doubleQuoteAlt = new RegExp(`alt="${escapedFromAlt}"`);
         const singleQuoteAlt = new RegExp(`alt='${escapedFromAlt}'`);
+
+        const altBlockClass = edit.blockClass || edit.elementProps?.blockClass || '';
+        const altBlockGlobalIndex = edit.blockGlobalIndex
+          ?? edit.elementProps?.blockGlobalIndex
+          ?? -1;
+
+        // eslint-disable-next-line no-console
+        console.log('[applyEasyEdits] image-alt', {
+          fromAlt, toAlt, altBlockClass, altBlockGlobalIndex,
+        });
+
+        if (altBlockClass && altBlockGlobalIndex >= 0) {
+          const wrapper = document.createElement('div');
+          wrapper.innerHTML = `<main>${updatedHtml}</main>`;
+          const mainEl = wrapper.querySelector('main');
+          const targetBlock = findBlockInDaHtml(mainEl, altBlockClass, altBlockGlobalIndex);
+          // eslint-disable-next-line no-console
+          console.log('[applyEasyEdits] image-alt block found:', !!targetBlock);
+          if (targetBlock) {
+            const originalBlockHtml = targetBlock.outerHTML;
+            const dqAttr = `alt="${fromAlt}"`;
+            const sqAttr = `alt='${fromAlt}'`;
+            let attrStr = null;
+            if (originalBlockHtml.includes(dqAttr)) attrStr = dqAttr;
+            else if (originalBlockHtml.includes(sqAttr)) attrStr = sqAttr;
+            if (attrStr) {
+              const altCount = countOccurrences(originalBlockHtml, attrStr);
+              const altIdx = getViewportOccurrenceIndex(altCount, edit.viewport);
+              const toAttr = attrStr.startsWith('alt="') ? `alt="${toAlt}"` : `alt='${toAlt}'`;
+              const newBlockHtml = replaceNthOccurrence(originalBlockHtml, attrStr, toAttr, altIdx);
+              // eslint-disable-next-line no-console
+              console.log('[applyEasyEdits] image-alt count:', altCount, 'idx:', altIdx);
+              if (newBlockHtml !== originalBlockHtml) {
+                updatedHtml = replaceFirstOccurrence(updatedHtml, originalBlockHtml, newBlockHtml);
+                // eslint-disable-next-line no-console
+                console.log('[applyEasyEdits] image-alt replaced');
+              }
+            }
+          }
+          return;
+        }
+
         if (doubleQuoteAlt.test(updatedHtml)) {
           updatedHtml = updatedHtml.replace(doubleQuoteAlt, `alt="${toAlt}"`);
         } else if (singleQuoteAlt.test(updatedHtml)) {
@@ -381,8 +598,61 @@ export function createAnnotationStore({ annotationState, annotationUI }) {
       const fromText = `${edit.from || ''}`;
       const toText = `${edit.to || ''}`;
 
+      const blockClass = edit.blockClass || edit.elementProps?.blockClass || '';
+      const blockGlobalIndex = edit.blockGlobalIndex
+        ?? edit.elementProps?.blockGlobalIndex
+        ?? -1;
+
+      // eslint-disable-next-line no-console
+      console.log('[applyEasyEdits] text/html edit', {
+        editType: edit.editType,
+        fromText,
+        toText,
+        fromHtml: fromHtml.slice(0, 80),
+        blockClass,
+        blockGlobalIndex,
+      });
+
+      if (blockClass && blockGlobalIndex >= 0) {
+        const wrapper = document.createElement('div');
+        wrapper.innerHTML = `<main>${updatedHtml}</main>`;
+        const mainEl = wrapper.querySelector('main');
+        const targetBlock = findBlockInDaHtml(mainEl, blockClass, blockGlobalIndex);
+        // eslint-disable-next-line no-console
+        console.log('[applyEasyEdits] block found:', !!targetBlock, 'fromHtml match:', !!targetBlock && fromHtml ? targetBlock.outerHTML.includes(fromHtml) : false, 'fromText match:', !!targetBlock && fromText ? targetBlock.outerHTML.includes(fromText) : false);
+
+        if (targetBlock) {
+          const originalBlockHtml = targetBlock.outerHTML;
+          if (fromHtml && originalBlockHtml.includes(fromHtml)) {
+            const htmlCount = countOccurrences(originalBlockHtml, fromHtml);
+            const htmlIdx = getViewportOccurrenceIndex(htmlCount, edit.viewport);
+            const repl = toHtml || fromHtml;
+            const newBlockHtml = replaceNthOccurrence(originalBlockHtml, fromHtml, repl, htmlIdx);
+            updatedHtml = replaceFirstOccurrence(updatedHtml, originalBlockHtml, newBlockHtml);
+            // eslint-disable-next-line no-console
+            console.log('[applyEasyEdits] replaced via fromHtml in block, count:', htmlCount, 'idx:', htmlIdx);
+            return;
+          }
+          if (fromText && originalBlockHtml.includes(fromText)) {
+            const textCount = countOccurrences(originalBlockHtml, fromText);
+            const textIdx = getViewportOccurrenceIndex(textCount, edit.viewport);
+            const newBlockHtml = replaceNthOccurrence(originalBlockHtml, fromText, toText, textIdx);
+            updatedHtml = replaceFirstOccurrence(updatedHtml, originalBlockHtml, newBlockHtml);
+            // eslint-disable-next-line no-console
+            console.log('[applyEasyEdits] replaced via fromText in block, count:', textCount, 'idx:', textIdx);
+            return;
+          }
+        }
+        // eslint-disable-next-line no-console
+        console.log('[applyEasyEdits] block scoped — content not found, skipping');
+        return;
+      }
+
+      // No positional info: fallback string matching
       if (fromHtml) {
         const replaced = replaceFirstOccurrence(updatedHtml, fromHtml, toHtml || fromHtml);
+        // eslint-disable-next-line no-console
+        console.log('[applyEasyEdits] fallback fromHtml match:', replaced !== updatedHtml);
         if (replaced !== updatedHtml) { updatedHtml = replaced; return; }
         // fromHtml didn't match cachedCleanHtml, fall through to fromText
       }
@@ -497,6 +767,16 @@ export function createAnnotationStore({ annotationState, annotationUI }) {
     const blockIndex = blockChildren.indexOf(block);
     const blockClass = Array.from(block.classList || []).find(Boolean) || '';
 
+    const allSimilarBlocks = blockClass
+      ? getDirectSectionChildren(root).flatMap(
+        (s) => Array.from(s.children).filter(
+          (child) => child instanceof HTMLElement
+            && Array.from(child.classList || []).find(Boolean) === blockClass,
+        ),
+      )
+      : [];
+    const blockGlobalIndex = allSimilarBlocks.indexOf(block);
+
     return {
       section,
       block,
@@ -505,6 +785,7 @@ export function createAnnotationStore({ annotationState, annotationUI }) {
       blockDaaLh: block.getAttribute('daa-lh') || '',
       blockClass,
       blockIndex: blockIndex > -1 ? blockIndex : null,
+      blockGlobalIndex: blockGlobalIndex > -1 ? blockGlobalIndex : null,
     };
   }
 
@@ -518,6 +799,20 @@ export function createAnnotationStore({ annotationState, annotationUI }) {
       });
     }
 
+    const picEl = element.closest('picture') || (element.tagName === 'IMG' ? element : null);
+    // Index among pictures in the block that share the same persisted source URL.
+    // Using same-src siblings avoids counting extra pictures that the render layer
+    // adds (icons, logos) which do not exist in DA HTML.
+    const imgEl = picEl ? picEl.querySelector('img') : null;
+    const picSrc = imgEl ? getPersistedElementSource(imgEl) : '';
+    const sameSrcPics = picEl && picSrc
+      ? Array.from(context.block.querySelectorAll('picture')).filter((pic) => {
+        const pImg = pic.querySelector('img');
+        return pImg && getPersistedElementSource(pImg) === picSrc;
+      })
+      : [];
+    const picIndexInBlock = sameSrcPics.length > 0 ? sameSrcPics.indexOf(picEl) : -1;
+
     return JSON.stringify({
       selector,
       sectionDaaLh: context.sectionDaaLh,
@@ -525,7 +820,9 @@ export function createAnnotationStore({ annotationState, annotationUI }) {
       blockDaaLh: context.blockDaaLh,
       blockClass: context.blockClass,
       blockIndex: context.blockIndex,
+      blockGlobalIndex: context.blockGlobalIndex,
       pathWithinBlock: buildRelativeElementPath(element, context.block),
+      picIndexInBlock: picIndexInBlock > -1 ? picIndexInBlock : null,
       ...getCommentElementDescriptor(element),
     });
   }

--- a/streamlibs/operations/edit/dom.js
+++ b/streamlibs/operations/edit/dom.js
@@ -145,6 +145,32 @@ export function normalizeDAImages(root) {
   });
 }
 
+const imageBase64Cache = new Map();
+
+export async function fetchImageAsBase64(url, token) {
+  const cleanUrl = url ? url.split('?')[0] : url;
+  if (imageBase64Cache.has(cleanUrl)) return imageBase64Cache.get(cleanUrl);
+  const rawToken = token || window.streamConfig?.streamMapper?.daToken || window.streamConfig?.token || '';
+  const authToken = rawToken && !rawToken.startsWith('Bearer ') ? `Bearer ${rawToken}` : rawToken;
+  try {
+    const res = await fetch(cleanUrl, authToken ? { headers: { Authorization: authToken } } : {});
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const blob = await res.blob();
+    const base64 = await new Promise((resolve) => {
+      const reader = new FileReader();
+      reader.onloadend = () => resolve(reader.result);
+      reader.onerror = () => resolve(null);
+      reader.readAsDataURL(blob);
+    });
+    if (base64) imageBase64Cache.set(cleanUrl, base64);
+    return base64;
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.warn('[stream-mapper] Could not fetch image as base64', err);
+    return null;
+  }
+}
+
 export function getIdxFromId(id) {
   if (!id) return null;
 

--- a/streamlibs/previewer.js
+++ b/streamlibs/previewer.js
@@ -19,6 +19,7 @@ import {
   initializeTokens,
   miloLoadArea,
   getMapperEnv,
+  transformImages,
 } from './utils/utils.js';
 import { handleError } from './utils/error-handler.js';
 import { showGlobalSnackbar } from './utils/snackbar.js';
@@ -36,6 +37,7 @@ import {
   applyRemoteCollabSnapshot,
   preparePendingRemoteEditsRefresh,
   attachRegenHandlers,
+  setupCollabSpace,
 } from './utils/operations.js';
 import {
   ANNOTATION_REFRESH_EVENT,
@@ -52,6 +54,7 @@ import {
   notifyParentPreviewInteractive,
 } from './utils/loader.js';
 import { setupBlockActionModal, syncBlockSelectionChrome } from './utils/block-action-modal.js';
+import { fetchDAContent } from './sources/da.js';
 
 const PUSH_TO_DA_RESULT = 'PUSH_TO_DA_RESULT';
 
@@ -175,13 +178,19 @@ export async function initiatePreviewer(forceOperation = null) {
       break;
     case 'annotation':
       updateLoader();
+      await setupCollabSpace();
       await annotationOperation();
       hideLoader();
       notifyAnnotationReady();
       break;
     case 'aiSeoAnnotation':
+      updateLoader({ percentage: 10, message: 'Loading Page' });
+      await mergeImageUrls();
+      updateLoader({ percentage: 50, message: 'Loading Page' });
+      await setupCollabSpace();
+      updateLoader({ percentage: 80, message: 'Loading Page' });
+      annotationOperationOnHostPage();
       updateLoader({ percentage: 100, message: 'Loading Page' });
-      await annotationOperationOnHostPage();
       attachRegenHandlers();
       hideLoader();
       notifyAnnotationReady();
@@ -309,7 +318,7 @@ async function setupMessageListener() {
       await handleBackToEditor();
       syncBlockSelectionChrome();
     }
-    if (event.data.type === 'RESET') {
+    if (event.data.type === 'RESET' && window.streamConfig?.operation !== 'aiSeoAnnotation') {
       window.location.reload();
     }
     if (event.data.type === 'STREAM_GET_TARGET_HTML') {
@@ -402,12 +411,13 @@ export async function persist(versionLabel = null) {
 
 export async function saveChanges() {
   const isAnnotationOperation = isAnnotationOp();
+  const isHostPageAnnotation = window.streamConfig?.operation === 'aiSeoAnnotation';
   try {
     updateLoader({
       message: LOADER_STEP_MESSAGES.SAVE_PREPARING,
       percentage: LOADER_PROGRESS_STEPS.SAVE_PREPARING,
     });
-    hideDOMElements([document.querySelector('main')]);
+    if (!isHostPageAnnotation) hideDOMElements([document.querySelector('main')]);
     if (isAnnotationOperation) {
       await saveAnnotationChanges((stage) => {
         if (stage === 'editsSaved') {
@@ -417,20 +427,17 @@ export async function saveChanges() {
           });
         }
       });
-      updateLoader({
-        message: LOADER_STEP_MESSAGES.START_PAINTING,
-        percentage: LOADER_PROGRESS_STEPS.START_PAINTING,
-      });
-      if (window.streamConfig.operation === 'aiSeoAnnotation') {
-        await annotationOperationOnHostPage({ preserveRemoteEditState: true });
-        attachRegenHandlers();
-      } else {
+      if (!isHostPageAnnotation) {
+        updateLoader({
+          message: LOADER_STEP_MESSAGES.START_PAINTING,
+          percentage: LOADER_PROGRESS_STEPS.START_PAINTING,
+        });
         await annotationOperation({ preserveRemoteEditState: true });
       }
     } else {
       await persistOnTarget();
     }
-    showDOMElements([document.querySelector('main')]);
+    if (!isHostPageAnnotation) showDOMElements([document.querySelector('main')]);
     if (isAnnotationOperation) {
       await refreshAnnotationFloatingUI();
     }
@@ -440,7 +447,7 @@ export async function saveChanges() {
     }
   } catch (error) {
     hideLoader();
-    showDOMElements([document.querySelector('main')]);
+    if (!isHostPageAnnotation) showDOMElements([document.querySelector('main')]);
     if (isAnnotationOperation) {
       showGlobalSnackbar(ANNOTATION_MESSAGES.saveEditsError);
     } else {
@@ -486,11 +493,32 @@ function loadCssFiles(filePath) {
   document.head.appendChild(link);
 }
 
-(async function selfRender() {
+export async function mergeImageUrls() {
+  const { host, pathname } = window.location;
+  const searchParams = new URLSearchParams(window.location.search);
+  if (searchParams.get('daRenderingApp') !== 'stream' && searchParams.get('darenderingapp') !== 'stream') return;
+  const repo = host.split('--')[1];
+  const daUrl = `adobecom/${repo}${pathname}`;
+  const daHtml = await fetchDAContent(daUrl);
+  const daImg = daHtml.querySelectorAll('main img');
+  const pageImg = [...document.querySelectorAll('main img')].filter((img) => !img.src.toLowerCase().includes('.svg'));
+  daImg.forEach((img, idx) => {
+    if (!pageImg[idx]) return;
+    pageImg[idx].src = img.src;
+    const pic = pageImg[idx].closest('picture');
+    if (pic) {
+      // eslint-disable-next-line no-return-assign
+      pic.querySelectorAll('source').forEach((s) => s.srcset = img.src);
+    }
+  });
+  await transformImages();
+}
+
+export async function selfRender() {
   const searchParams = new URLSearchParams(window.location.search);
   if (searchParams.get('daRenderingApp') !== 'stream' && searchParams.get('darenderingapp') !== 'stream') return;
   if (window.location.host.includes('stream-mapper--adobecom.aem')) return;
   const mapperOrigin = searchParams.get('mapperOrigin') || searchParams.get('mapperorigin');
   loadCssFiles(`${mapperOrigin}/streamlibs/styles/styles.css`);
   await initPreviewer();
-}());
+}

--- a/streamlibs/sources/da.js
+++ b/streamlibs/sources/da.js
@@ -1,4 +1,5 @@
 import { handleError, safeFetch } from '../utils/error-handler.js';
+import { postData } from '../target/da.js';
 
 function restoreImgToPicture(html) {
   const parser = new DOMParser();
@@ -31,6 +32,50 @@ export function getMiloCompatibleHtml(html) {
   return restoreImgToPicture(htmlWithRestoredColonText);
 }
 
+export async function daPageExists(path) {
+  let url = path;
+  if (!url.startsWith('/')) url = `/${url}`;
+  if (!url.endsWith('.html')) url += '.html';
+  const options = {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'text/html',
+      Authorization: `Bearer ${window.streamConfig.token}`,
+    },
+  };
+  try {
+    const response = await fetch(`https://admin.da.live/source${url}`, options);
+    if (response.status !== 200) {
+      return false;
+    }
+    return true;
+  } catch (error) {
+    // pass
+  }
+  return false;
+}
+
+export async function copyDaPage(fromPath, toPath) {
+  let from = fromPath;
+  if (!from.startsWith('/')) from = `/${from}`;
+  if (!from.endsWith('.html')) from += '.html';
+  let html;
+  try {
+    const response = await safeFetch(`https://admin.da.live/source${from}`, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'text/html',
+        Authorization: `Bearer ${window.streamConfig.token}`,
+      },
+    });
+    html = await response.text();
+    await postData(toPath, html, {}, false);
+    return true;
+  } catch (error) {
+    return false;
+  }
+}
+
 async function getDAContent(path = false) {
   let url = window.streamConfig.targetUrl;
   if (path) url = path;
@@ -40,7 +85,7 @@ async function getDAContent(path = false) {
     method: 'GET',
     headers: {
       'Content-Type': 'text/html',
-      Authorization: window.streamConfig.token,
+      Authorization: `Bearer ${window.streamConfig.token}`,
     },
   };
   let response = null;

--- a/streamlibs/target/da.js
+++ b/streamlibs/target/da.js
@@ -56,9 +56,10 @@ function wrapHTMLForDA(html) {
   return `<body><header></header><main>${html}</main><footer></footer>`;
 }
 
-export async function postData(url, html, options = {}) {
+export async function postData(url, html, options = {}, wrapHtml=true) {
   const { streamMapper } = window.streamConfig;
-  const wrappedHtml = wrapHTMLForDA(html);
+  let wrappedHtml = html;
+  if (wrapHtml) wrappedHtml = wrapHTMLForDA(html);
   const { suppressErrorPage = false, versionLabel } = options;
   const { pageUrl } = window.streamConfig || {};
   const payloadUrl = url || pageUrl;

--- a/streamlibs/utils/operations.js
+++ b/streamlibs/utils/operations.js
@@ -16,6 +16,7 @@ export {
   persistAnnotationChangesToDA,
   saveAnnotationChanges,
   annotationOperationOnHostPage,
+  setupCollabSpace,
 } from '../operations/annotation.js';
 export {
   default as attachRegenHandlers,

--- a/streamlibs/utils/utils.js
+++ b/streamlibs/utils/utils.js
@@ -1,4 +1,5 @@
 import { BROKEN_PLACEHOLDER_HTML } from './constants.js';
+import { fetchImageAsBase64 } from '../operations/edit/dom.js';
 
 export const [setLibs, getLibs] = (() => {
   let libs;
@@ -139,20 +140,6 @@ export function ackCodeGeneration() {
   return ackCode;
 }
 
-async function fetchImageAsBase64(url, token) {
-  const res = await fetch(url, {
-    headers: { Authorization: token.startsWith('Bearer ') ? token : `Bearer ${token}` },
-  });
-  if (!res.ok) throw new Error(`Failed to fetch image: ${res.status}`);
-  const blob = await res.blob();
-  return new Promise((resolve, reject) => {
-    const reader = new FileReader();
-    reader.onloadend = () => resolve(reader.result);
-    reader.onerror = reject;
-    reader.readAsDataURL(blob);
-  });
-}
-
 function persistOriginalImageUrl(img, url) {
   if (!url) return;
   img.setAttribute('data-stream-original-src', url);
@@ -172,14 +159,15 @@ export async function transformImages() {
     Array.from(imgs).map(async (img) => {
       const url = img.getAttribute('src');
       if (!url) return;
+      const cleanUrl = url.split('?')[0];
       try {
         const dataUrl = await fetchImageAsBase64(url, window.streamConfig.streamMapper.daToken);
-        persistOriginalImageUrl(img, url);
-        img.src = dataUrl;
+        persistOriginalImageUrl(img, cleanUrl);
+        img.src = dataUrl || cleanUrl;
         const picture = img.closest('picture');
         if (picture) {
           picture.querySelectorAll('source').forEach((source) => {
-            source.srcset = dataUrl;
+            source.srcset = dataUrl || cleanUrl;
           });
         }
       } catch (err) {


### PR DESCRIPTION
- Viewport-aware asset editing: Inline image/alt edits now record the viewport (mobile/tablet/desktop) and a blockGlobalIndex + picIndexInBlock at capture time. When the collab draft is saved, edits are applied to the correct picture element within the correct block instance, even when the same block appears multiple times or the same image source is reused across breakpoints.
- Regen button flickering fix: Increased hide timers from 200–350 ms to 5 s for both text and image regen buttons. Added per-image mouseleave listeners and a MutationObserver so buttons hide cleanly when annotation modes change, eliminating the flickering caused by rapid mouse movement.
- Owner-only auto-apply: The annotation-card-auto-apply-btn is now disabled for non-owner collaborators, with a descriptive tooltip explaining the restriction.
- Collab space setup reliability: copyDaPage is now awaited and a 15 s wait is added after the copy to ensure the DA page is available before the draft workflow continues.

Test URL - https://da.live/app/adobecom/da-cc-sandbox/tools/stream/figma?ref=mathuria