### PR TITLE
MWPW-197373 | Unable to save the changes after Replacing the Images and Texts via "Auto apply comment"

### DIFF
--- a/streamlibs/operations/aiSeoAnnotation/ai-seo-annotation.css
+++ b/streamlibs/operations/aiSeoAnnotation/ai-seo-annotation.css
@@ -149,11 +149,11 @@ main div.fragment {
     pointer-events: none;
 }
 
-main div.fragment div {
+main div.fragment:not([data-path$="fragments/stream-block-placeholder"]) div {
     filter: blur(2px);
 }
 
-main div.fragment::before {
+main div.fragment:not([data-path$="fragments/stream-block-placeholder"])::before {
     content: 'Fragment edit blocked';
     position: absolute;
     inset: 0;

--- a/streamlibs/operations/aiSeoAnnotation/ai-seo-annotation.js
+++ b/streamlibs/operations/aiSeoAnnotation/ai-seo-annotation.js
@@ -34,7 +34,7 @@ function hideRegenBtn() {
 }
 
 function scheduleHideRegenBtn() {
-  regenState.hideTimer = setTimeout(hideRegenBtn, 5000);
+  regenState.hideTimer = setTimeout(hideRegenBtn, 1000);
 }
 
 function cancelHideRegenBtn() {
@@ -168,7 +168,7 @@ function hideImgRegenBtn() {
 }
 
 function scheduleHideImgRegenBtn() {
-  imgRegenState.hideTimer = setTimeout(hideImgRegenBtn, 5000);
+  imgRegenState.hideTimer = setTimeout(hideImgRegenBtn, 1000);
 }
 
 function cancelHideImgRegenBtn() {

--- a/streamlibs/operations/annotation.js
+++ b/streamlibs/operations/annotation.js
@@ -728,6 +728,7 @@ export async function persistAnnotationChangesToDA() {
   await postData(normalizePersistUrlForDaApi(rawPushUrl) || rawPushUrl, daCompatibleHtml, {
     suppressErrorPage: true,
   });
+  // eslint-disable-next-line no-use-before-define
   await persistEditsToDb();
 }
 async function persistEditsToDb() {
@@ -774,7 +775,9 @@ export function recordTextRegenAsEdit(element, fromText, toText, fromHtml = '') 
     elementRef, editAnchor.elementPath, editAnchor.elementProps,
   );
   const stampedOriginal = store.getEasyEditOriginalForElement(element);
+  // eslint-disable-next-line max-len
   const baselineText = existing?.from ?? stampedOriginal?.from ?? snapshot?.originalText ?? fromText;
+  // eslint-disable-next-line max-len
   const baselineHtml = existing?.fromHtml ?? stampedOriginal?.fromHtml ?? snapshot?.originalHtml ?? fromHtml;
   const segments = store.getChangedSegments(baselineText, toText);
 

--- a/streamlibs/operations/annotation.js
+++ b/streamlibs/operations/annotation.js
@@ -80,7 +80,7 @@ export async function recordImageRegenAsLocalAsset(imgEl, generatedUrl, pendingA
   for (let i = 0; i < binaryStr.length; i += 1) bytes[i] = binaryStr.charCodeAt(i);
   const file = new File([bytes], `generated-${Date.now()}.${ext}`, { type: mimeType });
 
-  await assetsPanel.registerLocalAssetFromRegen(imgEl, file, base64Data, pendingAlt);
+  await assetsPanel.registerLocalAssetFromRegen(imgEl, file, base64Data, pendingAlt, generatedUrl);
 }
 
 const commentsPanel = createCommentsPanelController({

--- a/streamlibs/operations/annotation/annotation.css
+++ b/streamlibs/operations/annotation/annotation.css
@@ -1739,28 +1739,6 @@ body.annotation-asset-select-mode main img:hover {
   background: #fef2f2;
 }
 
-/* Visual indicator on replaced images */
-.annotation-asset-pending-indicator {
-  outline: 3px dashed #2563eb !important;
-  outline-offset: 2px;
-}
-
-.annotation-asset-pending-badge {
-  position: absolute;
-  top: 4px;
-  left: 4px;
-  font-size: 10px;
-  font-weight: 700;
-  color: #fff;
-  background: #2563eb;
-  padding: 2px 8px;
-  border-radius: 4px;
-  z-index: 10;
-  pointer-events: none;
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
-}
-
 /* Attach asset button in reply composer */
 .annotation-panel-attach-btn {
   display: inline-flex;

--- a/streamlibs/operations/annotation/assets-panel.js
+++ b/streamlibs/operations/annotation/assets-panel.js
@@ -154,6 +154,7 @@ export default function createAssetsPanelController({
     }
     const fromSrc = store.getAssetPreviewSrc(step.from);
     const toSrc = store.getAssetPreviewSrc(step.to);
+    const toLinkUrl = step.to?.to || '';
     const fromLink = document.createElement('a');
     fromLink.href = fromSrc || '#';
     fromLink.textContent = 'From Image';
@@ -164,11 +165,33 @@ export default function createAssetsPanelController({
     arrow.className = 'annotation-asset-arrow';
     arrow.innerHTML = ARROW_ICON_SVG;
     const toLink = document.createElement('a');
-    toLink.href = toSrc || '#';
     toLink.textContent = 'To Image';
     toLink.target = '_blank';
     toLink.rel = 'noopener noreferrer';
     toLink.className = 'annotation-asset-link';
+    if (toLinkUrl && !toLinkUrl.startsWith('data:')) {
+      // Real URL (regen API URL or promoted DA URL) — directly navigable.
+      toLink.href = toLinkUrl;
+    } else if (toSrc?.startsWith('data:')) {
+      // Base64 data URL — Chrome blocks data: navigation; open via blob URL instead.
+      toLink.href = '#';
+      toLink.addEventListener('click', (e) => {
+        e.preventDefault();
+        try {
+          const [header, b64] = toSrc.split(',');
+          const mime = header.match(/:(.*?);/)?.[1] || 'image/jpeg';
+          const binary = atob(b64);
+          const bytes = new Uint8Array(binary.length);
+          for (let i = 0; i < binary.length; i += 1) bytes[i] = binary.charCodeAt(i);
+          const blob = new Blob([bytes], { type: mime });
+          const blobUrl = URL.createObjectURL(blob);
+          window.open(blobUrl, '_blank');
+          setTimeout(() => URL.revokeObjectURL(blobUrl), 60000);
+        } catch { /* ignore */ }
+      });
+    } else {
+      toLink.href = toSrc || '#';
+    }
     text.appendChild(fromLink);
     text.appendChild(arrow);
     text.appendChild(toLink);
@@ -771,6 +794,13 @@ export default function createAssetsPanelController({
     const uploadedIds = [];
 
     for (const localAsset of localAssets) {
+      if (localAsset.skipUploadAndPromotion) {
+        // Regen image — already at its final content.da.live URL.
+        // The image-src easyEdit carries the URL; no upload or promotion needed.
+        annotationUI.appliedAssets.delete(localAsset.localId);
+        // eslint-disable-next-line no-continue
+        continue;
+      }
       try {
         // eslint-disable-next-line no-await-in-loop
         const asset = await assetService.uploadAsset(
@@ -854,7 +884,7 @@ export default function createAssetsPanelController({
     annotationUI.appliedAssets.clear();
   }
 
-  async function registerLocalAssetFromRegen(targetImg, file, base64Data, pendingAlt = '') {
+  async function registerLocalAssetFromRegen(targetImg, file, base64Data, pendingAlt = '', generatedUrl = '') {
     if (!targetImg || !file || !base64Data) return null;
 
     const anchorTarget = targetImg.closest('picture') || targetImg;
@@ -884,6 +914,8 @@ export default function createAssetsPanelController({
       base64Data,
       targetImg,
       createdAt: new Date().toISOString(),
+      // Already at its final content.da.live URL; skip upload and promotion.
+      skipUploadAndPromotion: true,
     };
 
     const supersededLocal = annotationState.store.localAssets.filter((a) => a.elementPath === elementPath);
@@ -897,6 +929,22 @@ export default function createAssetsPanelController({
     for (const old of supersededRemote) annotationUI.appliedAssets.delete(old.id);
 
     annotationState.store.localAssets.push(localAsset);
+
+    const assetFileKey = store.generateId('asset-file');
+    store.registerAssetFile(assetFileKey, file, base64Data);
+    localAsset.assetFileKey = assetFileKey;
+    store.upsertEasyEdit({
+      editType: 'image-src',
+      elementPath,
+      elementProps,
+      elementRef,
+      from: targetImg.getAttribute('data-stream-original-src') || originalSrc,
+      to: generatedUrl || '',
+      fromHtml: '',
+      toHtml: '',
+      assetFileKey,
+    });
+
     applyAssetPreviewToImg(targetImg, base64Data, localAsset);
 
     if (pendingAlt) {

--- a/streamlibs/operations/annotation/assets-panel.js
+++ b/streamlibs/operations/annotation/assets-panel.js
@@ -5,9 +5,6 @@
 import { showGlobalSnackbar } from '../../utils/snackbar.js';
 import { formatCardTimestamp, ARROW_ICON_SVG } from '../../utils/utils.js';
 
-const ASSET_INDICATOR_CLASS = 'annotation-asset-pending-indicator';
-const ASSET_INDICATOR_BADGE_CLASS = 'annotation-asset-pending-badge';
-
 const ALLOWED_MIME_TYPES = [
   'image/png', 'image/jpeg',
 ];
@@ -616,8 +613,6 @@ export default function createAssetsPanelController({
       elementPath: asset.elementPath,
       targetImg,
     });
-
-    addPendingIndicator(targetImg);
   }
 
   async function applyAssetToPage(asset, targetImgOverride) {
@@ -716,42 +711,6 @@ export default function createAssetsPanelController({
     });
   }
 
-  function addPendingIndicator(imgEl) {
-    removePendingIndicator(imgEl);
-
-    const container = imgEl.closest('picture') || imgEl.parentElement;
-    if (!container) return;
-
-    const computedPosition = getComputedStyle(container).position;
-    if (computedPosition === 'static') {
-      container.style.position = 'relative';
-    }
-
-    imgEl.classList.add(ASSET_INDICATOR_CLASS);
-
-    const badge = document.createElement('span');
-    badge.className = ASSET_INDICATOR_BADGE_CLASS;
-    badge.textContent = 'Pending';
-    container.appendChild(badge);
-  }
-
-  function removePendingIndicator(imgEl) {
-    imgEl.classList.remove(ASSET_INDICATOR_CLASS);
-    const container = imgEl.closest('picture') || imgEl.parentElement;
-    if (!container) return;
-    const existingBadge = container.querySelector(`.${ASSET_INDICATOR_BADGE_CLASS}`);
-    if (existingBadge) existingBadge.remove();
-  }
-
-  function removeAllPendingIndicators() {
-    document.querySelectorAll(`.${ASSET_INDICATOR_CLASS}`).forEach((img) => {
-      img.classList.remove(ASSET_INDICATOR_CLASS);
-    });
-    document.querySelectorAll(`.${ASSET_INDICATOR_BADGE_CLASS}`).forEach((badge) => {
-      badge.remove();
-    });
-  }
-
   async function handleDeleteAsset(asset) {
     try {
       await assetService.deleteAsset(asset.id);
@@ -787,7 +746,6 @@ export default function createAssetsPanelController({
         }
       });
     }
-    removePendingIndicator(imgEl);
   }
 
   async function uploadLocalAssets() {
@@ -871,19 +829,17 @@ export default function createAssetsPanelController({
     });
     annotationState.store.assets = merged;
 
-    for (const [assetId, applied] of annotationUI.appliedAssets) {
+    for (const [assetId] of annotationUI.appliedAssets) {
       // eslint-disable-next-line no-continue
       if (String(assetId).startsWith('local-')) continue;
       const asset = merged.find((a) => a.id === assetId);
       if (!asset || asset.status !== 'pending') {
-        if (applied.targetImg) removePendingIndicator(applied.targetImg);
         annotationUI.appliedAssets.delete(assetId);
       }
     }
   }
 
   function clearAppliedAssets() {
-    removeAllPendingIndicators();
     annotationUI.appliedAssets.clear();
   }
 
@@ -921,11 +877,13 @@ export default function createAssetsPanelController({
       skipUploadAndPromotion: true,
     };
 
+    // eslint-disable-next-line max-len
     const supersededLocal = annotationState.store.localAssets.filter((a) => a.elementPath === elementPath);
     annotationState.store.localAssets = annotationState.store.localAssets
       .filter((a) => a.elementPath !== elementPath);
     for (const old of supersededLocal) annotationUI.appliedAssets.delete(old.localId);
 
+    // eslint-disable-next-line max-len
     const supersededRemote = (annotationState.store.assets || []).filter((a) => a.elementPath === elementPath);
     annotationState.store.assets = (annotationState.store.assets || [])
       .filter((a) => a.elementPath !== elementPath);
@@ -986,7 +944,6 @@ export default function createAssetsPanelController({
 
   function cleanup() {
     exitSelectMode();
-    removeAllPendingIndicators();
     annotationUI.appliedAssets.clear();
     annotationState.store.localAssets = [];
     if (fileInputEl) {

--- a/streamlibs/operations/annotation/assets-panel.js
+++ b/streamlibs/operations/annotation/assets-panel.js
@@ -100,6 +100,33 @@ export default function createAssetsPanelController({
     renderAssetMarkers();
   }
 
+  // Sets href on an anchor to realUrl when it's a proper URL, or attaches a
+  // blob-URL click handler when only a data URL (previewSrc) is available.
+  function setAssetLinkHref(anchorEl, previewSrc, realUrl) {
+    if (realUrl && !realUrl.startsWith('data:')) {
+      anchorEl.href = realUrl;
+      return;
+    }
+    if (previewSrc?.startsWith('data:')) {
+      anchorEl.href = '#';
+      anchorEl.addEventListener('click', (e) => {
+        e.preventDefault();
+        try {
+          const [header, b64] = previewSrc.split(',');
+          const mime = header.match(/:(.*?);/)?.[1] || 'image/jpeg';
+          const binary = atob(b64);
+          const bytes = new Uint8Array(binary.length);
+          for (let i = 0; i < binary.length; i += 1) bytes[i] = binary.charCodeAt(i);
+          const blobUrl = URL.createObjectURL(new Blob([bytes], { type: mime }));
+          window.open(blobUrl, '_blank');
+          setTimeout(() => URL.revokeObjectURL(blobUrl), 60000);
+        } catch { /* ignore */ }
+      });
+      return;
+    }
+    anchorEl.href = previewSrc || '#';
+  }
+
   // Stacked From→To cards for one image edit, newest first; no-op steps dropped.
   function buildAssetEditStepCards(edit) {
     const steps = [];
@@ -154,13 +181,12 @@ export default function createAssetsPanelController({
     }
     const fromSrc = store.getAssetPreviewSrc(step.from);
     const toSrc = store.getAssetPreviewSrc(step.to);
-    const toLinkUrl = step.to?.to || '';
     const fromLink = document.createElement('a');
-    fromLink.href = fromSrc || '#';
     fromLink.textContent = 'From Image';
     fromLink.target = '_blank';
     fromLink.rel = 'noopener noreferrer';
     fromLink.className = 'annotation-asset-link';
+    setAssetLinkHref(fromLink, fromSrc, step.from?.to || '');
     const arrow = document.createElement('span');
     arrow.className = 'annotation-asset-arrow';
     arrow.innerHTML = ARROW_ICON_SVG;
@@ -169,29 +195,7 @@ export default function createAssetsPanelController({
     toLink.target = '_blank';
     toLink.rel = 'noopener noreferrer';
     toLink.className = 'annotation-asset-link';
-    if (toLinkUrl && !toLinkUrl.startsWith('data:')) {
-      // Real URL (regen API URL or promoted DA URL) — directly navigable.
-      toLink.href = toLinkUrl;
-    } else if (toSrc?.startsWith('data:')) {
-      // Base64 data URL — Chrome blocks data: navigation; open via blob URL instead.
-      toLink.href = '#';
-      toLink.addEventListener('click', (e) => {
-        e.preventDefault();
-        try {
-          const [header, b64] = toSrc.split(',');
-          const mime = header.match(/:(.*?);/)?.[1] || 'image/jpeg';
-          const binary = atob(b64);
-          const bytes = new Uint8Array(binary.length);
-          for (let i = 0; i < binary.length; i += 1) bytes[i] = binary.charCodeAt(i);
-          const blob = new Blob([bytes], { type: mime });
-          const blobUrl = URL.createObjectURL(blob);
-          window.open(blobUrl, '_blank');
-          setTimeout(() => URL.revokeObjectURL(blobUrl), 60000);
-        } catch { /* ignore */ }
-      });
-    } else {
-      toLink.href = toSrc || '#';
-    }
+    setAssetLinkHref(toLink, toSrc, step.to?.to || '');
     text.appendChild(fromLink);
     text.appendChild(arrow);
     text.appendChild(toLink);
@@ -266,20 +270,20 @@ export default function createAssetsPanelController({
     const fromSrc = store.getAssetPreviewSrc({ to: localAsset.originalSrc }) || localAsset.originalSrc || '';
     const toSrc = localAsset.base64Data || '';
     const fromLink = document.createElement('a');
-    fromLink.href = fromSrc || localAsset.originalSrc || '#';
     fromLink.textContent = 'From Image';
     fromLink.target = '_blank';
     fromLink.rel = 'noopener noreferrer';
     fromLink.className = 'annotation-asset-link';
+    setAssetLinkHref(fromLink, fromSrc, localAsset.originalSrc || '');
     const arrow = document.createElement('span');
     arrow.className = 'annotation-asset-arrow';
     arrow.innerHTML = ARROW_ICON_SVG;
     const toLink = document.createElement('a');
-    toLink.href = toSrc || localAsset.filename || '#';
     toLink.textContent = 'To Image';
     toLink.target = '_blank';
     toLink.rel = 'noopener noreferrer';
     toLink.className = 'annotation-asset-link';
+    setAssetLinkHref(toLink, toSrc, '');
     text.appendChild(fromLink);
     text.appendChild(arrow);
     text.appendChild(toLink);
@@ -319,23 +323,22 @@ export default function createAssetsPanelController({
       text.appendChild(blockLabel);
     }
     const fromSrc = store.getAssetPreviewSrc({ to: asset.originalSrc }) || asset.originalSrc || '';
-    const toSrc = asset._base64Data
-      || store.getAssetPreviewSrc({ to: asset.daUrl }) || asset.daUrl || '';
+    const toSrc = asset._base64Data || store.getAssetPreviewSrc({ to: asset.daUrl }) || '';
     const fromLink = document.createElement('a');
-    fromLink.href = fromSrc || asset.originalSrc || '#';
     fromLink.textContent = 'From Image';
     fromLink.target = '_blank';
     fromLink.rel = 'noopener noreferrer';
     fromLink.className = 'annotation-asset-link';
+    setAssetLinkHref(fromLink, fromSrc, asset.originalSrc || '');
     const arrow = document.createElement('span');
     arrow.className = 'annotation-asset-arrow';
     arrow.innerHTML = ARROW_ICON_SVG;
     const toLink = document.createElement('a');
-    toLink.href = toSrc || asset.daUrl || asset.filename || '#';
     toLink.textContent = 'To Image';
     toLink.target = '_blank';
     toLink.rel = 'noopener noreferrer';
     toLink.className = 'annotation-asset-link';
+    setAssetLinkHref(toLink, toSrc, asset.daUrl || '');
     text.appendChild(fromLink);
     text.appendChild(arrow);
     text.appendChild(toLink);

--- a/streamlibs/operations/annotation/store.js
+++ b/streamlibs/operations/annotation/store.js
@@ -608,6 +608,22 @@ export function createAnnotationStore({ annotationState, annotationUI }) {
               if (newBlockHtml !== originalBlockHtml) {
                 updatedHtml = replaceFirstOccurrence(updatedHtml, originalBlockHtml, newBlockHtml);
               }
+            } else {
+              // fromAlt not in the block HTML — happens when cachedCleanHtml was refreshed
+              // from DA after a prior push (DA converts all quotes to single, so the previous
+              // push result is now the current text). Fall back to the image by position.
+              const picIdx = edit.picIndexInBlock ?? edit.elementProps?.picIndexInBlock ?? null;
+              const pics = Array.from(targetBlock.querySelectorAll('picture'));
+              const targetPic = picIdx != null ? pics[picIdx] : pics[0];
+              const targetImgEl = targetPic?.querySelector('img');
+              if (targetImgEl) {
+                targetImgEl.setAttribute('alt', toAlt);
+                const newBlockHtml = targetBlock.outerHTML;
+                if (newBlockHtml !== originalBlockHtml) {
+                  // eslint-disable-next-line max-len
+                  updatedHtml = replaceFirstOccurrence(updatedHtml, originalBlockHtml, newBlockHtml);
+                }
+              }
             }
           }
           return;
@@ -617,6 +633,18 @@ export function createAnnotationStore({ annotationState, annotationUI }) {
           updatedHtml = updatedHtml.replace(doubleQuoteAlt, `alt="${toAlt}"`);
         } else if (singleQuoteAlt.test(updatedHtml)) {
           updatedHtml = updatedHtml.replace(singleQuoteAlt, `alt='${toAlt}'`);
+        } else {
+          // fromAlt not found globally — fall back to locating the element by elementPath.
+          const elPath = edit.elementPath;
+          if (elPath) {
+            const globalWrapper = document.createElement('div');
+            globalWrapper.innerHTML = `<main>${updatedHtml}</main>`;
+            const targetImgEl = globalWrapper.querySelector(elPath);
+            if (targetImgEl?.tagName === 'IMG') {
+              targetImgEl.setAttribute('alt', toAlt);
+              updatedHtml = globalWrapper.querySelector('main').innerHTML;
+            }
+          }
         }
         return;
       }


### PR DESCRIPTION
MWPW-197373 | Unable to save the changes after Replacing the Images and Texts via "Auto apply comment"

- Images updated via the regen button (stream-img-regen-btn) now create an image-src easyEdit entry with the generated API URL as to, matching how manual uploads are tracked. Alt text changes from regen are also written to the edit store. Regen assets carry a skipUploadAndPromotion flag so they bypass uploadLocalAssets and batchPromote — their content.da.live URL is already final and requires no re-upload. The from field uses data-stream-original-src (the canonical server URL) rather than the live DOM src.

- Extracted a shared setAssetLinkHref helper used across all three card builders. Real URLs (regen API URL, DA URL, original src) are set as href directly when only a base64 data URL is available (unsaved uploads), a blob URL is created on click to bypass Chrome's data: navigation block.