### PR TITLE
[MWPW-195581]Render figma alt text

### DIFF
--- a/streamlibs/blocks/aside-std.js
+++ b/streamlibs/blocks/aside-std.js
@@ -5,6 +5,7 @@ import {
   handleComponents,
   handleImageComponent,
   handleProductLockup,
+  resolveImageValue,
 } from '../components/components.js';
 import { LOGOS } from '../utils/constants.js';
 import { safeJsonFetch } from '../utils/error-handler.js';
@@ -64,8 +65,11 @@ function handleSwap(blockContent, properties) {
 
 function handleAvatar(value, areaEl) {
   if (!areaEl || !value) return;
-  areaEl.querySelectorAll('source').forEach((source) => { source.srcset = value || LOGOS.placeholder; });
-  areaEl.querySelector('img').src = value || LOGOS.placeholder;
+  const { url, altText } = resolveImageValue(value);
+  areaEl.querySelectorAll('source').forEach((source) => { source.srcset = url || LOGOS.placeholder; });
+  const imgEl = areaEl.querySelector('img');
+  imgEl.src = url || LOGOS.placeholder;
+  if (altText) imgEl.alt = altText;
 }
 export function handleActionsArray(el, configData, value, areaEl) {
   if (!value) return;

--- a/streamlibs/blocks/aside.js
+++ b/streamlibs/blocks/aside.js
@@ -4,6 +4,7 @@ import {
   handleComponents,
   handleImageComponent,
   handleProductLockup,
+  resolveImageValue,
 } from '../components/components.js';
 import { LOGOS } from '../utils/constants.js';
 import { safeJsonFetch } from '../utils/error-handler.js';
@@ -132,8 +133,11 @@ function handleSwap(blockContent, properties) {
 
 function handleAvatar(value, areaEl) {
   if (!areaEl || !value) return;
-  areaEl.querySelectorAll('source').forEach((source) => { source.srcset = value || LOGOS.placeholder; });
-  areaEl.querySelector('img').src = value || LOGOS.placeholder;
+  const { url, altText } = resolveImageValue(value);
+  areaEl.querySelectorAll('source').forEach((source) => { source.srcset = url || LOGOS.placeholder; });
+  const imgEl = areaEl.querySelector('img');
+  imgEl.src = url || LOGOS.placeholder;
+  if (altText) imgEl.alt = altText;
 }
 
 function handleSpacer(spacer, position) {

--- a/streamlibs/blocks/hero-marquee.js
+++ b/streamlibs/blocks/hero-marquee.js
@@ -88,8 +88,12 @@ function blockBackground(value, areaEl, properties) {
 
 function handleLogo(value, areaEl) {
   if (!areaEl || !value) return;
-  areaEl.querySelectorAll('source').forEach((source) => { source.srcset = value || LOGOS.placeholder; });
-  areaEl.querySelector('img').src = value || LOGOS.placeholder;
+  const url = (typeof value === 'object' && value.url) ? value.url : value;
+  const altText = (typeof value === 'object' && value.altText) ? value.altText : '';
+  areaEl.querySelectorAll('source').forEach((source) => { source.srcset = url || LOGOS.placeholder; });
+  const imgEl = areaEl.querySelector('img');
+  imgEl.src = url || LOGOS.placeholder;
+  if (altText) imgEl.alt = altText;
 }
 
 function handleSupplemental(blockContent, selector, value) {

--- a/streamlibs/blocks/icon-block.js
+++ b/streamlibs/blocks/icon-block.js
@@ -1,6 +1,6 @@
 import {
   handleAccentBar, handleActionButtons, handleBackgroundWithSectionMetadata, handleComponents,
-  handleSpacer,
+  handleSpacer, resolveImageValue,
 } from '../components/components.js';
 import { LOGOS } from '../utils/constants.js';
 import { safeJsonFetch } from '../utils/error-handler.js';
@@ -66,8 +66,11 @@ function handleProductLockup(value, areaEl) {
 
 function handleAvatar(value, areaEl) {
   if (!value) return;
-  areaEl.querySelectorAll('source').forEach((source) => { source.srcset = value; });
-  areaEl.querySelector('img').src = value;
+  const { url, altText } = resolveImageValue(value);
+  areaEl.querySelectorAll('source').forEach((source) => { source.srcset = url; });
+  const imgEl = areaEl.querySelector('img');
+  imgEl.src = url;
+  if (altText) imgEl.alt = altText;
 }
 
 export default async function mapBlockContent(

--- a/streamlibs/blocks/marquee-anchors.js
+++ b/streamlibs/blocks/marquee-anchors.js
@@ -2,6 +2,7 @@ import {
   handleComponents,
   handleActionButtons,
   handleBackground,
+  resolveImageValue,
 } from '../components/components.js';
 import { safeJsonFetch } from '../utils/error-handler.js';
 import { DEFAULT_TMP_URL } from '../utils/constants.js';
@@ -9,8 +10,11 @@ import { DEFAULT_TMP_URL } from '../utils/constants.js';
 function handleForegroundPhoto(value, areaEl) {
   if (!areaEl) return;
   const pic = areaEl.querySelector('picture');
-  pic.querySelectorAll('source').forEach((source) => { source.srcset = value; });
-  pic.querySelector('img').src = value;
+  const { url, altText } = resolveImageValue(value);
+  pic.querySelectorAll('source').forEach((source) => { source.srcset = url; });
+  const imgEl = pic.querySelector('img');
+  imgEl.src = url;
+  if (altText) imgEl.alt = altText;
 }
 
 function handleAnchorTitle(blockContent, value) {

--- a/streamlibs/blocks/marquee.js
+++ b/streamlibs/blocks/marquee.js
@@ -3,6 +3,7 @@ import {
   handleActionButtons,
   handleBackground,
   handleProductLockup,
+  resolveImageValue,
 } from '../components/components.js';
 import { safeJsonFetch } from '../utils/error-handler.js';
 
@@ -17,8 +18,11 @@ const VARIANT_SMALL = 'small';
 
 function handleForegroundPhoto(value, areaEl) {
   if (!areaEl) return;
-  areaEl.querySelectorAll('source').forEach((source) => { source.srcset = value; });
-  areaEl.querySelector('img').src = value;
+  const { url, altText } = resolveImageValue(value);
+  areaEl.querySelectorAll('source').forEach((source) => { source.srcset = url; });
+  const imgEl = areaEl.querySelector('img');
+  imgEl.src = url;
+  if (altText) imgEl.alt = altText;
 }
 
 function handlePhotoCredits(value, areaEl) {

--- a/streamlibs/blocks/media.js
+++ b/streamlibs/blocks/media.js
@@ -3,6 +3,7 @@ import {
   handleBackground,
   handleComponents,
   handleSpacerWithSectionMetadata,
+  resolveImageValue,
 } from '../components/components.js';
 import { LOGOS } from '../utils/constants.js';
 import { safeJsonFetch } from '../utils/error-handler.js';
@@ -14,10 +15,23 @@ function handleSwap(blockContent, properties) {
   }
 }
 
+/** Nested text-media alt text lives on properties.media.imageRef; foregroundImage is often URL-only. */
+function resolveForegroundImageValue(properties, foregroundImage) {
+  const nested = properties?.media?.imageRef;
+  if (nested && (typeof nested === 'object' ? nested.url : nested)) return nested;
+  const { url, altText } = resolveImageValue(foregroundImage);
+  const nestedAlt = typeof nested === 'object' ? (nested?.altText || '') : '';
+  if (url && nestedAlt && !altText) return { url, altText: nestedAlt };
+  return foregroundImage;
+}
+
 function handleForegroundImage(value, areaEl) {
   if (!value) return;
-  areaEl.querySelectorAll('source').forEach((source) => { source.srcset = value; });
-  areaEl.querySelector('img').src = value;
+  const { url, altText } = resolveImageValue(value);
+  areaEl.querySelectorAll('source').forEach((source) => { source.srcset = url; });
+  const imgEl = areaEl.querySelector('img');
+  imgEl.src = url;
+  if (altText) imgEl.alt = altText;
 }
 
 function handleCompact(blockContent, properties) {
@@ -138,10 +152,13 @@ function handleAppList(items, areaEl) {
 
 function handleQRCode(value, areaEl) {
   if (!value || !areaEl) return;
-  areaEl.querySelectorAll('source').forEach((source) => { source.srcset = value; });
-  areaEl.querySelector('img').src = value;
-  areaEl.querySelector('img').style.width = '140px';
-  areaEl.querySelector('img').style.height = '140px';
+  const { url, altText } = resolveImageValue(value);
+  areaEl.querySelectorAll('source').forEach((source) => { source.srcset = url; });
+  const imgEl = areaEl.querySelector('img');
+  imgEl.src = url;
+  imgEl.style.width = '140px';
+  imgEl.style.height = '140px';
+  if (altText) imgEl.alt = altText;
 }
 
 export default async function mapBlockContent(sectionWrapper, blockContent, figContent) {
@@ -155,7 +172,9 @@ export default async function mapBlockContent(sectionWrapper, blockContent, figC
     if (properties?.miloTag?.includes('app')) configData = mappingData.appstore;
     if (properties?.miloTag?.includes('sbcpy')) configData = mappingData.subcopy;
     configData.data.forEach((mappingConfig) => {
-      const value = properties[mappingConfig.key];
+      const value = mappingConfig.key === 'foregroundImage'
+        ? resolveForegroundImageValue(properties, properties[mappingConfig.key])
+        : properties[mappingConfig.key];
       const areaEl = handleComponents(blockContent, value, mappingConfig);
       switch (mappingConfig.key) {
         case 'actions':

--- a/streamlibs/blocks/notification.js
+++ b/streamlibs/blocks/notification.js
@@ -5,6 +5,7 @@ import {
   handleBackground,
   handleAccentBar,
   handleGridLayout,
+  resolveImageValue,
 } from '../components/components.js';
 import { safeJsonFetch } from '../utils/error-handler.js';
 
@@ -18,8 +19,11 @@ export function handleForegroundImage(el, value, selector) {
   const picParentEl = el.querySelector(selector);
   if (!value) return picParentEl.classList.add('to-remove');
   const picEl = picParentEl.querySelector('picture');
-  picEl.querySelectorAll('source').forEach((source) => { source.srcset = value; });
-  picEl.querySelector('img').src = value;
+  const { url, altText } = resolveImageValue(value);
+  picEl.querySelectorAll('source').forEach((source) => { source.srcset = url; });
+  const imgEl = picEl.querySelector('img');
+  imgEl.src = url;
+  if (altText) imgEl.alt = altText;
   return picEl;
 }
 

--- a/streamlibs/blocks/quote.js
+++ b/streamlibs/blocks/quote.js
@@ -3,6 +3,7 @@ import {
   handleSpacer,
   handleGridLayout,
   handleBackgroundWithSectionMetadata,
+  resolveImageValue,
 } from '../components/components.js';
 import { safeJsonFetch } from '../utils/error-handler.js';
 
@@ -30,8 +31,11 @@ function handleVariants(blockContent, properties) {
 
 function handleAvatar(value, areaEl) {
   if (!value) return;
-  areaEl.querySelectorAll('source').forEach((source) => { source.srcset = value; });
-  areaEl.querySelector('img').src = value;
+  const { url, altText } = resolveImageValue(value);
+  areaEl.querySelectorAll('source').forEach((source) => { source.srcset = url; });
+  const imgEl = areaEl.querySelector('img');
+  imgEl.src = url;
+  if (altText) imgEl.alt = altText;
 }
 
 export default async function mapBlockContent(sectionWrapper, blockContent, figContent) {

--- a/streamlibs/components/components.js
+++ b/streamlibs/components/components.js
@@ -7,6 +7,12 @@ import {
   ICON_CLASS,
 } from '../utils/constants.js';
 
+export function resolveImageValue(value) {
+  if (!value) return { url: '', altText: '' };
+  if (typeof value === 'object' && value.url) return { url: value.url, altText: value.altText || '' };
+  return { url: `${value}`, altText: '' };
+}
+
 export function handleTextComponent({ el, value, selector }) {
   const textEl = el.querySelector(selector);
   if (!value) return textEl.classList.add('to-remove');
@@ -25,8 +31,11 @@ export function handleTextComponent({ el, value, selector }) {
 export function handleImageComponent({ el, value, selector }) {
   const picEl = el.querySelector(selector);
   if (!value) return picEl.classList.add('to-remove');
-  picEl.querySelectorAll('source').forEach((source) => { source.srcset = value; });
-  picEl.querySelector('img').src = value;
+  const { url, altText } = resolveImageValue(value);
+  picEl.querySelectorAll('source').forEach((source) => { source.srcset = url; });
+  const imgEl = picEl.querySelector('img');
+  imgEl.src = url;
+  if (altText) imgEl.alt = altText;
   return picEl;
 }
 
@@ -170,17 +179,19 @@ export function handleActionButtons(el, configData, value, areaEl) {
 
 export function handleBackground(value, areaEl) {
   if (!value) return;
-  if (value.startsWith('http')) {
+  const { url, altText } = resolveImageValue(value);
+  if (url.startsWith('http')) {
     const img = document.createElement('img');
-    img.src = value;
+    img.src = url;
+    if (altText) img.alt = altText;
     const pic = document.createElement('picture');
     const source = document.createElement('source');
-    source.srcset = value;
+    source.srcset = url;
     source.type = 'image/webp';
     pic.append(...[source, img]);
     areaEl.append(pic);
   } else {
-    areaEl.innerHTML = value;
+    areaEl.innerHTML = url;
   }
 }
 
@@ -263,19 +274,22 @@ export function handleSpacerWithSectionMetadata(secEl, blockEl, spacer, position
 }
 
 export function handleBackgroundWithSectionMetadata(secEl, blockEl, value) {
-  if (!value || value.startsWith('#fff')) return;
+  if (!value) return;
+  const { url, altText } = resolveImageValue(value);
+  if (url.startsWith('#fff')) return;
   const backgroundValue = addOrUpdateSectionMetadata(secEl, blockEl, 'background');
-  if (value.startsWith('http')) {
+  if (url.startsWith('http')) {
     const img = document.createElement('img');
-    img.src = value;
+    img.src = url;
+    if (altText) img.alt = altText;
     const pic = document.createElement('picture');
     const source = document.createElement('source');
-    source.srcset = value;
+    source.srcset = url;
     source.type = 'image/png';
     pic.append(...[source, img]);
     backgroundValue.append(pic);
   } else {
-    backgroundValue.innerHTML = value;
+    backgroundValue.innerHTML = url;
   }
 }
 
@@ -298,8 +312,11 @@ export function handleVariantWithSectionMetadata(secEl, blockEl, variant) {
 
 export function replaceImage(pic, src) {
   if (!pic || !src) return;
-  pic.querySelectorAll('source').forEach((source) => { source.srcset = src; });
-  pic.querySelector('img').src = src;
+  const { url, altText } = resolveImageValue(src);
+  pic.querySelectorAll('source').forEach((source) => { source.srcset = url; });
+  const imgEl = pic.querySelector('img');
+  imgEl.src = url;
+  if (altText) imgEl.alt = altText;
 }
 
 export function handleProductLockup(value, areaEl) {

--- a/streamlibs/previewer.js
+++ b/streamlibs/previewer.js
@@ -505,6 +505,9 @@ export async function mergeImageUrls() {
   daImg.forEach((img, idx) => {
     if (!pageImg[idx]) return;
     pageImg[idx].src = img.src;
+    if (img.hasAttribute('alt')) {
+      pageImg[idx].alt = img.getAttribute('alt') || '';
+    }
     const pic = pageImg[idx].closest('picture');
     if (pic) {
       // eslint-disable-next-line no-return-assign


### PR DESCRIPTION
- Add `resolveImageValue()` and teach shared handlers (`handleImageComponent`, `handleBackground`, `replaceImage`, etc.) to set `img.alt` from `{ url, altText }`.
- Update block mappers with custom image handlers (aside, quote, notification, marquee, marquee-anchors, hero-marquee, icon-block).

Hero-marquee
<img width="1918" height="781" alt="image (4)" src="https://github.com/user-attachments/assets/b9bd5145-34c0-4c24-b7a5-0e1ef3dd1048" />
aside
<img width="1918" height="628" alt="image (3)" src="https://github.com/user-attachments/assets/9c84efa2-322d-40c8-ad88-a8715b885ecf" />
<img width="1117" height="607" alt="image (2)" src="https://github.com/user-attachments/assets/23ade5c1-1389-4a10-b9db-006d131a20fb" />
media
<img width="1120" height="595" alt="image (1)" src="https://github.com/user-attachments/assets/574a61d9-d499-4460-aef9-8e2246de796d" />
Editorial Card
<img width="1654" height="852" alt="image (5)" src="https://github.com/user-attachments/assets/7a01f784-9f05-4862-ab6b-18bc2e140ed6" />



Test URLs:
- Before: https://main--{repo}--{owner}.aem.live/
- After: https://<branch>--{repo}--{owner}.aem.live/
