### PR TITLE
MWPW-196579 Enable metadata handling in collab on SEO pages

### DIFF
--- a/streamlibs/operations/annotation.js
+++ b/streamlibs/operations/annotation.js
@@ -21,7 +21,7 @@ import createAssetsPanelController from './annotation/assets-panel.js';
 import {
   sanitizeMetadataInnerHtml,
   sanitizeMetadataBlockHtml,
-  restoreMetadataImageUrlsOnLiveDom,
+  resolveMetadataImagesForPreview,
 } from './annotation/metadata-sanitize.js';
 import requestParentCollabRefresh from './annotation/collab-sync.js';
 import { handleError } from '../utils/error-handler.js';
@@ -133,8 +133,6 @@ function prepareLiveMetadataForPersist() {
     if (!(img instanceof HTMLImageElement)) return;
     img.setAttribute('data-stream-original-src', edit.to);
   });
-
-  restoreMetadataImageUrlsOnLiveDom(liveMetadata);
 }
 
 const inlineEditing = createInlineEditingController({
@@ -406,14 +404,10 @@ async function injectMetadataSection(mainEl) {
   const metadataSection = mainEl.querySelector('.stream-metadata-section');
   if (!metadataSection) return;
 
-  const imgResolves = [...metadataSection.querySelectorAll('img')].map(async (img) => {
-    const originalSrc = img.getAttribute('src') || '';
-    const resolved = await resolvePreviewUrl(originalSrc);
-    if (!resolved || resolved === originalSrc) return;
-    // PR #197 — keep DA URL for Save/Push; preview may use base64.
-    img.setAttribute('data-stream-original-src', originalSrc);
-    img.setAttribute('src', resolved);
-  });
+  const metadataRoot = metadataSection.querySelector('div.metadata');
+  if (metadataRoot) {
+    await resolveMetadataImagesForPreview(metadataRoot, resolvePreviewUrl);
+  }
   const sourceResolves = [...metadataSection.querySelectorAll('source')].map(async (source) => {
     const originalSrcset = source.getAttribute('srcset') || '';
     const resolved = await resolvePreviewUrl(originalSrcset);
@@ -422,7 +416,7 @@ async function injectMetadataSection(mainEl) {
       source.setAttribute('srcset', resolved);
     }
   });
-  await Promise.all([...imgResolves, ...sourceResolves]);
+  await Promise.all(sourceResolves);
 }
 
 // ── Preview DOM helpers (annotationOperation only) ───────────────────────────
@@ -1007,6 +1001,11 @@ export async function persistAnnotationChangesToDA(versionLabel = null) {
   syncCachedMetadataFromLiveDom();
   await uploadAndDecideAssets();
 
+  const liveMetadataForPush = getLiveMetadataElement();
+  if (liveMetadataForPush) {
+    await resolveMetadataImagesForPreview(liveMetadataForPush, resolvePreviewUrl);
+  }
+
   let promotedAssets = [];
   try {
     const result = await assetService.batchPromote();
@@ -1081,10 +1080,17 @@ export async function saveAnnotationChanges(reportProgress = () => {}) {
   await inlineEditing.syncInlineEditsBeforePersist();
   syncCachedMetadataFromLiveDom();
   await uploadAndDecideAssets();
+  const liveMetadataAfterUpload = getLiveMetadataElement();
+  if (liveMetadataAfterUpload) {
+    await resolveMetadataImagesForPreview(liveMetadataAfterUpload, resolvePreviewUrl);
+  }
   buildAssetReplacementsAndEdits((asset) => asset.daUrl);
   prepareLiveMetadataForPersist();
   syncCachedMetadataFromLiveDom();
   await persistEditsToDb();
+  if (liveMetadataAfterUpload) {
+    await resolveMetadataImagesForPreview(liveMetadataAfterUpload, resolvePreviewUrl);
+  }
   reportProgress('editsSaved');
   requestParentCollabRefresh('edits-saved');
 }

--- a/streamlibs/operations/annotation.js
+++ b/streamlibs/operations/annotation.js
@@ -120,7 +120,6 @@ function getSanitizedMetadataInnerHtml() {
   return getDACompatibleHtml(sanitizeMetadataBlockHtml(liveMetadata));
 }
 
-/** After asset upload — PR #197: replace preview base64 with final CDN URLs before Save/Push. */
 function prepareLiveMetadataForPersist() {
   const liveMetadata = getLiveMetadataElement();
   if (!liveMetadata) return;

--- a/streamlibs/operations/annotation.js
+++ b/streamlibs/operations/annotation.js
@@ -91,6 +91,32 @@ const commentsPanel = createCommentsPanelController({
 });
 commentsPanel.setImageRegenHandler(recordImageRegenAsLocalAsset);
 
+let cachedCleanHtml = '';
+let cachedMetadata = null;
+const regenReplacements = [];
+
+function buildMetadataToHtml() {
+  const liveMetadata = document.querySelector('main div.metadata');
+  if (!liveMetadata) return '';
+  const clone = liveMetadata.cloneNode(true);
+  clone.querySelectorAll('picture').forEach((picture) => {
+    const img = picture.querySelector('img');
+    if (img) picture.replaceWith(img);
+    else picture.remove();
+  });
+  clone.querySelectorAll('img').forEach((img) => {
+    const originalSrc = img.getAttribute('data-stream-original-srcset')
+      || img.getAttribute('data-stream-original-src');
+    if (originalSrc) img.setAttribute('src', originalSrc);
+  });
+  clone.querySelectorAll('*').forEach((el) => {
+    [...el.attributes]
+      .filter((attr) => attr.name.startsWith('data-'))
+      .forEach((attr) => el.removeAttribute(attr.name));
+  });
+  return getDACompatibleHtml(clone.outerHTML);
+}
+
 const inlineEditing = createInlineEditingController({
   annotationState,
   annotationUI,
@@ -110,9 +136,137 @@ assetsPanel.setOnAssetsChanged(() => {
   commentsPanel.renderCommentsPanel();
 });
 
-let cachedCleanHtml = '';
-let cachedPageMetadataHtml = null;
-const regenReplacements = [];
+function parseAndCacheCleanHtml(htmlDom) {
+  const metadataBlocks = [...htmlDom.querySelectorAll('div.metadata')];
+  let combinedInnerHtml = '';
+  metadataBlocks.forEach((block) => {
+    combinedInnerHtml += block.innerHTML;
+    const parent = block.parentElement;
+    block.remove();
+    if (parent && parent.children.length === 0) parent.remove();
+  });
+  if (metadataBlocks.length > 0) {
+    cachedMetadata = document.createElement('div');
+    cachedMetadata.className = 'metadata';
+    cachedMetadata.innerHTML = combinedInnerHtml;
+  } else {
+    cachedMetadata = null;
+  }
+  cachedCleanHtml = htmlDom.innerHTML;
+}
+
+function waitForMiloPageLoad(timeoutMs = 15000) {
+  if (document.getElementById('page-load-ok-milo')) return Promise.resolve();
+  return new Promise((resolve) => {
+    let observer;
+    const timeout = setTimeout(() => {
+      if (observer) observer.disconnect();
+      resolve();
+    }, timeoutMs);
+    observer = new MutationObserver(() => {
+      if (!document.getElementById('page-load-ok-milo')) return;
+      clearTimeout(timeout);
+      observer.disconnect();
+      resolve();
+    });
+    observer.observe(document.body, { childList: true, subtree: true });
+  });
+}
+
+const DEFAULT_METADATA_PLACEHOLDER_IMG = 'https://main--stream-mapper--adobecom.aem.live/assets/media_1bf6f8fe5a340bb3f4e022b300d7013821fe5ff89.png';
+
+function syncCachedMetadataFromLiveDom() {
+  const liveMetadata = document.querySelector('main .stream-metadata-section div.metadata');
+  if (liveMetadata && cachedMetadata) {
+    cachedMetadata.innerHTML = liveMetadata.innerHTML;
+  }
+}
+
+function attachMetadataAddRowControls(sectionEl) {
+  const metadataDom = sectionEl?.querySelector('div.metadata');
+  if (!metadataDom) return;
+
+  sectionEl.querySelectorAll('.stream-annotation-metadata-actions').forEach((el) => el.remove());
+
+  const addAndRegisterRow = (row) => {
+    metadataDom.append(row);
+    row.querySelectorAll('p').forEach((p) => inlineEditing.registerNewEditableElement(p));
+    syncCachedMetadataFromLiveDom();
+  };
+
+  const addTextBtn = document.createElement('button');
+  addTextBtn.type = 'button';
+  addTextBtn.className = 'stream-annotation-add-metadata-row';
+  addTextBtn.textContent = '+ Add text/link row';
+  addTextBtn.addEventListener('click', () => {
+    const row = document.createElement('div');
+    row.innerHTML = '<div><p>add metadata key</p></div><div><p>add text or link value</p></div>';
+    addAndRegisterRow(row);
+  });
+
+  const addImageBtn = document.createElement('button');
+  addImageBtn.type = 'button';
+  addImageBtn.className = 'stream-annotation-add-metadata-row';
+  addImageBtn.textContent = '+ Add image row';
+  addImageBtn.addEventListener('click', () => {
+    const row = document.createElement('div');
+    row.innerHTML = `<div><p>key</p></div><div><picture><img src="${DEFAULT_METADATA_PLACEHOLDER_IMG}"></picture></div>`;
+    addAndRegisterRow(row);
+  });
+
+  const metadataActions = document.createElement('div');
+  metadataActions.className = 'stream-annotation-metadata-actions';
+  metadataActions.append(addTextBtn, addImageBtn);
+  sectionEl.append(metadataActions);
+}
+
+async function injectMetadataSection(mainEl) {
+  if (!mainEl) return;
+
+  if (!cachedMetadata) {
+    cachedMetadata = document.createElement('div');
+    cachedMetadata.className = 'metadata';
+    cachedMetadata.innerHTML = '';
+  }
+
+  mainEl.querySelectorAll('.stream-metadata-section').forEach((section) => section.remove());
+  mainEl.querySelectorAll(':scope > div.metadata, :scope .section > div.metadata').forEach((block) => {
+    const parent = block.closest('.section') || block.parentElement;
+    block.remove();
+    if (parent instanceof HTMLElement && parent.children.length === 0) parent.remove();
+  });
+
+  const divWrapper = document.createElement('div');
+  divWrapper.classList.add('section', 'stream-metadata-section');
+  const blocktitle = document.createElement('h3');
+  blocktitle.textContent = 'Page Metadata';
+  divWrapper.appendChild(blocktitle);
+  divWrapper.insertAdjacentHTML('beforeend', cachedMetadata.outerHTML);
+
+  attachMetadataAddRowControls(divWrapper);
+  mainEl.appendChild(divWrapper);
+
+  const metadataSection = mainEl.querySelector('.stream-metadata-section');
+  if (!metadataSection) return;
+
+  const imgResolves = [...metadataSection.querySelectorAll('img')].map(async (img) => {
+    const originalSrc = img.getAttribute('src') || '';
+    const resolved = await resolvePreviewUrl(originalSrc);
+    if (resolved && resolved !== originalSrc) {
+      img.setAttribute('data-stream-original-src', originalSrc);
+      img.setAttribute('src', resolved);
+    }
+  });
+  const sourceResolves = [...metadataSection.querySelectorAll('source')].map(async (source) => {
+    const originalSrcset = source.getAttribute('srcset') || '';
+    const resolved = await resolvePreviewUrl(originalSrcset);
+    if (resolved && resolved !== originalSrcset) {
+      source.setAttribute('data-stream-original-srcset', originalSrcset);
+      source.setAttribute('srcset', resolved);
+    }
+  });
+  await Promise.all([...imgResolves, ...sourceResolves]);
+}
 
 // ── Preview DOM helpers (annotationOperation only) ───────────────────────────
 
@@ -146,19 +300,18 @@ async function initializePreview() {
   const htmlDom = await getDADom();
   const headerEle = document.createElement('header');
   const mainEle = document.createElement('main');
-  const metadataEle = document.createElement('div');
-  metadataEle.classList.add('metadata', 'page-metadata');
-  if (cachedPageMetadataHtml !== null) {
-    metadataEle.innerHTML = cachedPageMetadataHtml;
+  const rawHtml = (htmlDom instanceof HTMLElement && htmlDom.tagName === 'MAIN')
+    ? htmlDom
+    : null;
+  if (rawHtml) {
+    parseAndCacheCleanHtml(rawHtml);
+    mainEle.innerHTML = rawHtml.innerHTML;
+  } else if (htmlDom instanceof HTMLElement) {
+    parseAndCacheCleanHtml(htmlDom);
+    mainEle.innerHTML = htmlDom.innerHTML;
   } else {
-    htmlDom.querySelectorAll('div.metadata').forEach((mb) => {
-      metadataEle.innerHTML += mb.innerHTML;
-    });
+    mainEle.innerHTML = htmlDom;
   }
-  mainEle.innerHTML = (htmlDom instanceof HTMLElement && htmlDom.tagName === 'MAIN')
-    ? htmlDom.innerHTML
-    : htmlDom;
-  document.body.append(metadataEle);
   document.body.prepend(mainEle);
   document.body.prepend(headerEle);
 }
@@ -248,6 +401,26 @@ function findAssetElement(doc, elementPath, elementProps, originalSrc) {
   const main = doc.querySelector('main');
   if (!main) return null;
 
+  if (elementPath === 'metadata') {
+    const metadataRoot = main.querySelector('div.metadata');
+    if (!metadataRoot) return null;
+    if (originalSrc) {
+      const withoutParams = originalSrc.split('?')[0]?.split('#')[0] ?? '';
+      const filename = withoutParams.split('/').pop() || '';
+      for (const img of metadataRoot.querySelectorAll('img')) {
+        const src = (img.getAttribute('src') || '').split('?')[0]?.split('#')[0] ?? '';
+        const srcMatches = (withoutParams && src.includes(withoutParams))
+          || (filename && src.endsWith(filename));
+        if (srcMatches) {
+          return img.closest('picture') || img;
+        }
+      }
+    }
+    const pic = metadataRoot.querySelector('picture');
+    if (pic?.querySelector('img')) return pic;
+    return metadataRoot.querySelector('img');
+  }
+
   if (elementPath) {
     const selector = elementPath.startsWith('main > ')
       ? elementPath.slice('main > '.length) : elementPath;
@@ -325,12 +498,8 @@ function findAssetElement(doc, elementPath, elementProps, originalSrc) {
 
 // ── HTML export ───────────────────────────────────────────────────────────────
 
-function buildHtmlWithEditsAndAssets(assetReplacements, { excludeBlockClasses = [] } = {}) {
-  const isExcluded = (bc) => excludeBlockClasses.includes(bc);
-  const allEasyEdits = annotationState.store.easyEdits || [];
-  const easyEdits = excludeBlockClasses.length
-    ? allEasyEdits.filter((e) => !isExcluded(e?.blockClass || e?.elementProps?.blockClass))
-    : allEasyEdits;
+function buildHtmlWithEditsAndAssets(assetReplacements) {
+  const easyEdits = annotationState.store.easyEdits || [];
   const html = store.applyEasyEditsToHtmlString(cachedCleanHtml, easyEdits);
   const container = document.createElement('div');
   container.innerHTML = `<main>${html}</main>`;
@@ -339,7 +508,6 @@ function buildHtmlWithEditsAndAssets(assetReplacements, { excludeBlockClasses = 
     // Assets with block+globalIndex were already applied viewport-aware in the string phase
     const assetBc = asset.elementProps?.blockClass;
     const assetBgi = asset.elementProps?.blockGlobalIndex;
-    if (isExcluded(assetBc)) continue; // eslint-disable-line no-continue
     if (assetBc && assetBgi != null) continue; // eslint-disable-line no-continue
     const element = findAssetElement(
       container, asset.elementPath, asset.elementProps, asset.originalSrc,
@@ -383,8 +551,7 @@ function buildHtmlWithEditsAndAssets(assetReplacements, { excludeBlockClasses = 
   // image-src easyEdits take priority — they carry the final promoted URL and
   // reliable original src, so they overwrite the assetReplacements pass above.
   const imageSrcEdits = (annotationState.store.easyEdits || [])
-    .filter((e) => e?.editType === 'image-src' && e.to)
-    .filter((e) => !isExcluded(e?.blockClass || e?.elementProps?.blockClass));
+    .filter((e) => e?.editType === 'image-src' && e.to);
   // Edits with blockClass+blockGlobalIndex were already applied viewport-aware in the string phase
   imageSrcEdits
     .filter((edit) => {
@@ -421,6 +588,14 @@ function buildHtmlWithEditsAndAssets(assetReplacements, { excludeBlockClasses = 
 
   rewriteMediaUrls(container);
   const mainEl = container.querySelector('main');
+
+  const metadataHtml = buildMetadataToHtml();
+  if (metadataHtml && mainEl) {
+    const metadataWrap = document.createElement('div');
+    metadataWrap.innerHTML = metadataHtml;
+    const metadataEl = metadataWrap.querySelector('.metadata') || metadataWrap.firstElementChild;
+    if (metadataEl) mainEl.appendChild(metadataEl);
+  }
 
   return { easyEdits, daCompatibleHtml: getDACompatibleHtml(mainEl.innerHTML) };
 }
@@ -503,31 +678,55 @@ function buildAssetReplacementsAndEdits(resolveTargetUrl) {
     }
   }
 
-  const assetReplacements = Array.from(latestByPath.values()).map((asset) => ({
+  const resolvedAssets = Array.from(latestByPath.values()).map((asset) => {
+    const liveEl = asset.elementRef
+      ? document.querySelector(`[data-annotation-ref="${asset.elementRef}"]`)
+      : null;
+    const isMetadata = Boolean(liveEl?.closest('main div.metadata'));
+    const imgEl = liveEl?.tagName === 'IMG' ? liveEl : liveEl?.querySelector('img');
+    let { originalSrc } = asset;
+    if (isMetadata) {
+      const fromAttr = imgEl?.getAttribute('data-stream-original-src');
+      if (fromAttr) {
+        originalSrc = fromAttr;
+      } else if (cachedMetadata) {
+        const cachedImg = cachedMetadata.querySelector('img[src*="content.da.live"]');
+        if (cachedImg) originalSrc = cachedImg.getAttribute('src') || asset.originalSrc;
+      }
+    }
+    return { asset, isMetadata, originalSrc };
+  });
+
+  const assetReplacements = resolvedAssets.map(({ asset, originalSrc }) => ({
     elementPath: asset.elementPath,
     elementProps: asset.elementProps,
-    originalSrc: asset.originalSrc,
+    originalSrc,
     daUrl: asset.daUrl,
     targetUrl: resolveTargetUrl(asset),
   }));
 
-  for (const asset of latestByPath.values()) {
+  for (const { asset, isMetadata, originalSrc } of resolvedAssets) {
     const finalUrl = resolveTargetUrl(asset);
     if (!asset.elementPath || !finalUrl) continue; // eslint-disable-line no-continue
+    const trackingPath = isMetadata ? 'metadata' : asset.elementPath;
     const existingEdit = store.getEasyEditByElement(
-      asset.elementRef || '', asset.elementPath, asset.elementProps,
+      asset.elementRef || '', trackingPath, asset.elementProps,
     );
     if (!existingEdit || existingEdit.editType === 'image-src') {
+      const metadataFields = isMetadata
+        ? store.metadataEasyEditFields(asset.elementProps || {})
+        : {};
       store.upsertEasyEdit({
         ...(existingEdit || {}),
         editType: 'image-src',
-        elementPath: asset.elementPath,
-        elementProps: asset.elementProps || {},
+        elementPath: trackingPath,
+        elementProps: metadataFields.elementProps || asset.elementProps || {},
         elementRef: asset.elementRef || '',
-        from: existingEdit?.from || asset.originalSrc,
+        from: isMetadata ? originalSrc : (existingEdit?.from || originalSrc),
         to: finalUrl,
         fromHtml: '',
         toHtml: '',
+        ...(metadataFields.blockClass ? { blockClass: metadataFields.blockClass } : {}),
         // Keep the original replacement time so panel ordering stays chronological.
         updatedAt: existingEdit?.updatedAt || new Date().toISOString(),
       });
@@ -570,8 +769,6 @@ export async function annotationOperation(options = {}) {
     });
   }
 
-  if (!cachedCleanHtml) cachedCleanHtml = mainEl.innerHTML || '';
-
   if (window.streamConfig?.source === 'da') {
     const insertedFragments = await hydrateFragmentLinksInDaBlocks(mainEl);
     for (const root of insertedFragments) {
@@ -581,42 +778,7 @@ export async function annotationOperation(options = {}) {
   }
 
   await miloLoadArea();
-
-  const metadataDom = document.body.querySelector('.page-metadata');
-  const metadataSeparator = document.createElement('div');
-  metadataSeparator.classList.add('section', 'stream-annotation-page-metadata');
-  metadataSeparator.innerHTML = '<h3>Page Metadata</h3>';
-  metadataSeparator.append(metadataDom);
-
-  const addAndRegisterRow = (row) => {
-    metadataDom.append(row);
-    row.querySelectorAll('p').forEach((p) => inlineEditing.registerNewEditableElement(p));
-  };
-
-  const addTextBtn = document.createElement('button');
-  addTextBtn.className = 'stream-annotation-add-metadata-row';
-  addTextBtn.textContent = '+ Add text/link row';
-  addTextBtn.addEventListener('click', () => {
-    const row = document.createElement('div');
-    row.innerHTML = '<div><p>add metadata key</p></div><div><p>add text or link value</p></div>';
-    addAndRegisterRow(row);
-  });
-
-  const addImageBtn = document.createElement('button');
-  addImageBtn.className = 'stream-annotation-add-metadata-row';
-  addImageBtn.textContent = '+ Add image row';
-  addImageBtn.addEventListener('click', () => {
-    const row = document.createElement('div');
-    row.innerHTML = '<div><p>key</p></div><div><picture><img src="https://main--stream-mapper--adobecom.aem.live/assets/media_1bf6f8fe5a340bb3f4e022b300d7013821fe5ff89.png"></picture></div>';
-    addAndRegisterRow(row);
-  });
-
-  const metadataActions = document.createElement('div');
-  metadataActions.className = 'stream-annotation-metadata-actions';
-  metadataActions.append(addTextBtn, addImageBtn);
-  metadataSeparator.append(metadataActions);
-  mainEl.append(metadataSeparator);
-
+  await injectMetadataSection(mainEl);
   await finishAnnotationSession(mainEl, { preserveRemoteEditState, shouldRestoreInlineMode });
 }
 
@@ -627,14 +789,7 @@ export async function annotationOperationOnHostPage(options = {}) {
     baselineHtml = null,
   } = options;
 
-  await new Promise((resolve) => {
-    const observer = new MutationObserver(() => {
-      if (!document.getElementById('page-load-ok-milo')) return;
-      observer.disconnect();
-      resolve();
-    });
-    observer.observe(document.body, { childList: true });
-  });
+  await waitForMiloPageLoad();
 
   const { shouldRestoreInlineMode } = prepareAnnotationSession({ preserveRemoteEditState });
 
@@ -646,16 +801,27 @@ export async function annotationOperationOnHostPage(options = {}) {
       try {
         const cfg = window.streamConfig;
         const daMain = await fetchDAContent(cfg.draftLocation || cfg.contentUrl);
-        cachedCleanHtml = daMain?.innerHTML || '';
+        if (daMain instanceof HTMLElement) {
+          const tempMain = document.createElement('main');
+          tempMain.innerHTML = daMain.tagName === 'MAIN' ? daMain.innerHTML : daMain.outerHTML;
+          parseAndCacheCleanHtml(tempMain);
+        } else {
+          cachedCleanHtml = '';
+        }
       } catch (err) {
         console.warn('[annotation] Failed to fetch DA baseline HTML, falling back to live DOM:', err);
-        cachedCleanHtml = '';
+        const tempMain = document.createElement('main');
+        tempMain.innerHTML = baselineHtml || mainEl.innerHTML || '';
+        parseAndCacheCleanHtml(tempMain);
       }
     } else {
-      cachedCleanHtml = baselineHtml || mainEl.innerHTML || '';
+      const tempMain = document.createElement('main');
+      tempMain.innerHTML = baselineHtml || mainEl.innerHTML || '';
+      parseAndCacheCleanHtml(tempMain);
     }
   }
 
+  await injectMetadataSection(mainEl);
   await finishAnnotationSession(mainEl, { preserveRemoteEditState, shouldRestoreInlineMode });
 
   const stripBase64QueryParam = (el) => {
@@ -681,6 +847,7 @@ export async function annotationOperationOnHostPage(options = {}) {
 
 export async function persistAnnotationChangesToDA(versionLabel = null) {
   await inlineEditing.syncInlineEditsBeforePersist();
+  syncCachedMetadataFromLiveDom();
   await uploadAndDecideAssets();
 
   let promotedAssets = [];
@@ -700,37 +867,7 @@ export async function persistAnnotationChangesToDA(versionLabel = null) {
   const assetReplacements = buildAssetReplacementsAndEdits(
     (asset) => asset.finalDaUrl || asset.daUrl,
   );
-  let { daCompatibleHtml } = buildHtmlWithEditsAndAssets(assetReplacements, {
-    excludeBlockClasses: ['metadata'],
-  });
-
-  if (cachedPageMetadataHtml !== null) {
-    const metaContainer = document.createElement('div');
-    metaContainer.innerHTML = `<main>${daCompatibleHtml}</main>`;
-    const metaMain = metaContainer.querySelector('main');
-    metaMain.querySelectorAll('.metadata').forEach((el) => {
-      const parentSection = el.parentElement;
-      el.remove();
-      if (parentSection.children.length === 0) parentSection.remove();
-    });
-    const metadataDiv = document.createElement('div');
-    metadataDiv.className = 'metadata';
-    metadataDiv.innerHTML = cachedPageMetadataHtml;
-    metadataDiv.querySelectorAll('p').forEach((p) => {
-      [...p.attributes].forEach((attr) => p.removeAttribute(attr.name));
-    });
-    metadataDiv.querySelectorAll('img').forEach((img) => {
-      const daSrc = img.getAttribute('data-stream-original-src');
-      if (daSrc) img.setAttribute('src', daSrc);
-      [...img.attributes].forEach((attr) => {
-        if (attr.name.startsWith('data-')) img.removeAttribute(attr.name);
-      });
-    });
-    const divWrapper = document.createElement('div');
-    divWrapper.append(metadataDiv);
-    metaMain.appendChild(divWrapper);
-    daCompatibleHtml = getDACompatibleHtml(metaMain.innerHTML);
-  }
+  const { daCompatibleHtml } = buildHtmlWithEditsAndAssets(assetReplacements);
 
   const cfg = window.streamConfig || {};
   const rawPushUrl = `${cfg.pageUrl || cfg.targetUrl || ''}`.trim();
@@ -767,53 +904,9 @@ async function persistEditsToDb() {
 
 export async function saveAnnotationChanges(reportProgress = () => {}) {
   await inlineEditing.syncInlineEditsBeforePersist();
+  syncCachedMetadataFromLiveDom();
   await uploadAndDecideAssets();
-  // Save assigns each image edit its content.da.live URL (no DA push here).
-  const assetReplacements = buildAssetReplacementsAndEdits((asset) => asset.daUrl);
-  // eslint-disable-next-line no-unused-vars
-  const { daCompatibleHtml } = buildHtmlWithEditsAndAssets(assetReplacements);
-
-  // Apply page metadata edits to the outgoing HTML
-  const pageMetadataDom = document.body.querySelector('main .page-metadata');
-  let htmlToPush = cachedCleanHtml;
-  if (pageMetadataDom && pageMetadataDom.children.length) {
-    cachedPageMetadataHtml = pageMetadataDom.innerHTML;
-    const metaContainer = document.createElement('div');
-    metaContainer.innerHTML = `<main>${cachedCleanHtml}</main>`;
-    const metaMain = metaContainer.querySelector('main');
-    metaMain.querySelectorAll('.metadata').forEach((el) => {
-      const parentSection = el.parentElement;
-      el.remove();
-      if (parentSection.children.length === 0) parentSection.remove();
-    });
-    const metadataDiv = document.createElement('div');
-    metadataDiv.className = 'metadata';
-    metadataDiv.innerHTML = pageMetadataDom.innerHTML;
-    metadataDiv.querySelectorAll('p').forEach((p) => {
-      [...p.attributes].forEach((attr) => p.removeAttribute(attr.name));
-    });
-    metadataDiv.querySelectorAll('img').forEach((img) => {
-      const daSrc = img.getAttribute('data-stream-original-src');
-      img.setAttribute('src', daSrc);
-      [...img.attributes].forEach((attr) => {
-        if (attr.name.startsWith('data-')) {
-          img.removeAttribute(attr.name);
-        }
-      });
-    });
-    const divWrapper = document.createElement('div');
-    divWrapper.append(metadataDiv);
-    metaMain.appendChild(divWrapper);
-    htmlToPush = getDACompatibleHtml(metaMain.innerHTML);
-    const cfg = window.streamConfig || {};
-    const rawPushUrl = `${cfg.draftLocation || cfg.contentUrl || ''}`.trim();
-    if (rawPushUrl) {
-      await postData(normalizePersistUrlForDaApi(rawPushUrl) || rawPushUrl, htmlToPush, {
-        suppressErrorPage: true,
-      });
-    }
-  }
-
+  buildAssetReplacementsAndEdits((asset) => asset.daUrl);
   await persistEditsToDb();
   reportProgress('editsSaved');
   requestParentCollabRefresh('edits-saved');
@@ -829,28 +922,35 @@ export function recordTextRegenAsEdit(element, fromText, toText, fromHtml = '') 
   const elementRef = store.ensureElementRef(element);
   const snapshot = annotationUI.inlineElementSnapshot.get(elementRef);
 
+  const isInMetadata = Boolean(element.closest('main div.metadata'));
   const editAnchor = store.buildEditElementAnchor(element, annotationUI.mainEl);
+  const easyEditElementPath = isInMetadata ? 'metadata' : editAnchor.elementPath;
   const existing = store.getEasyEditByElement(
-    elementRef, editAnchor.elementPath, editAnchor.elementProps,
+    elementRef, easyEditElementPath, editAnchor.elementProps,
   );
   const stampedOriginal = store.getEasyEditOriginalForElement(element);
   // eslint-disable-next-line max-len
   const baselineText = existing?.from ?? stampedOriginal?.from ?? snapshot?.originalText ?? fromText;
   // eslint-disable-next-line max-len
   const baselineHtml = existing?.fromHtml ?? stampedOriginal?.fromHtml ?? snapshot?.originalHtml ?? fromHtml;
+  const currentHtml = `${element.innerHTML || ''}`.trim() || toText;
+  const metadataFields = isInMetadata
+    ? store.metadataEasyEditFields(editAnchor.elementProps)
+    : {};
   const segments = store.getChangedSegments(baselineText, toText);
 
   const persistedEdit = store.upsertEasyEdit({
     id: existing?.id || store.generateId('easy-edit'),
     editType: 'text',
     attrName: '',
-    elementPath: editAnchor.elementPath,
-    elementProps: editAnchor.elementProps,
+    elementPath: easyEditElementPath,
+    elementProps: metadataFields.elementProps || editAnchor.elementProps,
     elementRef,
     from: baselineText,
     to: toText,
     fromHtml: baselineHtml,
-    toHtml: toText,
+    toHtml: currentHtml || toText,
+    ...(metadataFields.blockClass ? { blockClass: metadataFields.blockClass } : {}),
     changedFrom: segments.changedFrom,
     changedTo: segments.changedTo,
     updatedAt: new Date().toISOString(),

--- a/streamlibs/operations/annotation.js
+++ b/streamlibs/operations/annotation.js
@@ -18,6 +18,10 @@ import createInlineEditingController from './annotation/inline-editing.js';
 import createAnnotationServiceClient from './annotation/service.js';
 import createAssetServiceClient from './annotation/asset-service.js';
 import createAssetsPanelController from './annotation/assets-panel.js';
+import {
+  sanitizeMetadataInnerHtml,
+  sanitizeMetadataBlockHtml,
+} from './annotation/metadata-sanitize.js';
 import requestParentCollabRefresh from './annotation/collab-sync.js';
 import { handleError } from '../utils/error-handler.js';
 
@@ -96,36 +100,32 @@ let cachedMetadata = null;
 let cachedMetadataBaselineInnerHtml = '';
 const regenReplacements = [];
 
-function sanitizeMetadataClone(metadataEl) {
-  const clone = metadataEl.cloneNode(true);
-  clone.querySelectorAll('picture').forEach((picture) => {
-    const img = picture.querySelector('img');
-    if (img) picture.replaceWith(img);
-    else picture.remove();
-  });
-  clone.querySelectorAll('img').forEach((img) => {
-    const originalSrc = img.getAttribute('data-stream-original-srcset')
-      || img.getAttribute('data-stream-original-src');
-    if (originalSrc) img.setAttribute('src', originalSrc);
-  });
-  clone.querySelectorAll('*').forEach((el) => {
-    [...el.attributes]
-      .filter((attr) => attr.name.startsWith('data-'))
-      .forEach((attr) => el.removeAttribute(attr.name));
-  });
-  return clone;
-}
-
 function buildMetadataToHtml() {
   const liveMetadata = document.querySelector('main div.metadata');
   if (!liveMetadata) return '';
-  return getDACompatibleHtml(sanitizeMetadataClone(liveMetadata).outerHTML);
+  const metadataDiv = document.createElement('div');
+  metadataDiv.className = 'metadata';
+  metadataDiv.innerHTML = sanitizeMetadataBlockHtml(liveMetadata);
+  return getDACompatibleHtml(metadataDiv.outerHTML);
 }
 
 function getSanitizedMetadataInnerHtml() {
   const liveMetadata = document.querySelector('main div.metadata');
   if (!liveMetadata) return '';
-  return getDACompatibleHtml(sanitizeMetadataClone(liveMetadata).innerHTML);
+  return getDACompatibleHtml(sanitizeMetadataBlockHtml(liveMetadata));
+}
+
+function refreshMetadataEditsFromLiveDom() {
+  const liveMetadata = document.querySelector('main div.metadata')
+    || document.querySelector('main .stream-metadata-section div.metadata');
+  if (!(liveMetadata instanceof HTMLElement)) return;
+
+  const sanitizedToHtml = sanitizeMetadataBlockHtml(liveMetadata);
+  annotationState.store.easyEdits = annotationState.store.easyEdits.map((edit) => {
+    if (edit?.elementPath !== 'metadata') return edit;
+    if (edit.editType !== 'text') return edit;
+    return { ...edit, toHtml: sanitizedToHtml };
+  });
 }
 
 const inlineEditing = createInlineEditingController({
@@ -934,7 +934,13 @@ export async function persistAnnotationChangesToDA(versionLabel = null) {
   await persistEditsToDb();
 }
 async function persistEditsToDb() {
-  const metadataChunk = buildMetadataChunkForSave();
+  let metadataChunk = buildMetadataChunkForSave();
+  if (metadataChunk && typeof metadataChunk.toHtml === 'string') {
+    metadataChunk = {
+      ...metadataChunk,
+      toHtml: sanitizeMetadataInnerHtml(metadataChunk.toHtml),
+    };
+  }
   const savePayload = store.buildSavePayload({ metadataChunk });
   const savedEditIds = savePayload.map((edit) => edit.id).filter(Boolean);
 
@@ -962,6 +968,7 @@ export async function saveAnnotationChanges(reportProgress = () => {}) {
   syncCachedMetadataFromLiveDom();
   await uploadAndDecideAssets();
   buildAssetReplacementsAndEdits((asset) => asset.daUrl);
+  refreshMetadataEditsFromLiveDom();
   await persistEditsToDb();
   reportProgress('editsSaved');
   requestParentCollabRefresh('edits-saved');

--- a/streamlibs/operations/annotation.js
+++ b/streamlibs/operations/annotation.js
@@ -93,12 +93,11 @@ commentsPanel.setImageRegenHandler(recordImageRegenAsLocalAsset);
 
 let cachedCleanHtml = '';
 let cachedMetadata = null;
+let cachedMetadataBaselineInnerHtml = '';
 const regenReplacements = [];
 
-function buildMetadataToHtml() {
-  const liveMetadata = document.querySelector('main div.metadata');
-  if (!liveMetadata) return '';
-  const clone = liveMetadata.cloneNode(true);
+function sanitizeMetadataClone(metadataEl) {
+  const clone = metadataEl.cloneNode(true);
   clone.querySelectorAll('picture').forEach((picture) => {
     const img = picture.querySelector('img');
     if (img) picture.replaceWith(img);
@@ -114,7 +113,19 @@ function buildMetadataToHtml() {
       .filter((attr) => attr.name.startsWith('data-'))
       .forEach((attr) => el.removeAttribute(attr.name));
   });
-  return getDACompatibleHtml(clone.outerHTML);
+  return clone;
+}
+
+function buildMetadataToHtml() {
+  const liveMetadata = document.querySelector('main div.metadata');
+  if (!liveMetadata) return '';
+  return getDACompatibleHtml(sanitizeMetadataClone(liveMetadata).outerHTML);
+}
+
+function getSanitizedMetadataInnerHtml() {
+  const liveMetadata = document.querySelector('main div.metadata');
+  if (!liveMetadata) return '';
+  return getDACompatibleHtml(sanitizeMetadataClone(liveMetadata).innerHTML);
 }
 
 const inlineEditing = createInlineEditingController({
@@ -149,8 +160,10 @@ function parseAndCacheCleanHtml(htmlDom) {
     cachedMetadata = document.createElement('div');
     cachedMetadata.className = 'metadata';
     cachedMetadata.innerHTML = combinedInnerHtml;
+    cachedMetadataBaselineInnerHtml = combinedInnerHtml;
   } else {
     cachedMetadata = null;
+    cachedMetadataBaselineInnerHtml = '';
   }
   cachedCleanHtml = htmlDom.innerHTML;
 }
@@ -180,6 +193,43 @@ function syncCachedMetadataFromLiveDom() {
   if (liveMetadata && cachedMetadata) {
     cachedMetadata.innerHTML = liveMetadata.innerHTML;
   }
+}
+
+function buildMetadataChunkForSave() {
+  if (!cachedMetadata) return null;
+
+  syncCachedMetadataFromLiveDom();
+  const fromHtml = cachedMetadataBaselineInnerHtml || '';
+  const toHtml = getSanitizedMetadataInnerHtml();
+  const hasMetadataEdits = (annotationState.store.easyEdits || []).some((edit) => {
+    if (!edit || edit.elementPath !== 'metadata') return false;
+    if ((edit.editType === 'image-src' || edit.editType === 'image-alt') && !edit.to) {
+      return false;
+    }
+    return edit.from !== edit.to || (edit.fromHtml || '') !== (edit.toHtml || '');
+  });
+  if (!hasMetadataEdits && fromHtml === toHtml) return null;
+
+  const existing = (annotationState.store.easyEdits || []).find(
+    (edit) => edit?.elementPath === 'metadata',
+  );
+  const segments = store.getChangedSegments(fromHtml, toHtml);
+
+  return {
+    id: existing?.id || store.generateId('easy-edit'),
+    editType: 'text',
+    elementPath: 'metadata',
+    blockClass: 'metadata',
+    elementProps: { blockClass: 'metadata' },
+    elementRef: '',
+    from: 'metadata',
+    to: 'metadata',
+    fromHtml,
+    toHtml,
+    changedFrom: segments.changedFrom,
+    changedTo: segments.changedTo,
+    updatedAt: new Date().toISOString(),
+  };
 }
 
 function attachMetadataAddRowControls(sectionEl) {
@@ -884,13 +934,18 @@ export async function persistAnnotationChangesToDA(versionLabel = null) {
   await persistEditsToDb();
 }
 async function persistEditsToDb() {
-  const savePayload = store.buildSavePayload();
+  const metadataChunk = buildMetadataChunkForSave();
+  const savePayload = store.buildSavePayload({ metadataChunk });
   const savedEditIds = savePayload.map((edit) => edit.id).filter(Boolean);
 
   if (annotationService.isAvailable()) {
     const persistedEditSnapshot = await annotationService.saveEdits(savePayload);
     if (persistedEditSnapshot) {
       store.clearChangeHistoryAfterSave(savedEditIds);
+      if (metadataChunk) {
+        store.collapseMetadataEasyEdits(metadataChunk);
+        cachedMetadataBaselineInnerHtml = metadataChunk.toHtml;
+      }
       annotationState.latestSavedEditsUpdatedAt = persistedEditSnapshot.updatedAt
         || persistedEditSnapshot.createdAt
         || null;

--- a/streamlibs/operations/annotation.js
+++ b/streamlibs/operations/annotation.js
@@ -201,7 +201,11 @@ const DEFAULT_METADATA_PLACEHOLDER_IMG = 'https://main--stream-mapper--adobecom.
 function syncCachedMetadataFromLiveDom() {
   const liveMetadata = getLiveMetadataElement();
   if (liveMetadata && cachedMetadata) {
-    cachedMetadata.innerHTML = liveMetadata.innerHTML;
+    const clone = liveMetadata.cloneNode(true);
+    if (clone instanceof HTMLElement) {
+      clone.querySelectorAll('.stream-annotation-metadata-row-delete').forEach((btn) => btn.remove());
+      cachedMetadata.innerHTML = clone.innerHTML;
+    }
   }
 }
 
@@ -243,14 +247,107 @@ function buildMetadataChunkForSave() {
   };
 }
 
+function collectMetadataElementRefs(rootEl) {
+  if (!(rootEl instanceof HTMLElement)) return [];
+  const refs = new Set();
+  rootEl.querySelectorAll('[data-annotation-ref]').forEach((el) => {
+    const ref = el.dataset.annotationRef;
+    if (ref) refs.add(ref);
+  });
+  rootEl.querySelectorAll('p, img').forEach((el) => {
+    if (!(el instanceof HTMLElement)) return;
+    store.ensureElementRef(el);
+    const ref = el.dataset.annotationRef;
+    if (ref) refs.add(ref);
+  });
+  return [...refs];
+}
+
+function deleteMetadataRow(rowEl) {
+  if (!(rowEl instanceof HTMLElement)) return;
+  const metadataDom = rowEl.parentElement;
+  if (!(metadataDom instanceof HTMLElement) || !metadataDom.classList.contains('metadata')) return;
+
+  const refs = collectMetadataElementRefs(rowEl);
+  inlineEditing.unregisterElementsInSubtree(rowEl);
+  if (refs.length) {
+    store.pruneMetadataEasyEditsForElementRefs(refs);
+    const refSet = new Set(refs);
+    annotationState.store.assets = (annotationState.store.assets || []).filter(
+      (asset) => !refSet.has(asset.elementRef),
+    );
+  }
+
+  rowEl.remove();
+  syncCachedMetadataFromLiveDom();
+  store.saveAnnotationStore();
+  commentsPanel.renderThreadMarkers({ resolveTargets: true });
+  commentsPanel.renderCommentsPanel();
+}
+
+function createMetadataRowDeleteButton(rowEl) {
+  const btn = document.createElement('button');
+  btn.type = 'button';
+  btn.className = 'stream-annotation-metadata-row-delete';
+  btn.setAttribute('aria-label', 'Delete metadata row');
+  btn.innerHTML = '<svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="3 6 5 6 21 6"/><path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"/><path d="M10 11v6"/><path d="M14 11v6"/><path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2"/></svg>';
+  btn.addEventListener('click', (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+    deleteMetadataRow(rowEl);
+  });
+  return btn;
+}
+
+function getMetadataRowValueCell(rowEl) {
+  if (!(rowEl instanceof HTMLElement)) return null;
+  const cells = [...rowEl.children].filter(
+    (child) => child instanceof HTMLElement
+      && !child.classList.contains('stream-annotation-metadata-row-delete'),
+  );
+  return cells[cells.length - 1] || null;
+}
+
+function attachMetadataRowDeleteButton(rowEl) {
+  if (!(rowEl instanceof HTMLElement)) return;
+  rowEl.classList.add('stream-annotation-metadata-row');
+  rowEl.querySelector('.stream-annotation-metadata-row-delete')?.remove();
+
+  const cells = [...rowEl.children].filter(
+    (child) => child instanceof HTMLElement
+      && !child.classList.contains('stream-annotation-metadata-row-delete'),
+  );
+  const keyCell = cells[0];
+  const valueCell = cells[cells.length - 1];
+
+  if (keyCell instanceof HTMLElement) {
+    keyCell.classList.add('stream-annotation-metadata-key-cell');
+  }
+  if (!(valueCell instanceof HTMLElement)) return;
+  valueCell.classList.add('stream-annotation-metadata-value-cell');
+  valueCell.append(createMetadataRowDeleteButton(rowEl));
+}
+
+function attachMetadataRowDeleteButtons(metadataDom) {
+  if (!(metadataDom instanceof HTMLElement)) return;
+  metadataDom.querySelectorAll('.stream-annotation-metadata-row-delete').forEach((btn) => btn.remove());
+  [...metadataDom.children].forEach((child) => {
+    if (!(child instanceof HTMLElement)) return;
+    if (child.classList.contains('stream-annotation-metadata-row-delete')) return;
+    attachMetadataRowDeleteButton(child);
+  });
+}
+
 function attachMetadataAddRowControls(sectionEl) {
   const metadataDom = sectionEl?.querySelector('div.metadata');
   if (!metadataDom) return;
 
   sectionEl.querySelectorAll('.stream-annotation-metadata-actions').forEach((el) => el.remove());
+  attachMetadataRowDeleteButtons(metadataDom);
 
   const addAndRegisterRow = (row) => {
     metadataDom.append(row);
+    attachMetadataRowDeleteButton(row);
     row.querySelectorAll('p').forEach((p) => inlineEditing.registerNewEditableElement(p));
     syncCachedMetadataFromLiveDom();
   };

--- a/streamlibs/operations/annotation.js
+++ b/streamlibs/operations/annotation.js
@@ -21,6 +21,7 @@ import createAssetsPanelController from './annotation/assets-panel.js';
 import {
   sanitizeMetadataInnerHtml,
   sanitizeMetadataBlockHtml,
+  restoreMetadataImageUrlsOnLiveDom,
 } from './annotation/metadata-sanitize.js';
 import requestParentCollabRefresh from './annotation/collab-sync.js';
 import { handleError } from '../utils/error-handler.js';
@@ -100,8 +101,12 @@ let cachedMetadata = null;
 let cachedMetadataBaselineInnerHtml = '';
 const regenReplacements = [];
 
+function getLiveMetadataElement() {
+  return document.querySelector('main .stream-metadata-section div.metadata');
+}
+
 function buildMetadataToHtml() {
-  const liveMetadata = document.querySelector('main div.metadata');
+  const liveMetadata = getLiveMetadataElement();
   if (!liveMetadata) return '';
   const metadataDiv = document.createElement('div');
   metadataDiv.className = 'metadata';
@@ -110,22 +115,27 @@ function buildMetadataToHtml() {
 }
 
 function getSanitizedMetadataInnerHtml() {
-  const liveMetadata = document.querySelector('main div.metadata');
+  const liveMetadata = getLiveMetadataElement();
   if (!liveMetadata) return '';
   return getDACompatibleHtml(sanitizeMetadataBlockHtml(liveMetadata));
 }
 
-function refreshMetadataEditsFromLiveDom() {
-  const liveMetadata = document.querySelector('main div.metadata')
-    || document.querySelector('main .stream-metadata-section div.metadata');
-  if (!(liveMetadata instanceof HTMLElement)) return;
+/** After asset upload — PR #197: replace preview base64 with final CDN URLs before Save/Push. */
+function prepareLiveMetadataForPersist() {
+  const liveMetadata = getLiveMetadataElement();
+  if (!liveMetadata) return;
 
-  const sanitizedToHtml = sanitizeMetadataBlockHtml(liveMetadata);
-  annotationState.store.easyEdits = annotationState.store.easyEdits.map((edit) => {
-    if (edit?.elementPath !== 'metadata') return edit;
-    if (edit.editType !== 'text') return edit;
-    return { ...edit, toHtml: sanitizedToHtml };
+  (annotationState.store.easyEdits || []).forEach((edit) => {
+    if (edit?.elementPath !== 'metadata' || edit.editType !== 'image-src' || !edit.to) return;
+    const el = edit.elementRef
+      ? liveMetadata.querySelector(`[data-annotation-ref="${edit.elementRef}"]`)
+      : null;
+    const img = el?.tagName === 'IMG' ? el : el?.querySelector('img');
+    if (!(img instanceof HTMLImageElement)) return;
+    img.setAttribute('data-stream-original-src', edit.to);
   });
+
+  restoreMetadataImageUrlsOnLiveDom(liveMetadata);
 }
 
 const inlineEditing = createInlineEditingController({
@@ -189,7 +199,7 @@ function waitForMiloPageLoad(timeoutMs = 15000) {
 const DEFAULT_METADATA_PLACEHOLDER_IMG = 'https://main--stream-mapper--adobecom.aem.live/assets/media_1bf6f8fe5a340bb3f4e022b300d7013821fe5ff89.png';
 
 function syncCachedMetadataFromLiveDom() {
-  const liveMetadata = document.querySelector('main .stream-metadata-section div.metadata');
+  const liveMetadata = getLiveMetadataElement();
   if (liveMetadata && cachedMetadata) {
     cachedMetadata.innerHTML = liveMetadata.innerHTML;
   }
@@ -198,8 +208,9 @@ function syncCachedMetadataFromLiveDom() {
 function buildMetadataChunkForSave() {
   if (!cachedMetadata) return null;
 
+  prepareLiveMetadataForPersist();
   syncCachedMetadataFromLiveDom();
-  const fromHtml = cachedMetadataBaselineInnerHtml || '';
+  const fromHtml = sanitizeMetadataInnerHtml(cachedMetadataBaselineInnerHtml || '');
   const toHtml = getSanitizedMetadataInnerHtml();
   const hasMetadataEdits = (annotationState.store.easyEdits || []).some((edit) => {
     if (!edit || edit.elementPath !== 'metadata') return false;
@@ -302,10 +313,10 @@ async function injectMetadataSection(mainEl) {
   const imgResolves = [...metadataSection.querySelectorAll('img')].map(async (img) => {
     const originalSrc = img.getAttribute('src') || '';
     const resolved = await resolvePreviewUrl(originalSrc);
-    if (resolved && resolved !== originalSrc) {
-      img.setAttribute('data-stream-original-src', originalSrc);
-      img.setAttribute('src', resolved);
-    }
+    if (!resolved || resolved === originalSrc) return;
+    // PR #197 — keep DA URL for Save/Push; preview may use base64.
+    img.setAttribute('data-stream-original-src', originalSrc);
+    img.setAttribute('src', resolved);
   });
   const sourceResolves = [...metadataSection.querySelectorAll('source')].map(async (source) => {
     const originalSrcset = source.getAttribute('srcset') || '';
@@ -917,6 +928,8 @@ export async function persistAnnotationChangesToDA(versionLabel = null) {
   const assetReplacements = buildAssetReplacementsAndEdits(
     (asset) => asset.finalDaUrl || asset.daUrl,
   );
+  prepareLiveMetadataForPersist();
+  syncCachedMetadataFromLiveDom();
   const { daCompatibleHtml } = buildHtmlWithEditsAndAssets(assetReplacements);
 
   const cfg = window.streamConfig || {};
@@ -935,10 +948,15 @@ export async function persistAnnotationChangesToDA(versionLabel = null) {
 }
 async function persistEditsToDb() {
   let metadataChunk = buildMetadataChunkForSave();
-  if (metadataChunk && typeof metadataChunk.toHtml === 'string') {
+  if (metadataChunk) {
     metadataChunk = {
       ...metadataChunk,
-      toHtml: sanitizeMetadataInnerHtml(metadataChunk.toHtml),
+      ...(typeof metadataChunk.fromHtml === 'string'
+        ? { fromHtml: sanitizeMetadataInnerHtml(metadataChunk.fromHtml) }
+        : {}),
+      ...(typeof metadataChunk.toHtml === 'string'
+        ? { toHtml: sanitizeMetadataInnerHtml(metadataChunk.toHtml) }
+        : {}),
     };
   }
   const savePayload = store.buildSavePayload({ metadataChunk });
@@ -968,7 +986,8 @@ export async function saveAnnotationChanges(reportProgress = () => {}) {
   syncCachedMetadataFromLiveDom();
   await uploadAndDecideAssets();
   buildAssetReplacementsAndEdits((asset) => asset.daUrl);
-  refreshMetadataEditsFromLiveDom();
+  prepareLiveMetadataForPersist();
+  syncCachedMetadataFromLiveDom();
   await persistEditsToDb();
   reportProgress('editsSaved');
   requestParentCollabRefresh('edits-saved');

--- a/streamlibs/operations/annotation/annotation.css
+++ b/streamlibs/operations/annotation/annotation.css
@@ -2397,11 +2397,10 @@ body.editor-mode .figma-panel .has-block-action .block-action-btn.block-action-b
     outline-offset: 2px;
   }
 
-  .annotation-mode .stream-annotation-page-metadata {
+  .annotation-mode .stream-metadata-section {
     width: 100%;
     border-top: 2px dashed #ababab;
     margin-top: 10px;
-    background: #eff5ff;
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -2410,7 +2409,7 @@ body.editor-mode .figma-panel .has-block-action .block-action-btn.block-action-b
     padding-bottom: 50px;
   }
 
-  .annotation-mode .stream-annotation-page-metadata h3 {
+  .annotation-mode .stream-metadata-section h3 {
     display: flex;
     align-items: start;
     width: 80%;
@@ -2418,23 +2417,27 @@ body.editor-mode .figma-panel .has-block-action .block-action-btn.block-action-b
     color: #1d4ed8;
   }
 
-  .annotation-mode .page-metadata {
+  .annotation-mode .stream-metadata-section div.metadata,
+  .annotation-mode main .stream-metadata-section div.metadata {
     width: 80%;
     display: flex;
     flex-wrap: wrap;
   }
 
-  .annotation-mode .page-metadata > div {
+  .annotation-mode .stream-metadata-section div.metadata > div,
+  .annotation-mode main .stream-metadata-section div.metadata > div {
     display: flex;
     width: 100%;
     box-sizing: border-box;
   }
 
-  .annotation-mode .page-metadata > div > div:first-child {
+  .annotation-mode .stream-metadata-section div.metadata > div > div:first-child,
+  .annotation-mode main .stream-metadata-section div.metadata > div > div:first-child {
     font-weight: bold;
   }
 
-  .annotation-mode .page-metadata > div > div {
+  .annotation-mode .stream-metadata-section div.metadata > div > div,
+  .annotation-mode main .stream-metadata-section div.metadata > div > div {
     flex: 1 1 0;
     min-width: 0;
     border: 0.5px solid #cacaca;
@@ -2442,7 +2445,8 @@ body.editor-mode .figma-panel .has-block-action .block-action-btn.block-action-b
     padding-left: 20px;
   }
 
-  .annotation-mode .page-metadata > div > div img {
+  .annotation-mode .stream-metadata-section div.metadata > div > div img,
+  .annotation-mode main .stream-metadata-section div.metadata > div > div img {
     width: 100px;
     height: auto;
     max-width: 100px;
@@ -2476,7 +2480,7 @@ body.editor-mode .figma-panel .has-block-action .block-action-btn.block-action-b
     color: #fff;
   }
 
-  .page-metadata .annotation-asset-pending-badge {
+  .stream-metadata-section div.metadata .annotation-asset-pending-badge {
     display: none;
   }
 

--- a/streamlibs/operations/annotation/annotation.css
+++ b/streamlibs/operations/annotation/annotation.css
@@ -2420,15 +2420,14 @@ body.editor-mode .figma-panel .has-block-action .block-action-btn.block-action-b
   .annotation-mode .stream-metadata-section div.metadata,
   .annotation-mode main .stream-metadata-section div.metadata {
     width: 80%;
-    display: flex;
-    flex-wrap: wrap;
+    display: table;
+    border-collapse: collapse;
+    table-layout: fixed;
   }
 
   .annotation-mode .stream-metadata-section div.metadata > div,
   .annotation-mode main .stream-metadata-section div.metadata > div {
-    display: flex;
-    width: 100%;
-    box-sizing: border-box;
+    display: table-row;
   }
 
   .annotation-mode .stream-metadata-section div.metadata > div > div:first-child,
@@ -2438,11 +2437,13 @@ body.editor-mode .figma-panel .has-block-action .block-action-btn.block-action-b
 
   .annotation-mode .stream-metadata-section div.metadata > div > div,
   .annotation-mode main .stream-metadata-section div.metadata > div > div {
-    flex: 1 1 0;
-    min-width: 0;
+    display: table-cell;
+    vertical-align: top;
+    box-sizing: border-box;
     border: 0.5px solid #cacaca;
     padding: 10px;
     padding-left: 20px;
+    padding-right: 10px;
   }
 
   .annotation-mode .stream-metadata-section div.metadata > div > div img,
@@ -2478,6 +2479,50 @@ body.editor-mode .figma-panel .has-block-action .block-action-btn.block-action-b
   .annotation-inline-edit-mode .stream-annotation-add-metadata-row:hover {
     background: #3d63ae;
     color: #fff;
+  }
+
+  .annotation-mode .stream-metadata-section div.metadata > div > .stream-annotation-metadata-key-cell,
+  .annotation-mode .stream-metadata-section div.metadata > div > .stream-annotation-metadata-value-cell {
+    position: relative;
+  }
+
+  /* Reserve a consistent top strip for action icons in pencil mode */
+  .annotation-inline-edit-mode .stream-metadata-section div.metadata > div > div {
+    padding-top: 34px;
+    padding-bottom: 10px;
+  }
+
+  .annotation-inline-edit-mode .stream-metadata-section div.metadata > div > .stream-annotation-metadata-value-cell {
+    padding-right: 40px;
+  }
+
+  .annotation-mode .stream-metadata-section div.metadata .stream-annotation-metadata-row-delete {
+    display: none;
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    z-index: 2;
+    width: 24px;
+    height: 24px;
+    margin: 0;
+    padding: 0;
+    border: 1px solid #fca5a5;
+    border-radius: 6px;
+    background: #fef2f2;
+    color: #dc2626;
+    box-shadow: 0 1px 4px rgb(220 38 38 / 15%);
+    cursor: pointer;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .annotation-inline-edit-mode .stream-metadata-section div.metadata .stream-annotation-metadata-row-delete {
+    display: inline-flex;
+  }
+
+  .annotation-inline-edit-mode .stream-metadata-section div.metadata .stream-annotation-metadata-row-delete:hover {
+    background: #fee2e2;
+    border-color: #f87171;
   }
 
   .stream-metadata-section div.metadata .annotation-asset-pending-badge {

--- a/streamlibs/operations/annotation/assets-panel.js
+++ b/streamlibs/operations/annotation/assets-panel.js
@@ -447,7 +447,11 @@ export default function createAssetsPanelController({
       return;
     }
 
-    const originalSrc = targetImg.dataset.originalSrc || elementProps?.src || targetImg.src || '';
+    const originalSrc = targetImg.dataset.streamOriginalSrc
+      || targetImg.dataset.originalSrc
+      || elementProps?.src
+      || targetImg.src
+      || '';
 
     // Cache the absolute loaded URL so a page-relative originalSrc still renders.
     const fromDisplaySrc = targetImg.currentSrc || targetImg.src || '';
@@ -498,16 +502,21 @@ export default function createAssetsPanelController({
     const assetFileKey = store.generateId('asset-file');
     store.registerAssetFile(assetFileKey, file, base64Data);
     localAsset.assetFileKey = assetFileKey;
+    const isInMetadata = Boolean(targetImg.closest('main div.metadata'));
+    const metadataFields = isInMetadata ? store.metadataEasyEditFields(elementProps) : {};
     store.upsertEasyEdit({
       editType: 'image-src',
-      elementPath,
-      elementProps,
+      elementPath: isInMetadata ? 'metadata' : elementPath,
+      elementProps: metadataFields.elementProps || elementProps,
       elementRef,
-      from: originalSrc,
+      from: isInMetadata
+        ? (targetImg.getAttribute('data-stream-original-src') || originalSrc)
+        : originalSrc,
       to: '',
       fromHtml: '',
       toHtml: '',
       assetFileKey,
+      ...(metadataFields.blockClass ? { blockClass: metadataFields.blockClass } : {}),
     });
 
     applyAssetPreviewToImg(targetImg, base64Data, localAsset);
@@ -592,6 +601,15 @@ export default function createAssetsPanelController({
       // Store the attribute value (not the resolved .src property) so it
       // matches the literal src string in cachedCleanHtml for reliable lookup.
       targetImg.dataset.originalSrc = targetImg.getAttribute('src') || targetImg.src;
+    }
+    if (targetImg.closest('main div.metadata') && !targetImg.getAttribute('data-stream-original-src')) {
+      targetImg.setAttribute(
+        'data-stream-original-src',
+        targetImg.getAttribute('data-stream-original-src')
+          || targetImg.dataset.originalSrc
+          || targetImg.getAttribute('src')
+          || '',
+      );
     }
 
     targetImg.src = base64Data;

--- a/streamlibs/operations/annotation/assets-panel.js
+++ b/streamlibs/operations/annotation/assets-panel.js
@@ -612,8 +612,12 @@ export default function createAssetsPanelController({
       );
     }
 
+    targetImg.setAttribute('src', base64Data);
     targetImg.src = base64Data;
-    if (targetImg.srcset) targetImg.srcset = base64Data;
+    if (targetImg.srcset) {
+      targetImg.setAttribute('srcset', base64Data);
+      targetImg.srcset = base64Data;
+    }
 
     const pictureEl = targetImg.closest('picture');
     if (pictureEl) {
@@ -810,7 +814,13 @@ export default function createAssetsPanelController({
             targetImg: applied.targetImg,
           });
           if (applied.targetImg && asset.daUrl) {
-            applied.targetImg.dataset.streamOriginalSrc = asset.daUrl;
+            const { targetImg } = applied;
+            targetImg.setAttribute('data-stream-original-src', asset.daUrl);
+            const inMetadata = targetImg.closest('main div.metadata');
+            if (inMetadata) {
+              targetImg.setAttribute('src', asset.daUrl);
+              targetImg.removeAttribute('srcset');
+            }
           }
         }
 

--- a/streamlibs/operations/annotation/comments-panel.js
+++ b/streamlibs/operations/annotation/comments-panel.js
@@ -1828,6 +1828,43 @@ export default function createCommentsPanelController({
     });
     clearMarkers();
 
+    const METADATA_DELETE_MARKER_RESERVE = 32;
+    const METADATA_CELL_PADDING_TOP = 10;
+
+    const getMarkerAnchorForTarget = (targetEl) => {
+      if (!(targetEl instanceof Element)) {
+        return { anchorEl: targetEl, leftOffset: 0, alignTopWithCell: false };
+      }
+      const metadataRow = targetEl.closest('.stream-metadata-section div.metadata > div');
+      if (!(metadataRow instanceof HTMLElement)) {
+        return { anchorEl: targetEl, leftOffset: 0, alignTopWithCell: false };
+      }
+
+      const valueCell = targetEl.closest('.stream-annotation-metadata-value-cell');
+      if (valueCell instanceof HTMLElement) {
+        return {
+          anchorEl: valueCell,
+          leftOffset: METADATA_DELETE_MARKER_RESERVE,
+          alignTopWithCell: true,
+        };
+      }
+
+      const keyCell = targetEl.closest('.stream-annotation-metadata-key-cell');
+      if (keyCell instanceof HTMLElement) {
+        return {
+          anchorEl: keyCell,
+          leftOffset: 0,
+          alignTopWithCell: true,
+        };
+      }
+
+      return { anchorEl: targetEl, leftOffset: 0, alignTopWithCell: false };
+    };
+
+    const getMarkerTop = (rect, alignTopWithCell) => (
+      alignTopWithCell ? rect.top + METADATA_CELL_PADDING_TOP : rect.top - 8
+    );
+
     const resolveMarkerPosition = (baseTop, baseLeft) => {
       const row = Math.max(0, Math.round(baseTop));
       let nextLeft = Math.max(MIN_MARKER_LEFT, Math.round(baseLeft));
@@ -1890,7 +1927,8 @@ export default function createCommentsPanelController({
         const targetEl = getCachedThreadTarget(thread);
         if (!targetEl) return;
 
-        const rect = targetEl.getBoundingClientRect();
+        const { anchorEl, leftOffset, alignTopWithCell } = getMarkerAnchorForTarget(targetEl);
+        const rect = anchorEl.getBoundingClientRect();
         if (rect.bottom < 0 || rect.top > window.innerHeight) return;
 
         const groups = buildCommentGroups(thread);
@@ -1910,8 +1948,8 @@ export default function createCommentsPanelController({
           `;
 
           const position = resolveMarkerPosition(
-            rect.top - 8,
-            rect.right - 8 - (idx * MARKER_STEP),
+            getMarkerTop(rect, alignTopWithCell),
+            rect.right - 8 - (idx * MARKER_STEP) - leftOffset,
           );
           marker.style.top = `${position.top}px`;
           marker.style.left = `${position.left}px`;
@@ -1933,10 +1971,14 @@ export default function createCommentsPanelController({
         if (!el) return;
         const targetImg = el.tagName === 'IMG' ? el : el.querySelector('img');
         const targetEl = targetImg || el;
-        const rect = targetEl.getBoundingClientRect();
+        const { anchorEl, leftOffset, alignTopWithCell } = getMarkerAnchorForTarget(targetEl);
+        const rect = anchorEl.getBoundingClientRect();
         if (rect.bottom < 0 || rect.top > window.innerHeight) return;
 
-        const position = resolveMarkerPosition(rect.top - 8, rect.right - 8);
+        const position = resolveMarkerPosition(
+          getMarkerTop(rect, alignTopWithCell),
+          rect.right - 8 - leftOffset,
+        );
         const marker = document.createElement('button');
         marker.type = 'button';
         marker.className = 'annotation-asset-marker';

--- a/streamlibs/operations/annotation/inline-editing.js
+++ b/streamlibs/operations/annotation/inline-editing.js
@@ -232,8 +232,9 @@ export default function createInlineEditingController({
       return;
     }
 
+    const isInMetadata = Boolean(element.closest('main div.metadata'));
     const editAnchor = store.buildEditElementAnchor(element, annotationUI.mainEl);
-    const easyEditElementPath = editAnchor.elementPath;
+    const easyEditElementPath = isInMetadata ? 'metadata' : editAnchor.elementPath;
     const existing = store.getEasyEditByElement(
       elementRef,
       easyEditElementPath,
@@ -248,17 +249,21 @@ export default function createInlineEditingController({
     const baselineText = existing?.from ?? stampedOriginal?.from ?? snapshot.originalText;
     const baselineHtml = existing?.fromHtml ?? stampedOriginal?.fromHtml ?? snapshot.originalHtml;
     const segments = store.getChangedSegments(baselineText, currentText);
+    const metadataFields = isInMetadata
+      ? store.metadataEasyEditFields(editAnchor.elementProps)
+      : {};
     const editRecord = {
       id: existing?.id || store.generateId('easy-edit'),
       editType: 'text',
       attrName: '',
       elementPath: easyEditElementPath,
-      elementProps: editAnchor.elementProps,
+      elementProps: metadataFields.elementProps || editAnchor.elementProps,
       elementRef,
       from: baselineText,
       to: currentText,
       fromHtml: baselineHtml,
       toHtml: currentHtml,
+      ...(metadataFields.blockClass ? { blockClass: metadataFields.blockClass } : {}),
       changedFrom: segments.changedFrom,
       changedTo: segments.changedTo,
       updatedAt: new Date().toISOString(),
@@ -322,7 +327,8 @@ export default function createInlineEditingController({
 
     const elementRef = store.ensureElementRef(imageElement);
     const editAnchor = store.buildEditElementAnchor(imageElement, annotationUI.mainEl);
-    const easyEditElementPath = editAnchor.elementPath;
+    const isInMetadata = Boolean(imageElement.closest('main div.metadata'));
+    const easyEditElementPath = isInMetadata ? 'metadata' : editAnchor.elementPath;
     const snapshotAlt = annotationUI.inlineImageAltSnapshot.get(elementRef);
     const originalAlt = snapshotAlt !== undefined ? `${snapshotAlt}` : (imageElement.getAttribute('alt') || '');
     const currentAlt = `${imageElement.getAttribute('alt') || ''}`;
@@ -333,12 +339,15 @@ export default function createInlineEditingController({
       easyEditElementPath,
       editAnchor.elementProps,
     );
+    const metadataFields = isInMetadata
+      ? store.metadataEasyEditFields(editAnchor.elementProps)
+      : {};
     const editRecord = {
       id: existing?.id || store.generateId('easy-edit'),
       editType: 'image-alt',
       attrName: 'alt',
       elementPath: easyEditElementPath,
-      elementProps: editAnchor.elementProps,
+      elementProps: metadataFields.elementProps || editAnchor.elementProps,
       elementRef,
       from: originalAlt,
       to: currentAlt,
@@ -347,6 +356,7 @@ export default function createInlineEditingController({
       changedFrom: originalAlt,
       changedTo: currentAlt,
       updatedAt: new Date().toISOString(),
+      ...(metadataFields.blockClass ? { blockClass: metadataFields.blockClass } : {}),
     };
     const persistedEdit = store.upsertEasyEdit(editRecord);
     annotationUI.inlineImageAltSnapshot.set(elementRef, currentAlt);

--- a/streamlibs/operations/annotation/inline-editing.js
+++ b/streamlibs/operations/annotation/inline-editing.js
@@ -688,6 +688,51 @@ export default function createInlineEditingController({
     store.saveAnnotationStore();
   }
 
+  function detachInlineElementHandlers(element) {
+    if (!(element instanceof HTMLElement)) return;
+    const elementRef = element.dataset.annotationRef;
+    if (!elementRef) return;
+    const focusHandler = annotationUI.inlineFocusHandlers.get(elementRef);
+    const blurHandler = annotationUI.inlineBlurHandlers.get(elementRef);
+    if (focusHandler) {
+      element.removeEventListener('focus', focusHandler, true);
+      element.removeEventListener('click', focusHandler, true);
+      annotationUI.inlineFocusHandlers.delete(elementRef);
+    }
+    if (blurHandler) {
+      element.removeEventListener('blur', blurHandler, true);
+      annotationUI.inlineBlurHandlers.delete(elementRef);
+    }
+    element.classList.remove('annotation-inline-editable', 'annotation-inline-editable-image');
+    annotationUI.inlineElementSnapshot.delete(elementRef);
+    annotationUI.inlineImageAltSnapshot.delete(elementRef);
+    clearExplicitFormattingIntent(elementRef);
+    annotationUI.editableElements = annotationUI.editableElements.filter((el) => el !== element);
+    annotationUI.editableImages = annotationUI.editableImages.filter((el) => el !== element);
+  }
+
+  function unregisterElementsInSubtree(rootEl) {
+    if (!(rootEl instanceof HTMLElement)) return;
+    const tracked = new Set();
+    rootEl.querySelectorAll('[data-annotation-ref]').forEach((el) => {
+      if (el instanceof HTMLElement) tracked.add(el);
+    });
+    rootEl.querySelectorAll('p, img').forEach((el) => {
+      if (!(el instanceof HTMLElement)) return;
+      store.ensureElementRef(el);
+      tracked.add(el);
+    });
+    const elements = [...tracked];
+    if (elements.length && annotationUI.mediumEditorInstance?.removeElements) {
+      try {
+        annotationUI.mediumEditorInstance.removeElements(elements);
+      } catch {
+        // Element may already be detached from MediumEditor.
+      }
+    }
+    elements.forEach(detachInlineElementHandlers);
+  }
+
   function registerNewEditableElement(element) {
     if (!annotationUI.inlineMode || !annotationUI.mediumEditorInstance) return;
     if (!(element instanceof HTMLElement) || isInsideStreamFragment(element)) return;
@@ -712,6 +757,7 @@ export default function createInlineEditingController({
     disableInlineEditMode,
     enableInlineEditMode,
     registerNewEditableElement,
+    unregisterElementsInSubtree,
     resetInlineEditModeState,
     syncInlineEditsBeforePersist,
   };

--- a/streamlibs/operations/annotation/metadata-sanitize.js
+++ b/streamlibs/operations/annotation/metadata-sanitize.js
@@ -76,7 +76,7 @@ export function sanitizeMetadataInnerHtml(htmlString) {
   return sanitizeMetadataHtmlRoot(wrapper).innerHTML;
 }
 
-/** PR #197 parity — restore CDN URLs on live metadata imgs before Save/Push. */
+
 export function restoreMetadataImageUrlsOnLiveDom(metadataRoot) {
   if (!(metadataRoot instanceof HTMLElement)) return;
   metadataRoot.querySelectorAll('img').forEach((img) => {

--- a/streamlibs/operations/annotation/metadata-sanitize.js
+++ b/streamlibs/operations/annotation/metadata-sanitize.js
@@ -24,14 +24,30 @@ export function sanitizeMetadataHtmlRoot(root) {
 
   root.querySelectorAll('picture').forEach((picture) => {
     const img = picture.querySelector('img');
-    if (img) picture.replaceWith(img);
-    else picture.remove();
+    if (img) {
+      const sourceOriginal = picture.querySelector('source')?.getAttribute('data-stream-original-srcset')
+        || picture.querySelector('source')?.getAttribute('data-stream-original-src')
+        || '';
+      const fallbackSrc = `${sourceOriginal}`.split(/[\s,]/).find((part) => part && !part.startsWith('data:'));
+      if (fallbackSrc && !img.getAttribute('data-stream-original-src')) {
+        img.setAttribute('data-stream-original-src', fallbackSrc);
+      }
+      picture.replaceWith(img);
+    } else {
+      picture.remove();
+    }
   });
 
   root.querySelectorAll('img').forEach((img) => {
     const persistSrc = resolvePersistableImgSrc(img);
-    if (persistSrc) img.setAttribute('src', persistSrc);
-    else img.removeAttribute('src');
+    if (persistSrc) {
+      img.setAttribute('src', persistSrc);
+      img.src = persistSrc;
+    } else {
+      img.removeAttribute('src');
+      img.removeAttribute('srcset');
+      img.src = '';
+    }
 
     const srcset = img.getAttribute('srcset') || '';
     if (!srcset || srcset.startsWith('data:') || srcset.includes('base64')) {
@@ -58,4 +74,20 @@ export function sanitizeMetadataInnerHtml(htmlString) {
   const wrapper = document.createElement('div');
   wrapper.innerHTML = htmlString || '';
   return sanitizeMetadataHtmlRoot(wrapper).innerHTML;
+}
+
+/** PR #197 parity — restore CDN URLs on live metadata imgs before Save/Push. */
+export function restoreMetadataImageUrlsOnLiveDom(metadataRoot) {
+  if (!(metadataRoot instanceof HTMLElement)) return;
+  metadataRoot.querySelectorAll('img').forEach((img) => {
+    const persistSrc = resolvePersistableImgSrc(img);
+    if (!persistSrc) return;
+    img.setAttribute('src', persistSrc);
+    img.src = persistSrc;
+    img.removeAttribute('srcset');
+    const picture = img.closest('picture');
+    if (picture) {
+      picture.querySelectorAll('source').forEach((source) => source.remove());
+    }
+  });
 }

--- a/streamlibs/operations/annotation/metadata-sanitize.js
+++ b/streamlibs/operations/annotation/metadata-sanitize.js
@@ -77,6 +77,23 @@ export function sanitizeMetadataInnerHtml(htmlString) {
 }
 
 
+export async function resolveMetadataImagesForPreview(metadataRoot, resolvePreviewUrl) {
+  if (!(metadataRoot instanceof HTMLElement) || typeof resolvePreviewUrl !== 'function') return;
+  await Promise.all([...metadataRoot.querySelectorAll('img')].map(async (img) => {
+    const originalSrc = img.getAttribute('data-stream-original-src') || img.getAttribute('src') || '';
+    if (!originalSrc || originalSrc.startsWith('data:')) return;
+    const resolved = await resolvePreviewUrl(originalSrc);
+    if (!resolved || resolved === originalSrc) return;
+    img.setAttribute('data-stream-original-src', originalSrc);
+    img.setAttribute('src', resolved);
+    img.removeAttribute('srcset');
+    const picture = img.closest('picture');
+    if (picture) {
+      picture.querySelectorAll('source').forEach((source) => source.remove());
+    }
+  }));
+}
+
 export function restoreMetadataImageUrlsOnLiveDom(metadataRoot) {
   if (!(metadataRoot instanceof HTMLElement)) return;
   metadataRoot.querySelectorAll('img').forEach((img) => {

--- a/streamlibs/operations/annotation/metadata-sanitize.js
+++ b/streamlibs/operations/annotation/metadata-sanitize.js
@@ -1,0 +1,61 @@
+/* eslint-disable no-restricted-syntax */
+
+function resolvePersistableImgSrc(img) {
+  const daSrc = img.getAttribute('data-stream-original-src')
+    || img.getAttribute('data-original-src')
+    || img.dataset?.originalSrc
+    || '';
+  const currentSrc = img.getAttribute('src') || '';
+
+  if (daSrc && !daSrc.startsWith('data:')) return daSrc;
+  if (currentSrc && !currentSrc.startsWith('data:')) return currentSrc;
+  if (daSrc) return daSrc;
+  return '';
+}
+
+export function sanitizeMetadataHtmlRoot(root) {
+  if (!(root instanceof HTMLElement)) return root;
+
+  root.querySelectorAll('.stream-annotation-metadata-row-delete').forEach((b) => b.remove());
+
+  root.querySelectorAll('p').forEach((p) => {
+    [...p.attributes].forEach((attr) => p.removeAttribute(attr.name));
+  });
+
+  root.querySelectorAll('picture').forEach((picture) => {
+    const img = picture.querySelector('img');
+    if (img) picture.replaceWith(img);
+    else picture.remove();
+  });
+
+  root.querySelectorAll('img').forEach((img) => {
+    const persistSrc = resolvePersistableImgSrc(img);
+    if (persistSrc) img.setAttribute('src', persistSrc);
+    else img.removeAttribute('src');
+
+    const srcset = img.getAttribute('srcset') || '';
+    if (!srcset || srcset.startsWith('data:') || srcset.includes('base64')) {
+      img.removeAttribute('srcset');
+    }
+
+    [...img.attributes]
+      .filter((attr) => attr.name.startsWith('data-'))
+      .forEach((attr) => img.removeAttribute(attr.name));
+  });
+
+  root.querySelectorAll('source').forEach((s) => s.remove());
+
+  return root;
+}
+
+export function sanitizeMetadataBlockHtml(blockEl) {
+  if (!(blockEl instanceof HTMLElement)) return '';
+  const clone = blockEl.cloneNode(true);
+  return sanitizeMetadataHtmlRoot(clone).innerHTML;
+}
+
+export function sanitizeMetadataInnerHtml(htmlString) {
+  const wrapper = document.createElement('div');
+  wrapper.innerHTML = htmlString || '';
+  return sanitizeMetadataHtmlRoot(wrapper).innerHTML;
+}

--- a/streamlibs/operations/annotation/store.js
+++ b/streamlibs/operations/annotation/store.js
@@ -1334,22 +1334,6 @@ export function createAnnotationStore({ annotationState, annotationUI }) {
     rebuildEditThreadsFromEasyEdits();
   }
 
-  /*function isBloatedMetadataHtml(html) {
-    const value = `${html || ''}`;
-    if (!value) return false;
-    if (value.length > 4096) return true;
-    return /\bclass=["']metadata["']/.test(value)
-      || value.includes('<div class="metadata"');
-  }*/
-
-  function trimMetadataEditForSave(edit) {
-    if (!edit || edit.elementPath !== 'metadata') return edit;
-    const fromHtml = isBloatedMetadataHtml(edit.fromHtml) ? '' : `${edit.fromHtml || ''}`;
-    const toHtml = isBloatedMetadataHtml(edit.toHtml) ? '' : `${edit.toHtml || ''}`;
-    if (fromHtml === edit.fromHtml && toHtml === edit.toHtml) return edit;
-    return { ...edit, fromHtml, toHtml };
-  }
-
   function metadataEasyEditFields(elementProps = {}) {
     return {
       blockClass: 'metadata',
@@ -1357,10 +1341,23 @@ export function createAnnotationStore({ annotationState, annotationUI }) {
     };
   }
 
-  function buildSavePayload() {
-    return annotationState.store.easyEdits
+  function collapseMetadataEasyEdits(metadataChunk) {
+    if (!metadataChunk || typeof metadataChunk !== 'object') return;
+    const nonMetadata = annotationState.store.easyEdits.filter(
+      (edit) => edit?.elementPath !== 'metadata',
+    );
+    annotationState.store.easyEdits = [
+      ...nonMetadata,
+      { ...normalizeEasyEdit(metadataChunk), isCommitted: true },
+    ];
+    rebuildEditThreadsFromEasyEdits();
+  }
+
+  function buildSavePayload({ metadataChunk = null } = {}) {
+    const pending = annotationState.store.easyEdits
       .filter((edit) => {
         if (!edit) return false;
+        if (edit.elementPath === 'metadata') return false;
         // Don't persist a pending asset edit that hasn't been assigned a URL yet.
         if ((edit.editType === 'image-src' || edit.editType === 'image-alt') && !edit.to) {
           return false;
@@ -1369,8 +1366,15 @@ export function createAnnotationStore({ annotationState, annotationUI }) {
       })
       .map((edit) => {
         const { changeHistory, assetFileKey, ...rest } = edit;
-        return trimMetadataEditForSave(rest);
+        return rest;
       });
+
+    if (metadataChunk) {
+      const { changeHistory, assetFileKey, ...rest } = metadataChunk;
+      pending.push(rest);
+    }
+
+    return pending;
   }
 
   function replaceEasyEdits(nextEasyEdits = []) {
@@ -1626,6 +1630,7 @@ export function createAnnotationStore({ annotationState, annotationUI }) {
     undoLastChange,
     clearChangeHistoryAfterSave,
     buildSavePayload,
+    collapseMetadataEasyEdits,
     metadataEasyEditFields,
   };
 }

--- a/streamlibs/operations/annotation/store.js
+++ b/streamlibs/operations/annotation/store.js
@@ -1351,6 +1351,20 @@ export function createAnnotationStore({ annotationState, annotationUI }) {
     return false;
   }
 
+  function pruneMetadataEasyEditsForElementRefs(elementRefs = []) {
+    const refSet = new Set((elementRefs || []).filter(Boolean));
+    if (!refSet.size) return;
+    const beforeCount = annotationState.store.easyEdits.length;
+    annotationState.store.easyEdits = annotationState.store.easyEdits.filter((edit) => {
+      if (!edit || edit.elementPath !== 'metadata') return true;
+      if (!edit.elementRef) return true;
+      return !refSet.has(edit.elementRef);
+    });
+    if (annotationState.store.easyEdits.length !== beforeCount) {
+      rebuildEditThreadsFromEasyEdits();
+    }
+  }
+
   function collapseMetadataEasyEdits(metadataChunk) {
     if (!metadataChunk || typeof metadataChunk !== 'object') return;
     const nonMetadata = annotationState.store.easyEdits.filter(
@@ -1642,6 +1656,7 @@ export function createAnnotationStore({ annotationState, annotationUI }) {
     clearChangeHistoryAfterSave,
     buildSavePayload,
     collapseMetadataEasyEdits,
+    pruneMetadataEasyEditsForElementRefs,
     metadataEasyEditFields,
   };
 }

--- a/streamlibs/operations/annotation/store.js
+++ b/streamlibs/operations/annotation/store.js
@@ -1341,10 +1341,20 @@ export function createAnnotationStore({ annotationState, annotationUI }) {
     };
   }
 
+  function isLegacyMetadataEdit(edit) {
+    if (!edit) return false;
+    if (edit.editType === 'metadata-block') return true;
+    const blockClass = `${edit.blockClass || edit.elementProps?.blockClass || ''}`;
+    if (blockClass === 'page-metadata') return true;
+    const blockSelector = `${edit.blockSelector || ''}`;
+    if (blockSelector.includes('page-metadata')) return true;
+    return false;
+  }
+
   function collapseMetadataEasyEdits(metadataChunk) {
     if (!metadataChunk || typeof metadataChunk !== 'object') return;
     const nonMetadata = annotationState.store.easyEdits.filter(
-      (edit) => edit?.elementPath !== 'metadata',
+      (edit) => edit?.elementPath !== 'metadata' && !isLegacyMetadataEdit(edit),
     );
     annotationState.store.easyEdits = [
       ...nonMetadata,
@@ -1358,6 +1368,7 @@ export function createAnnotationStore({ annotationState, annotationUI }) {
       .filter((edit) => {
         if (!edit) return false;
         if (edit.elementPath === 'metadata') return false;
+        if (isLegacyMetadataEdit(edit)) return false;
         // Don't persist a pending asset edit that hasn't been assigned a URL yet.
         if ((edit.editType === 'image-src' || edit.editType === 'image-alt') && !edit.to) {
           return false;

--- a/streamlibs/operations/annotation/store.js
+++ b/streamlibs/operations/annotation/store.js
@@ -494,6 +494,7 @@ export function createAnnotationStore({ annotationState, annotationUI }) {
     const origMainEl = origWrapper.querySelector('main');
     effectiveEdits.forEach((edit) => {
       if (!edit || typeof edit !== 'object') return;
+      if (edit.elementPath === 'metadata') return;
 
       if (edit.editType === 'image-src') {
         const fromSrc = `${edit.from || ''}`;
@@ -1162,6 +1163,13 @@ export function createAnnotationStore({ annotationState, annotationUI }) {
 
   function getElementForEdit(edit) {
     if (!annotationUI.mainEl) return null;
+    if (edit.elementRef) {
+      const byRef = getElementByRef(edit.elementRef);
+      if (byRef instanceof HTMLElement) return byRef;
+    }
+    if (edit.elementPath === 'metadata') {
+      return annotationUI.mainEl.querySelector('div.metadata');
+    }
     if (!edit.elementPath && !Object.keys(edit.elementProps || {}).length) {
       return edit.elementRef ? getElementByRef(edit.elementRef) : null;
     }
@@ -1287,7 +1295,7 @@ export function createAnnotationStore({ annotationState, annotationUI }) {
     const edit = annotationState.store.easyEdits[index];
     const history = Array.isArray(edit.changeHistory) ? [...edit.changeHistory] : [];
 
-   if (!history.length && edit.from === edit.to) return null;
+    if (!history.length && edit.from === edit.to) return null;
     if (!history.length && edit.isCommitted) return null;
 
     let previousTo;
@@ -1326,6 +1334,29 @@ export function createAnnotationStore({ annotationState, annotationUI }) {
     rebuildEditThreadsFromEasyEdits();
   }
 
+  /*function isBloatedMetadataHtml(html) {
+    const value = `${html || ''}`;
+    if (!value) return false;
+    if (value.length > 4096) return true;
+    return /\bclass=["']metadata["']/.test(value)
+      || value.includes('<div class="metadata"');
+  }*/
+
+  function trimMetadataEditForSave(edit) {
+    if (!edit || edit.elementPath !== 'metadata') return edit;
+    const fromHtml = isBloatedMetadataHtml(edit.fromHtml) ? '' : `${edit.fromHtml || ''}`;
+    const toHtml = isBloatedMetadataHtml(edit.toHtml) ? '' : `${edit.toHtml || ''}`;
+    if (fromHtml === edit.fromHtml && toHtml === edit.toHtml) return edit;
+    return { ...edit, fromHtml, toHtml };
+  }
+
+  function metadataEasyEditFields(elementProps = {}) {
+    return {
+      blockClass: 'metadata',
+      elementProps: { ...elementProps, blockClass: 'metadata' },
+    };
+  }
+
   function buildSavePayload() {
     return annotationState.store.easyEdits
       .filter((edit) => {
@@ -1338,7 +1369,7 @@ export function createAnnotationStore({ annotationState, annotationUI }) {
       })
       .map((edit) => {
         const { changeHistory, assetFileKey, ...rest } = edit;
-        return rest;
+        return trimMetadataEditForSave(rest);
       });
   }
 
@@ -1595,5 +1626,6 @@ export function createAnnotationStore({ annotationState, annotationUI }) {
     undoLastChange,
     clearChangeHistoryAfterSave,
     buildSavePayload,
+    metadataEasyEditFields,
   };
 }

--- a/streamlibs/operations/annotation/store.js
+++ b/streamlibs/operations/annotation/store.js
@@ -1,4 +1,5 @@
 import { ANNOTATION_COMMENT_STATUSES, ANNOTATION_DEFAULT_USERNAME } from '../../utils/constants.js';
+import { resolveMetadataImagesForPreview } from './metadata-sanitize.js';
 
 const ANNOTATION_STORE_KEY = 'stream-annotation-comments';
 export const DEFAULT_USERNAME = ANNOTATION_DEFAULT_USERNAME;
@@ -1549,15 +1550,16 @@ export function createAnnotationStore({ annotationState, annotationUI }) {
       );
     }
 
-    keepLatestImageEdits(annotationState.store.easyEdits).forEach((edit) => {
+    const editsToApply = keepLatestImageEdits(annotationState.store.easyEdits);
+    for (const edit of editsToApply) {
       const target = getElementForEdit(edit);
-      if (!(target instanceof HTMLElement)) return;
-      if (target.closest('[data-class="fragment"]')) return;
+      if (!(target instanceof HTMLElement)) continue; // eslint-disable-line no-continue
+      if (target.closest('[data-class="fragment"]')) continue; // eslint-disable-line no-continue
 
-      if (edit.from === edit.to && (edit.fromHtml || '') === (edit.toHtml || '')) return;
+      if (edit.from === edit.to && (edit.fromHtml || '') === (edit.toHtml || '')) continue; // eslint-disable-line no-continue
 
       // Pending asset edit (empty `to`): keep the existing base64 preview.
-      if ((edit.editType === 'image-src' || edit.editType === 'image-alt') && !edit.to) return;
+      if ((edit.editType === 'image-src' || edit.editType === 'image-alt') && !edit.to) continue; // eslint-disable-line no-continue
 
       if (edit.editType === 'text') {
         easyEditOriginalByElement.set(target, {
@@ -1577,31 +1579,35 @@ export function createAnnotationStore({ annotationState, annotationUI }) {
         if (picture) {
           picture.querySelectorAll('source').forEach((s) => s.setAttribute('srcset', displayUrl));
         }
-        return;
+        continue; // eslint-disable-line no-continue
       }
 
       if (edit.editType === 'image-alt') {
         target.setAttribute('alt', edit.to || '');
-        return;
+        continue; // eslint-disable-line no-continue
       }
 
       if (edit.toHtml) {
         if (target.innerHTML !== edit.toHtml) {
           target.innerHTML = edit.toHtml;
         }
-        return;
+        if (edit.elementPath === 'metadata' && previewUrlResolverFn) {
+          // eslint-disable-next-line no-await-in-loop
+          await resolveMetadataImagesForPreview(target, previewUrlResolverFn);
+        }
+        continue; // eslint-disable-line no-continue
       }
 
       const currentText = target.textContent || '';
       if (edit.from && edit.to && edit.from !== edit.to && currentText.includes(edit.to)) {
-        return;
+        continue; // eslint-disable-line no-continue
       }
       if (edit.from && currentText.includes(edit.from)) {
         target.textContent = currentText.replace(edit.from, edit.to);
       } else if (edit.to) {
         target.textContent = edit.to;
       }
-    });
+    }
   }
 
   return {

--- a/streamlibs/sources/da.js
+++ b/streamlibs/sources/da.js
@@ -11,7 +11,11 @@ function restoreImgToPicture(html) {
       const picture = document.createElement('picture');
       const newImg = document.createElement('img');
       Array.from(img.attributes).forEach((attr) => {
-        newImg.setAttribute(attr.name, attr.value);
+        try {
+          newImg.setAttribute(attr.name, attr.value);
+        } catch {
+          // Skip invalid attribute names from DA source HTML (e.g. Milo icon tokens).
+        }
       });
       picture.appendChild(newImg);
       p.replaceWith(picture);


### PR DESCRIPTION
Jira: https://jira.corp.adobe.com/browse/MWPW-196579

SUMMARY:
Implements page metadata for collab annotation (MWPW-196579 / MWPW-194556): parse DA <metadata> → preview edit → Save to edits DB (single chunk) → Push to DA on publish.

What changed:

- Load & preview

Strip div.metadata from DA HTML on load; cache baseline + inject main .stream-metadata-section
Resolve content.da.live images to base64 for preview; keep CDN URL on data-stream-original-src

- Edit:  
Inline edit metadata text/images (elementPath: metadata)
Add row — text/link and image rows
Delete row — trash per value cell; DOM-only until Save (no metadata-block / no DA push on delete)

- Save
One metadata edit per save: elementPath: metadata, editType: text, fromHtml → toHtml
Exclude per-cell metadata + legacy metadata-block / page-metadata from POST
Collapse to single committed metadata edit after successful save
No postData on Save — edits API only

- Push
Append sanitized metadata via buildMetadataToHtml() + existing DA push flow

- Persist / sanitizer (PR 197 parity)

New metadata-sanitize.js — strip UI chrome, base64, data-* attrs; restore CDN URLs before Save/Push
prepareLiveMetadataForPersist() + assets-panel metadata image handling

UI: 
Metadata table uses fixed column layout; delete + edit markers aligned in value/key cells (pencil mode)
Store / cleanup

collapseMetadataEasyEdits, isLegacyMetadataEdit, pruneMetadataEasyEditsForElementRefs
Inline-editing unregister on row delete

