### PR TITLE
[MWPW-196468] Inline text edit changelist: change history, discard, revert-on-reload, and card redesign

### DIFF
--- a/streamlibs/operations/annotation.js
+++ b/streamlibs/operations/annotation.js
@@ -762,14 +762,15 @@ export function recordTextRegenAsEdit(element, fromText, toText, fromHtml = '') 
 
   const elementRef = store.ensureElementRef(element);
   const snapshot = annotationUI.inlineElementSnapshot.get(elementRef);
-  const baselineText = snapshot?.originalText || fromText;
-  const baselineHtml = snapshot?.originalHtml || fromHtml;
 
   const editAnchor = store.buildEditElementAnchor(element, annotationUI.mainEl);
-  const segments = store.getChangedSegments(baselineText, toText);
   const existing = store.getEasyEditByElement(
     elementRef, editAnchor.elementPath, editAnchor.elementProps,
   );
+  const stampedOriginal = store.getEasyEditOriginalForElement(element);
+  const baselineText = existing?.from ?? stampedOriginal?.from ?? snapshot?.originalText ?? fromText;
+  const baselineHtml = existing?.fromHtml ?? stampedOriginal?.fromHtml ?? snapshot?.originalHtml ?? fromHtml;
+  const segments = store.getChangedSegments(baselineText, toText);
 
   const persistedEdit = store.upsertEasyEdit({
     id: existing?.id || store.generateId('easy-edit'),

--- a/streamlibs/operations/annotation.js
+++ b/streamlibs/operations/annotation.js
@@ -733,13 +733,13 @@ export async function saveAnnotationChanges(reportProgress = () => {}) {
   await inlineEditing.syncInlineEditsBeforePersist();
   await uploadAndDecideAssets();
 
-  const assetReplacements = buildAssetReplacementsAndEdits((asset) => asset.daUrl);
-  const { easyEdits } = buildHtmlWithEditsAndAssets(assetReplacements);
+  const savePayload = store.buildSavePayload();
+  const savedEditIds = savePayload.map((edit) => edit.id).filter(Boolean);
 
   if (annotationService.isAvailable()) {
-    const persistedEditSnapshot = await annotationService.saveEdits(easyEdits);
+    const persistedEditSnapshot = await annotationService.saveEdits(savePayload);
     if (persistedEditSnapshot) {
-      store.replaceEasyEdits(persistedEditSnapshot.editRecord);
+      store.clearChangeHistoryAfterSave(savedEditIds);
       annotationState.latestSavedEditsUpdatedAt = persistedEditSnapshot.updatedAt
         || persistedEditSnapshot.createdAt
         || null;

--- a/streamlibs/operations/annotation/annotation.css
+++ b/streamlibs/operations/annotation/annotation.css
@@ -570,7 +570,7 @@ body.annotation-mode main::-webkit-scrollbar {
   border-left: 4px solid #3b82f6;
   border-radius: 10px;
   background: #fff;
-  padding: 9px 10px;
+  padding: 10px 11px;
   cursor: pointer;
   position: relative;
 }
@@ -657,7 +657,7 @@ body.annotation-mode main::-webkit-scrollbar {
   align-items: center;
   justify-content: space-between;
   gap: 6px;
-  margin-bottom: 6px;
+  margin-bottom: 4px;
 }
 
 .annotation-panel-comment-user {
@@ -870,6 +870,71 @@ body.annotation-mode main::-webkit-scrollbar {
   background: #fee2e2;
   border-color: #fca5a5;
   transform: translateY(-1px);
+}
+
+.annotation-panel-cancel-btn {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  color: #6b7280;
+  opacity: 0.75;
+  transition: opacity 0.15s, background 0.15s;
+  z-index: 1;
+  line-height: 0;
+}
+
+.annotation-panel-cancel-btn:hover {
+  opacity: 1;
+  background: rgba(0, 0, 0, 0.06);
+}
+
+.annotation-panel-edit-item .annotation-panel-cancel-btn {
+  color: #b45309;
+}
+
+.annotation-panel-asset-item .annotation-panel-cancel-btn {
+  color: #047857;
+}
+
+.annotation-panel-asset-item .annotation-panel-comment-user {
+  margin-bottom: 4px;
+}
+
+.annotation-panel-block-label {
+  display: block;
+  margin: 0 0 3px;
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: #6b7280;
+}
+
+.annotation-arrow-icon {
+  width: 15px;
+  height: 15px;
+  margin: 0 4px;
+  vertical-align: middle;
+}
+
+.annotation-asset-arrow {
+  display: inline;
+}
+
+.annotation-panel-block-label-asset {
+  color: #047857;
+}
+
+.annotation-panel-block-label-edit {
+  color: #b45309;
 }
 
 .annotation-panel-edit-form {
@@ -1524,11 +1589,22 @@ body.annotation-asset-select-mode main img:hover {
 .annotation-asset-card-footer {
   display: flex;
   align-items: center;
-  justify-content: flex-end;
+  justify-content: space-between;
   gap: 6px;
   margin-top: 8px;
-  padding-top: 6px;
-  border-top: 1px solid #d1fae5;
+}
+
+.annotation-card-timestamp {
+  margin: 8px 0 0;
+  font-size: 10px;
+  line-height: 1.2;
+  color: #9ca3af;
+  text-align: right;
+}
+
+.annotation-asset-card-footer .annotation-card-timestamp {
+  margin: 0;
+  margin-left: auto;
 }
 
 .annotation-asset-status {
@@ -1573,15 +1649,7 @@ body.annotation-asset-select-mode main img:hover {
 }
 
 .annotation-asset-card-local::before {
-  content: '';
-  position: absolute;
-  top: 8px;
-  right: 8px;
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  background: #f97316;
-  box-shadow: 0 0 0 2px rgb(249 115 22 / 25%);
+  content: none;
 }
 
 .annotation-asset-from-to {

--- a/streamlibs/operations/annotation/annotation.css
+++ b/streamlibs/operations/annotation/annotation.css
@@ -854,6 +854,24 @@ body.annotation-mode main::-webkit-scrollbar {
   fill: currentcolor;
 }
 
+.annotation-panel-edit-discard-btn {
+  border: 1px solid #fecaca;
+  background: #fff5f5;
+  color: #b91c1c;
+  border-radius: 6px;
+  padding: 2px 8px;
+  font-size: 11px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background-color 0.15s ease, border-color 0.15s ease, transform 0.15s ease;
+}
+
+.annotation-panel-edit-discard-btn:hover {
+  background: #fee2e2;
+  border-color: #fca5a5;
+  transform: translateY(-1px);
+}
+
 .annotation-panel-edit-form {
   display: flex;
   flex-direction: column;

--- a/streamlibs/operations/annotation/assets-panel.js
+++ b/streamlibs/operations/annotation/assets-panel.js
@@ -3,6 +3,7 @@
 /* eslint-disable no-use-before-define */
 /* eslint-disable no-restricted-syntax */
 import { showGlobalSnackbar } from '../../utils/snackbar.js';
+import { formatCardTimestamp, ARROW_ICON_SVG } from '../../utils/utils.js';
 
 const ASSET_INDICATOR_CLASS = 'annotation-asset-pending-indicator';
 const ASSET_INDICATOR_BADGE_CLASS = 'annotation-asset-pending-badge';
@@ -109,6 +110,15 @@ export default function createAssetsPanelController({
     card.dataset.localAssetId = localAsset.localId;
     if (localAsset.createdAt) card.dataset.createdAt = localAsset.createdAt;
 
+    const cancelBtn = document.createElement('button');
+    cancelBtn.type = 'button';
+    cancelBtn.className = 'annotation-panel-cancel-btn';
+    cancelBtn.setAttribute('aria-label', 'Remove this asset');
+    cancelBtn.title = 'Remove';
+    cancelBtn.innerHTML = '<svg width="16" height="16" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M11.0605 10L13.2803 7.78028C13.5733 7.48731 13.5733 7.0127 13.2803 6.71973C12.9873 6.42676 12.5127 6.42676 12.2197 6.71973L10 8.93946L7.78027 6.71973C7.4873 6.42676 7.01269 6.42676 6.71972 6.71973C6.42675 7.0127 6.42675 7.48731 6.71972 7.78028L8.93945 10L6.71972 12.2197C6.42675 12.5127 6.42675 12.9873 6.71972 13.2803C6.8662 13.4268 7.05761 13.5 7.24999 13.5C7.44237 13.5 7.63378 13.4268 7.78026 13.2803L9.99999 11.0606L12.2197 13.2803C12.3662 13.4268 12.5576 13.5 12.75 13.5C12.9424 13.5 13.1338 13.4268 13.2803 13.2803C13.5732 12.9873 13.5732 12.5127 13.2803 12.2197L11.0605 10Z" fill="currentColor"/><path d="M10 18.75C5.1748 18.75 1.25 14.8252 1.25 10C1.25 5.1748 5.1748 1.25 10 1.25C14.8252 1.25 18.75 5.1748 18.75 10C18.75 14.8252 14.8252 18.75 10 18.75ZM10 2.75C6.00195 2.75 2.75 6.00195 2.75 10C2.75 13.998 6.00195 17.25 10 17.25C13.998 17.25 17.25 13.998 17.25 10C17.25 6.00195 13.998 2.75 10 2.75Z" fill="currentColor"/></svg>';
+    cancelBtn.addEventListener('click', () => removeLocalAsset(localAsset.localId));
+    card.appendChild(cancelBtn);
+
     const username = document.createElement('p');
     username.className = 'annotation-panel-comment-user';
     username.textContent = window.streamConfig?.username || 'You';
@@ -116,13 +126,22 @@ export default function createAssetsPanelController({
 
     const text = document.createElement('p');
     text.className = 'annotation-panel-comment-text annotation-panel-asset-links';
+    const blockClass = localAsset.elementProps?.blockClass || '';
+    if (blockClass) {
+      const blockLabel = document.createElement('span');
+      blockLabel.className = 'annotation-panel-block-label annotation-panel-block-label-asset';
+      blockLabel.textContent = blockClass;
+      text.appendChild(blockLabel);
+    }
     const fromLink = document.createElement('a');
     fromLink.href = localAsset.originalSrc || '#';
     fromLink.textContent = 'From Image';
     fromLink.target = '_blank';
     fromLink.rel = 'noopener noreferrer';
     fromLink.className = 'annotation-asset-link';
-    const arrow = document.createTextNode(' → ');
+    const arrow = document.createElement('span');
+    arrow.className = 'annotation-asset-arrow';
+    arrow.innerHTML = ARROW_ICON_SVG;
     const toLink = document.createElement('a');
     toLink.href = localAsset.base64Data || localAsset.filename || '#';
     toLink.textContent = 'To Image';
@@ -134,22 +153,13 @@ export default function createAssetsPanelController({
     text.appendChild(toLink);
     card.appendChild(text);
 
-    const statusBadge = document.createElement('span');
-    statusBadge.className = 'annotation-asset-status annotation-asset-status-unsaved';
-    statusBadge.title = 'unsaved';
-    card.appendChild(statusBadge);
-
-    const footer = document.createElement('div');
-    footer.className = 'annotation-asset-card-footer';
-    const actions = document.createElement('div');
-    actions.className = 'annotation-asset-actions';
-    const deleteBtn = document.createElement('button');
-    deleteBtn.className = 'annotation-asset-action-btn annotation-asset-action-delete';
-    deleteBtn.textContent = 'Remove';
-    deleteBtn.addEventListener('click', () => removeLocalAsset(localAsset.localId));
-    actions.appendChild(deleteBtn);
-    footer.appendChild(actions);
-    card.appendChild(footer);
+    const timestamp = formatCardTimestamp(localAsset.createdAt);
+    if (timestamp) {
+      const time = document.createElement('p');
+      time.className = 'annotation-card-timestamp';
+      time.textContent = timestamp;
+      card.appendChild(time);
+    }
 
     return card;
   }
@@ -169,13 +179,22 @@ export default function createAssetsPanelController({
 
     const text = document.createElement('p');
     text.className = 'annotation-panel-comment-text annotation-panel-asset-links';
+    const blockClass = asset.elementProps?.blockClass || asset.blockClass || '';
+    if (blockClass) {
+      const blockLabel = document.createElement('span');
+      blockLabel.className = 'annotation-panel-block-label annotation-panel-block-label-asset';
+      blockLabel.textContent = blockClass;
+      text.appendChild(blockLabel);
+    }
     const fromLink = document.createElement('a');
     fromLink.href = asset.originalSrc || '#';
     fromLink.textContent = 'From Image';
     fromLink.target = '_blank';
     fromLink.rel = 'noopener noreferrer';
     fromLink.className = 'annotation-asset-link';
-    const arrow = document.createTextNode(' → ');
+    const arrow = document.createElement('span');
+    arrow.className = 'annotation-asset-arrow';
+    arrow.innerHTML = ARROW_ICON_SVG;
     const toLink = document.createElement('a');
     toLink.href = asset.daUrl || asset.filename || '#';
     toLink.textContent = 'To Image';
@@ -186,19 +205,6 @@ export default function createAssetsPanelController({
     text.appendChild(arrow);
     text.appendChild(toLink);
     card.appendChild(text);
-
-    const statusBadge = document.createElement('span');
-    const statusTitles = {
-      promoted: 'Pushed to DA',
-      accepted: 'Saved to collab',
-    };
-    statusBadge.className = `annotation-asset-status annotation-asset-status-${asset.status}`;
-    statusBadge.title = statusTitles[asset.status] || asset.status;
-    if (isApplied && asset.status === 'pending') {
-      statusBadge.title = 'applied';
-      statusBadge.className = 'annotation-asset-status annotation-asset-status-applied';
-    }
-    card.appendChild(statusBadge);
 
     const footer = document.createElement('div');
     footer.className = 'annotation-asset-card-footer';
@@ -224,6 +230,15 @@ export default function createAssetsPanelController({
     }
 
     footer.appendChild(actions);
+
+    const timestamp = formatCardTimestamp(asset.updatedAt || asset.createdAt);
+    if (timestamp) {
+      const time = document.createElement('span');
+      time.className = 'annotation-card-timestamp';
+      time.textContent = timestamp;
+      footer.appendChild(time);
+    }
+
     card.appendChild(footer);
 
     return card;

--- a/streamlibs/operations/annotation/comments-panel.js
+++ b/streamlibs/operations/annotation/comments-panel.js
@@ -1431,6 +1431,33 @@ export default function createCommentsPanelController({
           }
         }
 
+        const hasPending = !!group.comment?.hasPendingHistory || !group.comment?.isCommitted;
+        if (!isCommentThread && group.comment?.isCurrent && hasPending) {
+          const discardBtn = document.createElement('button');
+          discardBtn.type = 'button';
+          discardBtn.className = 'annotation-panel-edit-discard-btn';
+          discardBtn.title = 'Discard last local change';
+          discardBtn.setAttribute('aria-label', 'Discard last local change');
+          discardBtn.textContent = 'Discard';
+          discardBtn.addEventListener('click', (event) => {
+            event.stopPropagation();
+            const result = store.undoLastChange(thread.id);
+            if (!result) return;
+            store.applyEasyEditsToDom();
+            store.saveAnnotationStore();
+            renderThreadMarkers({ resolveTargets: true });
+            renderCommentsPanel();
+          });
+          if (!cardHeader.querySelector('.annotation-panel-status-controls')) {
+            const controls = document.createElement('div');
+            controls.className = 'annotation-panel-status-controls';
+            controls.append(discardBtn);
+            cardHeader.append(controls);
+          } else {
+            cardHeader.querySelector('.annotation-panel-status-controls').append(discardBtn);
+          }
+        }
+
         card.append(cardHeader);
 
         const rootCommentKey = `${thread.id}::${group.comment.id || ''}`;

--- a/streamlibs/operations/annotation/comments-panel.js
+++ b/streamlibs/operations/annotation/comments-panel.js
@@ -10,6 +10,7 @@ import createAnnotationServiceClient from './service.js';
 import requestParentCollabRefresh from './collab-sync.js';
 import syncFragmentEditDisabledHints from './fragment-hints.js';
 import { hideGlobalSnackbar, showGlobalSnackbar } from '../../utils/snackbar.js';
+import { formatCardTimestamp, ARROW_ICON_SVG } from '../../utils/utils.js';
 
 const MAX_LINK_DISPLAY_LENGTH = 60;
 
@@ -1433,13 +1434,13 @@ export default function createCommentsPanelController({
 
         const hasPending = !!group.comment?.hasPendingHistory || !group.comment?.isCommitted;
         if (!isCommentThread && group.comment?.isCurrent && hasPending) {
-          const discardBtn = document.createElement('button');
-          discardBtn.type = 'button';
-          discardBtn.className = 'annotation-panel-edit-discard-btn';
-          discardBtn.title = 'Discard last local change';
-          discardBtn.setAttribute('aria-label', 'Discard last local change');
-          discardBtn.textContent = 'Discard';
-          discardBtn.addEventListener('click', (event) => {
+          const cancelBtn = document.createElement('button');
+          cancelBtn.type = 'button';
+          cancelBtn.className = 'annotation-panel-cancel-btn';
+          cancelBtn.title = 'Discard last local change';
+          cancelBtn.setAttribute('aria-label', 'Discard last local change');
+          cancelBtn.innerHTML = '<svg width="16" height="16" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M11.0605 10L13.2803 7.78028C13.5733 7.48731 13.5733 7.0127 13.2803 6.71973C12.9873 6.42676 12.5127 6.42676 12.2197 6.71973L10 8.93946L7.78027 6.71973C7.4873 6.42676 7.01269 6.42676 6.71972 6.71973C6.42675 7.0127 6.42675 7.48731 6.71972 7.78028L8.93945 10L6.71972 12.2197C6.42675 12.5127 6.42675 12.9873 6.71972 13.2803C6.8662 13.4268 7.05761 13.5 7.24999 13.5C7.44237 13.5 7.63378 13.4268 7.78026 13.2803L9.99999 11.0606L12.2197 13.2803C12.3662 13.4268 12.5576 13.5 12.75 13.5C12.9424 13.5 13.1338 13.4268 13.2803 13.2803C13.5732 12.9873 13.5732 12.5127 13.2803 12.2197L11.0605 10Z" fill="currentColor"/><path d="M10 18.75C5.1748 18.75 1.25 14.8252 1.25 10C1.25 5.1748 5.1748 1.25 10 1.25C14.8252 1.25 18.75 5.1748 18.75 10C18.75 14.8252 14.8252 18.75 10 18.75ZM10 2.75C6.00195 2.75 2.75 6.00195 2.75 10C2.75 13.998 6.00195 17.25 10 17.25C13.998 17.25 17.25 13.998 17.25 10C17.25 6.00195 13.998 2.75 10 2.75Z" fill="currentColor"/></svg>';
+          cancelBtn.addEventListener('click', (event) => {
             event.stopPropagation();
             const result = store.undoLastChange(thread.id);
             if (!result) return;
@@ -1448,14 +1449,7 @@ export default function createCommentsPanelController({
             renderThreadMarkers({ resolveTargets: true });
             renderCommentsPanel();
           });
-          if (!cardHeader.querySelector('.annotation-panel-status-controls')) {
-            const controls = document.createElement('div');
-            controls.className = 'annotation-panel-status-controls';
-            controls.append(discardBtn);
-            cardHeader.append(controls);
-          } else {
-            cardHeader.querySelector('.annotation-panel-status-controls').append(discardBtn);
-          }
+          card.append(cancelBtn);
         }
 
         card.append(cardHeader);
@@ -1479,7 +1473,19 @@ export default function createCommentsPanelController({
         } else {
           const text = document.createElement('p');
           text.className = 'annotation-panel-comment-text';
-          text.innerHTML = linkifyText(group.comment.text);
+          const blockClass = !isCommentThread ? (thread.elementProps?.blockClass || '') : '';
+          if (blockClass) {
+            const blockLabel = document.createElement('span');
+            blockLabel.className = 'annotation-panel-block-label annotation-panel-block-label-edit';
+            blockLabel.textContent = blockClass;
+            text.append(blockLabel);
+          }
+          const textBody = document.createElement('span');
+          const linkified = linkifyText(group.comment.text);
+          textBody.innerHTML = isCommentThread
+            ? linkified
+            : linkified.replace(/→/g, ARROW_ICON_SVG);
+          text.append(textBody);
           card.append(text);
         }
 
@@ -1562,6 +1568,16 @@ export default function createCommentsPanelController({
               replyInput.value = getPanelReplyDraft(thread.id, group.comment.id || '');
             }
             card.append(replyComposer);
+          }
+        }
+
+        if (!isCommentThread) {
+          const timestamp = formatCardTimestamp(group.comment.createdAt || thread.updatedAt);
+          if (timestamp) {
+            const time = document.createElement('p');
+            time.className = 'annotation-card-timestamp';
+            time.textContent = timestamp;
+            card.append(time);
           }
         }
 

--- a/streamlibs/operations/annotation/inline-editing.js
+++ b/streamlibs/operations/annotation/inline-editing.js
@@ -234,12 +234,15 @@ export default function createInlineEditingController({
 
     const editAnchor = store.buildEditElementAnchor(element, annotationUI.mainEl);
     const easyEditElementPath = editAnchor.elementPath;
-    const segments = store.getChangedSegments(snapshot.originalText, currentText);
     const existing = store.getEasyEditByElement(
       elementRef,
       easyEditElementPath,
       editAnchor.elementProps,
     );
+    const stampedOriginal = store.getEasyEditOriginalForElement(element);
+    const baselineText = existing?.from ?? stampedOriginal?.from ?? snapshot.originalText;
+    const baselineHtml = existing?.fromHtml ?? stampedOriginal?.fromHtml ?? snapshot.originalHtml;
+    const segments = store.getChangedSegments(baselineText, currentText);
     const editRecord = {
       id: existing?.id || store.generateId('easy-edit'),
       editType: 'text',
@@ -247,9 +250,9 @@ export default function createInlineEditingController({
       elementPath: easyEditElementPath,
       elementProps: editAnchor.elementProps,
       elementRef,
-      from: snapshot.originalText,
+      from: baselineText,
       to: currentText,
-      fromHtml: snapshot.originalHtml,
+      fromHtml: baselineHtml,
       toHtml: currentHtml,
       changedFrom: segments.changedFrom,
       changedTo: segments.changedTo,

--- a/streamlibs/operations/annotation/store.js
+++ b/streamlibs/operations/annotation/store.js
@@ -199,10 +199,16 @@ export function createAnnotationStore({ annotationState, annotationUI }) {
       updatedAt: edit.updatedAt || new Date().toISOString(),
       authorUsername: `${edit.authorUsername || window.streamConfig?.username || ''}`,
       changeHistory: Array.isArray(edit.changeHistory) ? edit.changeHistory : [],
+      isCommitted: !!edit.isCommitted,
     };
   }
 
   function getReviewId() {
+    const collabId = window.streamConfig?.collabId;
+    if (collabId !== null && collabId !== undefined && `${collabId}`.trim()) {
+      return `collab:${`${collabId}`.trim()}`;
+    }
+
     const streamConfigReviewId = window.streamConfig?.reviewId;
     if (streamConfigReviewId !== null && streamConfigReviewId !== undefined && `${streamConfigReviewId}`.trim()) {
       return `${streamConfigReviewId}`.trim();
@@ -280,6 +286,7 @@ export function createAnnotationStore({ annotationState, annotationUI }) {
         }),
         kind: 'comment',
         createdAt: entry.updatedAt || null,
+        historyIndex: i,
       });
       prevTo = entry.to;
       prevToHtml = entry.toHtml || '';
@@ -288,10 +295,19 @@ export function createAnnotationStore({ annotationState, annotationUI }) {
     messages.push({
       id: `${normalizedEdit.id}-message`,
       username: authorUsername,
-      text: getEditPanelMessage(normalizedEdit),
+      text: getEditPanelMessage({
+        ...normalizedEdit,
+        from: prevTo,
+        fromHtml: prevToHtml,
+      }),
       kind: 'comment',
       createdAt: normalizedEdit.updatedAt || null,
+      isCurrent: true,
+      isCommitted: !!normalizedEdit.isCommitted,
+      hasPendingHistory: history.length > 0,
     });
+
+    messages.reverse();
 
     return {
       id: normalizedEdit.id,
@@ -307,7 +323,12 @@ export function createAnnotationStore({ annotationState, annotationUI }) {
 
   function rebuildEditThreadsFromEasyEdits() {
     const nextEditThreads = annotationState.store.easyEdits
-      .filter((edit) => edit && typeof edit === 'object' && edit.editType !== 'image-src')
+      .filter((edit) => (
+        edit
+        && typeof edit === 'object'
+        && edit.editType !== 'image-src'
+        && (edit.from !== edit.to || (Array.isArray(edit.changeHistory) && edit.changeHistory.length > 0))
+      ))
       .map((edit) => buildEditThreadFromEasyEdit(edit));
     const preservedThreads = annotationState.store.threads.filter(
       (thread) => (thread?.threadType || 'comment') !== 'edit',
@@ -597,7 +618,6 @@ export function createAnnotationStore({ annotationState, annotationUI }) {
       if (fromHtml) {
         const replaced = replaceFirstOccurrence(updatedHtml, fromHtml, toHtml || fromHtml);
         if (replaced !== updatedHtml) { updatedHtml = replaced; return; }
-        // fromHtml didn't match cachedCleanHtml, fall through to fromText
       }
       if (fromText) {
         updatedHtml = replaceFirstOccurrence(updatedHtml, fromText, toText);
@@ -1160,6 +1180,7 @@ export function createAnnotationStore({ annotationState, annotationUI }) {
         // Preserve the viewport from when the edit was first created; don't let a
         // sync/update re-evaluate window.innerWidth at push time.
         viewport: editRecord.viewport || existing.viewport || normalizedEditRecord.viewport,
+        isCommitted: false,
       };
       const didPruneNestedEdits = pruneNestedTextEasyEdits();
       if (!didPruneNestedEdits) rebuildEditThreadsFromEasyEdits();
@@ -1171,11 +1192,67 @@ export function createAnnotationStore({ annotationState, annotationUI }) {
     return resolveStoredEasyEdit(normalizedEditRecord);
   }
 
+  function findEasyEditIndex(easyEditId) {
+    if (!easyEditId) return -1;
+    return annotationState.store.easyEdits.findIndex((edit) => edit?.id === easyEditId);
+  }
+
+  function undoLastChange(easyEditId) {
+    const index = findEasyEditIndex(easyEditId);
+    if (index < 0) return null;
+    const edit = annotationState.store.easyEdits[index];
+    const history = Array.isArray(edit.changeHistory) ? [...edit.changeHistory] : [];
+
+   if (!history.length && edit.from === edit.to) return null;
+    if (!history.length && edit.isCommitted) return null;
+
+    let previousTo;
+    let previousToHtml;
+    if (history.length) {
+      const popped = history.pop();
+      previousTo = popped?.to ?? edit.from;
+      previousToHtml = popped?.toHtml || '';
+    } else {
+      previousTo = edit.from;
+      previousToHtml = edit.fromHtml;
+    }
+
+    annotationState.store.easyEdits[index] = {
+      ...edit,
+      to: `${previousTo ?? ''}`,
+      toHtml: `${previousToHtml ?? ''}`,
+      changeHistory: history,
+      updatedAt: new Date().toISOString(),
+    };
+    rebuildEditThreadsFromEasyEdits();
+    return annotationState.store.easyEdits[index];
+  }
+
+  function clearChangeHistoryAfterSave(savedEditIds = null) {
+    const savedIdSet = Array.isArray(savedEditIds) && savedEditIds.length
+      ? new Set(savedEditIds)
+      : null;
+    annotationState.store.easyEdits = annotationState.store.easyEdits.map((edit) => {
+      if (savedIdSet && !savedIdSet.has(edit?.id)) return edit;
+      return { ...edit, changeHistory: [], isCommitted: true };
+    });
+    rebuildEditThreadsFromEasyEdits();
+  }
+
+  function buildSavePayload() {
+    return annotationState.store.easyEdits
+      .filter((edit) => edit && (edit.from !== edit.to || (edit.fromHtml || '') !== (edit.toHtml || '')))
+      .map((edit) => {
+        const { changeHistory, ...rest } = edit;
+        return rest;
+      });
+  }
+
   function replaceEasyEdits(nextEasyEdits = []) {
     annotationState.store.easyEdits = Array.isArray(nextEasyEdits)
       ? nextEasyEdits
         .filter((edit) => edit && typeof edit === 'object')
-        .map((edit) => normalizeEasyEdit(edit))
+        .map((edit) => ({ ...normalizeEasyEdit(edit), isCommitted: true }))
       : [];
     const didPruneNestedEdits = pruneNestedTextEasyEdits();
     if (!didPruneNestedEdits) rebuildEditThreadsFromEasyEdits();
@@ -1371,5 +1448,8 @@ export function createAnnotationStore({ annotationState, annotationUI }) {
     saveAnnotationStore,
     upsertThread,
     upsertEasyEdit,
+    undoLastChange,
+    clearChangeHistoryAfterSave,
+    buildSavePayload,
   };
 }

--- a/streamlibs/operations/annotation/store.js
+++ b/streamlibs/operations/annotation/store.js
@@ -247,10 +247,10 @@ export function createAnnotationStore({ annotationState, annotationUI }) {
     if (edit.editType === 'image-src') {
       const fromLabel = truncateInlineEditText(edit.from, 40);
       const toLabel = edit.to ? truncateInlineEditText(edit.to, 40) : 'pending upload';
-      return `replaced image src "${fromLabel}" -> "${toLabel}"`;
+      return `replaced image src "${fromLabel}" → "${toLabel}"`;
     }
     if (edit.editType === 'image-alt') {
-      return `changed alt "${truncateInlineEditText(edit.from, 40)}" -> "${truncateInlineEditText(edit.to, 40)}"`;
+      return `changed alt "${truncateInlineEditText(edit.from, 40)}" → "${truncateInlineEditText(edit.to, 40)}"`;
     }
     if (
       edit.editType === 'text'
@@ -261,7 +261,7 @@ export function createAnnotationStore({ annotationState, annotationUI }) {
     ) {
       return `updated formatting for "${truncateInlineEditText(edit.to || edit.from)}"`;
     }
-    return `changed "${truncateInlineEditText(edit.from)}" -> "${truncateInlineEditText(edit.to)}"`;
+    return `"${truncateInlineEditText(edit.from)}" → "${truncateInlineEditText(edit.to)}"`;
   }
 
   function buildEditThreadFromEasyEdit(edit) {

--- a/streamlibs/operations/annotation/store.js
+++ b/streamlibs/operations/annotation/store.js
@@ -339,6 +339,12 @@ export function createAnnotationStore({ annotationState, annotationUI }) {
     ];
   }
 
+  function discardUncommittedEasyEditsOnLoad() {
+    const edits = annotationState.store?.easyEdits;
+    if (!Array.isArray(edits)) return;
+    annotationState.store.easyEdits = edits.filter((edit) => edit && edit.isCommitted);
+  }
+
   function loadAnnotationStore() {
     try {
       const reviewId = getReviewId();
@@ -353,11 +359,13 @@ export function createAnnotationStore({ annotationState, annotationUI }) {
 
       if (reviewId && typeof parsed === 'object' && !Array.isArray(parsed) && parsed[reviewId]) {
         annotationState.store = parseAnnotationPayload(parsed[reviewId]);
+        discardUncommittedEasyEditsOnLoad();
         rebuildEditThreadsFromEasyEdits();
         return;
       }
 
       annotationState.store = parseAnnotationPayload(parsed);
+      discardUncommittedEasyEditsOnLoad();
       rebuildEditThreadsFromEasyEdits();
     } catch (error) {
       annotationState.store = {
@@ -1347,6 +1355,13 @@ export function createAnnotationStore({ annotationState, annotationUI }) {
     rebuildEditThreadsFromEasyEdits();
   }
 
+  const easyEditOriginalByElement = new WeakMap();
+
+  function getEasyEditOriginalForElement(element) {
+    if (!(element instanceof HTMLElement)) return null;
+    return easyEditOriginalByElement.get(element) || null;
+  }
+
   async function applyEasyEditsToDom() {
     if (!annotationUI.mainEl) return;
     removeEasyEditHighlights(annotationUI.mainEl);
@@ -1367,6 +1382,15 @@ export function createAnnotationStore({ annotationState, annotationUI }) {
       const target = getElementForEdit(edit);
       if (!(target instanceof HTMLElement)) return;
       if (target.closest('[data-class="fragment"]')) return;
+
+      if (edit.from === edit.to && (edit.fromHtml || '') === (edit.toHtml || '')) return;
+
+      if (edit.editType === 'text') {
+        easyEditOriginalByElement.set(target, {
+          from: edit.from,
+          fromHtml: edit.fromHtml || '',
+        });
+      }
 
       if (edit.editType === 'image-src') {
         const displayUrl = resolvedUrls.get(edit.to) || edit.to || '';
@@ -1426,6 +1450,7 @@ export function createAnnotationStore({ annotationState, annotationUI }) {
     getElementByCommentPath,
     getElementByThreadPath,
     getEasyEditByElement,
+    getEasyEditOriginalForElement,
     getElementByRef,
     getElementForThread,
     getStoredAnnotationPayload,

--- a/streamlibs/utils/utils.js
+++ b/streamlibs/utils/utils.js
@@ -93,6 +93,21 @@ export function divSwap(blockContent, divSelector, divSelector2) {
 
 export const compose = (...fns) => (initialArg) => fns.reduce((acc, fn) => fn(acc), initialArg);
 
+export const ARROW_ICON_SVG = '<svg class="annotation-arrow-icon" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M17.7686 9.48437L14.7632 6.47949C14.4702 6.18652 13.9956 6.18652 13.7026 6.47949C13.4097 6.77246 13.4097 7.24707 13.7026 7.54004L15.413 9.25H2.75C2.33594 9.25 2 9.58594 2 10C2 10.4141 2.33594 10.75 2.75 10.75H15.4425L13.7026 12.4902C13.4097 12.7832 13.4097 13.2578 13.7026 13.5508C13.8491 13.6973 14.041 13.7705 14.2329 13.7705C14.4248 13.7705 14.6167 13.6973 14.7632 13.5508L17.7685 10.5449C17.9092 10.4043 17.9883 10.2139 17.9883 10.0147C17.9883 9.81543 17.9092 9.62499 17.7686 9.48437Z" fill="currentColor"/></svg>';
+
+export function formatCardTimestamp(value) {
+  if (!value) return '';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return '';
+  const pad = (n) => `${n}`.padStart(2, '0');
+  const dd = pad(date.getDate());
+  const mm = pad(date.getMonth() + 1);
+  const yyyy = date.getFullYear();
+  const hh = pad(date.getHours());
+  const min = pad(date.getMinutes());
+  return `${dd}/${mm}/${yyyy} ${hh}:${min}`;
+}
+
 export const getFirstType = (text) => {
   if (!text) {
     return 'neither';


### PR DESCRIPTION
Introduces a client-side change history (undo stack) for inline text edits in the annotation/collaboration flow, lets users discard uncommitted local changes, reverts unsaved edits to the last-saved state on reload, and refreshes the edit/asset card design.

### Change history & discard
- **Change history tracking:** Each easy edit now carries a `changeHistory` array recording intermediate states. New edits are flagged `isCommitted: false`; edits loaded from the server are `isCommitted: true`.
- **Discard button:** A "Discard" button appears in the annotation panel for any edit that has pending (uncommitted) history. Clicking it rolls back to the previous value via `store.undoLastChange()`.
- **Save flow update:** Save now uses `store.buildSavePayload()` (strips `changeHistory` before sending) and calls `store.clearChangeHistoryAfterSave()` on success to mark persisted edits as committed and reset their history.
- **Thread display:** Edit thread messages are shown in reverse-chronological order (current state first); threads where `from === to` and there is no history are filtered out.

### Reload behavior (revert to last-saved)
- **Auto-discard on rehydrate:** On reload, `loadAnnotationStore()` drops uncommitted edits (`discardUncommittedEasyEditsOnLoad`), so the page reverts to the last-saved state instead of re-applying unsaved local edits.
- **`from` pinned to the true original:** `applyEasyEditsToDom` stamps each applied element's original value (`easyEditOriginalByElement`), and edit capture resolves `from` from the stored edit / stamp before the DOM — preventing `from` from drifting to an already-applied value after reload (incl. viewport-duplicated nodes / regenerated refs).
- **Collapsed edits don't paint the DOM:** `applyEasyEditsToDom` skips edits where `from === to`, mirroring the panel filter so a no-op edit changes neither the card list nor the page.

### Card design
- Edit and asset cards now show a formatted timestamp and the block name/class label.

Changes can be tested on: https://da.live/app/adobecom/da-cc-sandbox/tools/stream/figma?ref=mathuria
