### PR TITLE
MWPW-196579  Metadata add delete rows

### DIFF
--- a/streamlibs/operations/annotation.js
+++ b/streamlibs/operations/annotation.js
@@ -20,7 +20,7 @@ import createAssetServiceClient from './annotation/asset-service.js';
 import createAssetsPanelController from './annotation/assets-panel.js';
 import requestParentCollabRefresh from './annotation/collab-sync.js';
 import { handleError } from '../utils/error-handler.js';
-import { BLOCK_CLASSES, BLOCK_CLASS_TEMPLATES } from '../utils/constants.js';
+import { BLOCK_CLASSES } from '../utils/constants.js';
 
 // ── Module singletons ────────────────────────────────────────────────────────
 
@@ -151,15 +151,6 @@ function parseAndCacheCleanHtml(htmlDom) {
       block.remove();
       if (parent && parent.children.length === 0) parent.remove();
     });
-    if (blocks.length === 0) {
-      const template = BLOCK_CLASS_TEMPLATES[blockClass];
-      if (template){
-           // template: seed keys table (card-metadata)
-      combinedInnerHtml = template
-        .map((key) => `<div><div>${key}</div><div></div></div>`)
-        .join('');
-      }
-    }
     const cached = document.createElement('div');
     cached.className = blockClass;
     cached.innerHTML = combinedInnerHtml;

--- a/streamlibs/operations/annotation.js
+++ b/streamlibs/operations/annotation.js
@@ -147,7 +147,7 @@ async function initializePreview() {
   const headerEle = document.createElement('header');
   const mainEle = document.createElement('main');
   const metadataEle = document.createElement('div');
-  metadataEle.classList.add('metadata', 'page-metadata');
+  metadataEle.classList.add('page-metadata');
   if (cachedPageMetadataHtml !== null) {
     metadataEle.innerHTML = cachedPageMetadataHtml;
   } else {
@@ -325,12 +325,8 @@ function findAssetElement(doc, elementPath, elementProps, originalSrc) {
 
 // ── HTML export ───────────────────────────────────────────────────────────────
 
-function buildHtmlWithEditsAndAssets(assetReplacements, { excludeBlockClasses = [] } = {}) {
-  const isExcluded = (bc) => excludeBlockClasses.includes(bc);
-  const allEasyEdits = annotationState.store.easyEdits || [];
-  const easyEdits = excludeBlockClasses.length
-    ? allEasyEdits.filter((e) => !isExcluded(e?.blockClass || e?.elementProps?.blockClass))
-    : allEasyEdits;
+function buildHtmlWithEditsAndAssets(assetReplacements) {
+  const easyEdits = annotationState.store.easyEdits || [];
   const html = store.applyEasyEditsToHtmlString(cachedCleanHtml, easyEdits);
   const container = document.createElement('div');
   container.innerHTML = `<main>${html}</main>`;
@@ -339,7 +335,6 @@ function buildHtmlWithEditsAndAssets(assetReplacements, { excludeBlockClasses = 
     // Assets with block+globalIndex were already applied viewport-aware in the string phase
     const assetBc = asset.elementProps?.blockClass;
     const assetBgi = asset.elementProps?.blockGlobalIndex;
-    if (isExcluded(assetBc)) continue; // eslint-disable-line no-continue
     if (assetBc && assetBgi != null) continue; // eslint-disable-line no-continue
     const element = findAssetElement(
       container, asset.elementPath, asset.elementProps, asset.originalSrc,
@@ -383,8 +378,7 @@ function buildHtmlWithEditsAndAssets(assetReplacements, { excludeBlockClasses = 
   // image-src easyEdits take priority — they carry the final promoted URL and
   // reliable original src, so they overwrite the assetReplacements pass above.
   const imageSrcEdits = (annotationState.store.easyEdits || [])
-    .filter((e) => e?.editType === 'image-src' && e.to)
-    .filter((e) => !isExcluded(e?.blockClass || e?.elementProps?.blockClass));
+    .filter((e) => e?.editType === 'image-src' && e.to);
   // Edits with blockClass+blockGlobalIndex were already applied viewport-aware in the string phase
   imageSrcEdits
     .filter((edit) => {
@@ -421,6 +415,28 @@ function buildHtmlWithEditsAndAssets(assetReplacements, { excludeBlockClasses = 
 
   rewriteMediaUrls(container);
   const mainEl = container.querySelector('main');
+
+  const pageMetadataDom = document.body.querySelector('main .page-metadata');
+  if (pageMetadataDom) {
+    cachedPageMetadataHtml = pageMetadataDom.innerHTML;
+    mainEl.querySelectorAll('.metadata').forEach((el) => {
+      const parentSection = el.parentElement;
+      el.remove();
+      if (parentSection.children.length === 0) parentSection.remove();
+    });
+    const metadataDiv = document.createElement('div');
+    metadataDiv.className = 'metadata';
+    metadataDiv.innerHTML = pageMetadataDom.innerHTML;
+    metadataDiv.querySelectorAll('p').forEach((p) => {
+      [...p.attributes].forEach((attr) => p.removeAttribute(attr.name));
+    });
+    metadataDiv.querySelectorAll('img').forEach((img) => {
+      img.setAttribute('src', img.getAttribute('data-stream-original-src'));
+    });
+    const divWrapper = document.createElement('div');
+    divWrapper.append(metadataDiv);
+    mainEl.appendChild(divWrapper);
+  }
 
   return { easyEdits, daCompatibleHtml: getDACompatibleHtml(mainEl.innerHTML) };
 }
@@ -700,37 +716,7 @@ export async function persistAnnotationChangesToDA(versionLabel = null) {
   const assetReplacements = buildAssetReplacementsAndEdits(
     (asset) => asset.finalDaUrl || asset.daUrl,
   );
-  let { daCompatibleHtml } = buildHtmlWithEditsAndAssets(assetReplacements, {
-    excludeBlockClasses: ['metadata'],
-  });
-
-  if (cachedPageMetadataHtml !== null) {
-    const metaContainer = document.createElement('div');
-    metaContainer.innerHTML = `<main>${daCompatibleHtml}</main>`;
-    const metaMain = metaContainer.querySelector('main');
-    metaMain.querySelectorAll('.metadata').forEach((el) => {
-      const parentSection = el.parentElement;
-      el.remove();
-      if (parentSection.children.length === 0) parentSection.remove();
-    });
-    const metadataDiv = document.createElement('div');
-    metadataDiv.className = 'metadata';
-    metadataDiv.innerHTML = cachedPageMetadataHtml;
-    metadataDiv.querySelectorAll('p').forEach((p) => {
-      [...p.attributes].forEach((attr) => p.removeAttribute(attr.name));
-    });
-    metadataDiv.querySelectorAll('img').forEach((img) => {
-      const daSrc = img.getAttribute('data-stream-original-src');
-      if (daSrc) img.setAttribute('src', daSrc);
-      [...img.attributes].forEach((attr) => {
-        if (attr.name.startsWith('data-')) img.removeAttribute(attr.name);
-      });
-    });
-    const divWrapper = document.createElement('div');
-    divWrapper.append(metadataDiv);
-    metaMain.appendChild(divWrapper);
-    daCompatibleHtml = getDACompatibleHtml(metaMain.innerHTML);
-  }
+  const { daCompatibleHtml } = buildHtmlWithEditsAndAssets(assetReplacements);
 
   const cfg = window.streamConfig || {};
   const rawPushUrl = `${cfg.pageUrl || cfg.targetUrl || ''}`.trim();
@@ -769,51 +755,7 @@ export async function saveAnnotationChanges(reportProgress = () => {}) {
   await inlineEditing.syncInlineEditsBeforePersist();
   await uploadAndDecideAssets();
   // Save assigns each image edit its content.da.live URL (no DA push here).
-  const assetReplacements = buildAssetReplacementsAndEdits((asset) => asset.daUrl);
-  // eslint-disable-next-line no-unused-vars
-  const { daCompatibleHtml } = buildHtmlWithEditsAndAssets(assetReplacements);
-
-  // Apply page metadata edits to the outgoing HTML
-  const pageMetadataDom = document.body.querySelector('main .page-metadata');
-  let htmlToPush = cachedCleanHtml;
-  if (pageMetadataDom && pageMetadataDom.children.length) {
-    cachedPageMetadataHtml = pageMetadataDom.innerHTML;
-    const metaContainer = document.createElement('div');
-    metaContainer.innerHTML = `<main>${cachedCleanHtml}</main>`;
-    const metaMain = metaContainer.querySelector('main');
-    metaMain.querySelectorAll('.metadata').forEach((el) => {
-      const parentSection = el.parentElement;
-      el.remove();
-      if (parentSection.children.length === 0) parentSection.remove();
-    });
-    const metadataDiv = document.createElement('div');
-    metadataDiv.className = 'metadata';
-    metadataDiv.innerHTML = pageMetadataDom.innerHTML;
-    metadataDiv.querySelectorAll('p').forEach((p) => {
-      [...p.attributes].forEach((attr) => p.removeAttribute(attr.name));
-    });
-    metadataDiv.querySelectorAll('img').forEach((img) => {
-      const daSrc = img.getAttribute('data-stream-original-src');
-      img.setAttribute('src', daSrc);
-      [...img.attributes].forEach((attr) => {
-        if (attr.name.startsWith('data-')) {
-          img.removeAttribute(attr.name);
-        }
-      });
-    });
-    const divWrapper = document.createElement('div');
-    divWrapper.append(metadataDiv);
-    metaMain.appendChild(divWrapper);
-    htmlToPush = getDACompatibleHtml(metaMain.innerHTML);
-    const cfg = window.streamConfig || {};
-    const rawPushUrl = `${cfg.draftLocation || cfg.contentUrl || ''}`.trim();
-    if (rawPushUrl) {
-      await postData(normalizePersistUrlForDaApi(rawPushUrl) || rawPushUrl, htmlToPush, {
-        suppressErrorPage: true,
-      });
-    }
-  }
-
+  buildAssetReplacementsAndEdits((asset) => asset.daUrl);
   await persistEditsToDb();
   reportProgress('editsSaved');
   requestParentCollabRefresh('edits-saved');

--- a/streamlibs/operations/annotation.js
+++ b/streamlibs/operations/annotation.js
@@ -38,7 +38,13 @@ const assetsPanel = createAssetsPanelController({
 const previewUrlCache = new Map();
 
 async function resolvePreviewUrl(url) {
-  if (!url || !url.includes('content.da.live')) return url;
+  if (!url) return url;
+  // DA editor-format images store the real URL in the # fragment of an fpo.svg
+  // placeholder; decode it and map the source host to the delivery host.
+  if (url.includes('fpo.svg#')) {
+    url = (url.split('#')[1] || url).replace('admin.da.live/source/', 'content.da.live/');
+  }
+  if (!url.includes('content.da.live')) return url;
   if (previewUrlCache.has(url)) return previewUrlCache.get(url);
   const b64 = await fetchImageAsBase64(url);
   if (b64) previewUrlCache.set(url, b64);

--- a/streamlibs/operations/annotation.js
+++ b/streamlibs/operations/annotation.js
@@ -20,7 +20,7 @@ import createAssetServiceClient from './annotation/asset-service.js';
 import createAssetsPanelController from './annotation/assets-panel.js';
 import requestParentCollabRefresh from './annotation/collab-sync.js';
 import { handleError } from '../utils/error-handler.js';
-import { BLOCK_CLASSES } from '../utils/constants.js';
+import { BLOCK_CLASSES, isMetadata } from '../utils/constants.js';
 
 // ── Module singletons ────────────────────────────────────────────────────────
 
@@ -465,7 +465,7 @@ function buildHtmlWithEditsAndAssets(assetReplacements) {
   cachedMetadataBlocks.forEach((cachedBlock, blockClass) => {
     mainEl.querySelectorAll(`div.${blockClass}`).forEach((block) => block.remove());
     //picks the most recent saved edit for that metadata block (elementPath matches blockClass and has toHtml), so that version is used when re-appending the block on save instead of the original cached HTML.
-    const blockEdit = easyEdits.filter((e) => e.elementPath === blockClass && e.toHtml).at(-1);
+    const blockEdit = easyEdits.filter((e) => e.blockClass === blockClass && e.toHtml).at(-1);
     const finalHtml = blockEdit?.toHtml
       || (cachedBlock.innerHTML.trim() ? cachedBlock.outerHTML : '');
     // Wrap in a section <div> so DA treats it as a block inside a section (not a bare
@@ -592,9 +592,7 @@ function buildAssetReplacementsAndEdits(resolveTargetUrl) {
       : null;
       //checks if this image inside a metadata block?
       //fig out real ori da img url instead or using preview url shown  onscreen
-    const liveBlock = liveEl?.closest(BLOCK_CLASSES.map((c) => `main div.${c}`).join(', '));
-    const blockClass = liveBlock
-      ? (BLOCK_CLASSES.find((c) => liveBlock.classList.contains(c)) || '') : '';
+    const blockClass = isMetadata(liveEl);
     const imgEl = liveEl?.tagName === 'IMG' ? liveEl : liveEl?.querySelector('img');
     let { originalSrc } = asset;
     if (blockClass) {
@@ -621,15 +619,15 @@ function buildAssetReplacementsAndEdits(resolveTargetUrl) {
   for (const { asset, blockClass, originalSrc } of resolvedAssets) {
     const finalUrl = resolveTargetUrl(asset);
     if (!asset.elementPath || !finalUrl) continue; // eslint-disable-line no-continue
-    const trackingPath = blockClass || asset.elementPath;
     const existingEdit = store.getEasyEditByElement(
-      asset.elementRef || '', trackingPath, asset.elementProps,
+      asset.elementRef || '', asset.elementPath, asset.elementProps,
     );
     if (!existingEdit || existingEdit.editType === 'image-src') {
       store.upsertEasyEdit({
         ...(existingEdit || {}),
         editType: 'image-src',
-        elementPath: trackingPath,
+        elementPath: asset.elementPath,
+        blockClass,
         elementProps: asset.elementProps || {},
         elementRef: asset.elementRef || '',
         from: blockClass ? originalSrc : (existingEdit?.from || originalSrc),

--- a/streamlibs/operations/annotation.js
+++ b/streamlibs/operations/annotation.js
@@ -91,6 +91,32 @@ const commentsPanel = createCommentsPanelController({
 });
 commentsPanel.setImageRegenHandler(recordImageRegenAsLocalAsset);
 
+let cachedCleanHtml = '';
+let cachedMetadata = null;
+const regenReplacements = [];
+
+function buildMetadataToHtml() {
+  const liveMetadata = document.querySelector('main div.metadata');
+  if (!liveMetadata) return '';
+  const clone = liveMetadata.cloneNode(true);
+  clone.querySelectorAll('picture').forEach((picture) => {
+    const img = picture.querySelector('img');
+    if (img) picture.replaceWith(img);
+    else picture.remove();
+  });
+  clone.querySelectorAll('img').forEach((img) => {
+    const originalSrc = img.getAttribute('data-stream-original-srcset')
+      || img.getAttribute('data-stream-original-src');
+    if (originalSrc) img.setAttribute('src', originalSrc);
+  });
+  clone.querySelectorAll('*').forEach((el) => {
+    [...el.attributes]
+      .filter((attr) => attr.name.startsWith('data-'))
+      .forEach((attr) => el.removeAttribute(attr.name));
+  });
+  return getDACompatibleHtml(clone.outerHTML);
+}
+
 const inlineEditing = createInlineEditingController({
   annotationState,
   annotationUI,
@@ -98,6 +124,8 @@ const inlineEditing = createInlineEditingController({
   renderThreadMarkers: commentsPanel.renderThreadMarkers,
   renderCommentsPanel: commentsPanel.renderCommentsPanel,
   removePopup: commentsPanel.removePopup,
+  getMetadataFromHtml: () => (cachedMetadata ? cachedMetadata.outerHTML : ''),
+  buildMetadataToHtml,
 });
 
 commentsPanel.setInlineModeHandlers({
@@ -110,9 +138,22 @@ assetsPanel.setOnAssetsChanged(() => {
   commentsPanel.renderCommentsPanel();
 });
 
-let cachedCleanHtml = '';
-let cachedPageMetadataHtml = null;
-const regenReplacements = [];
+function parseAndCacheCleanHtml(htmlDom) {
+  const metadataBlocks = [...htmlDom.querySelectorAll('div.metadata')];
+  let combinedInnerHtml = '';
+  metadataBlocks.forEach((block) => {
+    combinedInnerHtml += block.innerHTML;
+    const parent = block.parentElement;
+    block.remove();
+    if (parent && parent.children.length === 0) parent.remove();
+  });
+  if (metadataBlocks.length > 0) {
+    cachedMetadata = document.createElement('div');
+    cachedMetadata.className = 'metadata';
+    cachedMetadata.innerHTML = combinedInnerHtml;
+  }
+  cachedCleanHtml = htmlDom.innerHTML;
+}
 
 // ── Preview DOM helpers (annotationOperation only) ───────────────────────────
 
@@ -146,19 +187,11 @@ async function initializePreview() {
   const htmlDom = await getDADom();
   const headerEle = document.createElement('header');
   const mainEle = document.createElement('main');
-  const metadataEle = document.createElement('div');
-  metadataEle.classList.add('page-metadata');
-  if (cachedPageMetadataHtml !== null) {
-    metadataEle.innerHTML = cachedPageMetadataHtml;
-  } else {
-    htmlDom.querySelectorAll('div.metadata').forEach((mb) => {
-      metadataEle.innerHTML += mb.innerHTML;
-    });
-  }
-  mainEle.innerHTML = (htmlDom instanceof HTMLElement && htmlDom.tagName === 'MAIN')
-    ? htmlDom.innerHTML
-    : htmlDom;
-  document.body.append(metadataEle);
+  const rawHtml = (htmlDom instanceof HTMLElement && htmlDom.tagName === 'MAIN')
+    ? htmlDom
+    : null;
+  if (rawHtml) parseAndCacheCleanHtml(rawHtml);
+  mainEle.innerHTML = rawHtml ? rawHtml.innerHTML : htmlDom;
   document.body.prepend(mainEle);
   document.body.prepend(headerEle);
 }
@@ -416,28 +449,6 @@ function buildHtmlWithEditsAndAssets(assetReplacements) {
   rewriteMediaUrls(container);
   const mainEl = container.querySelector('main');
 
-  const pageMetadataDom = document.body.querySelector('main .page-metadata');
-  if (pageMetadataDom) {
-    cachedPageMetadataHtml = pageMetadataDom.innerHTML;
-    mainEl.querySelectorAll('.metadata').forEach((el) => {
-      const parentSection = el.parentElement;
-      el.remove();
-      if (parentSection.children.length === 0) parentSection.remove();
-    });
-    const metadataDiv = document.createElement('div');
-    metadataDiv.className = 'metadata';
-    metadataDiv.innerHTML = pageMetadataDom.innerHTML;
-    metadataDiv.querySelectorAll('p').forEach((p) => {
-      [...p.attributes].forEach((attr) => p.removeAttribute(attr.name));
-    });
-    metadataDiv.querySelectorAll('img').forEach((img) => {
-      img.setAttribute('src', img.getAttribute('data-stream-original-src'));
-    });
-    const divWrapper = document.createElement('div');
-    divWrapper.append(metadataDiv);
-    mainEl.appendChild(divWrapper);
-  }
-
   return { easyEdits, daCompatibleHtml: getDACompatibleHtml(mainEl.innerHTML) };
 }
 
@@ -519,7 +530,26 @@ function buildAssetReplacementsAndEdits(resolveTargetUrl) {
     }
   }
 
-  const assetReplacements = Array.from(latestByPath.values()).map((asset) => ({
+  const resolvedAssets = Array.from(latestByPath.values()).map((asset) => {
+    const liveEl = asset.elementRef
+      ? document.querySelector(`[data-annotation-ref="${asset.elementRef}"]`)
+      : null;
+    const isMetadata = Boolean(liveEl?.closest('main div.metadata'));
+    const imgEl = liveEl?.tagName === 'IMG' ? liveEl : liveEl?.querySelector('img');
+    let { originalSrc } = asset;
+    if (isMetadata) {
+      const fromAttr = imgEl?.getAttribute('data-stream-original-src');
+      if (fromAttr) {
+        originalSrc = fromAttr;
+      } else if (cachedMetadata) {
+        const cachedImg = cachedMetadata.querySelector('img[src*="content.da.live"]');
+        if (cachedImg) originalSrc = cachedImg.getAttribute('src') || asset.originalSrc;
+      }
+    }
+    return { asset, isMetadata, originalSrc };
+  });
+
+  const assetReplacements = resolvedAssets.map(({ asset }) => ({
     elementPath: asset.elementPath,
     elementProps: asset.elementProps,
     originalSrc: asset.originalSrc,
@@ -527,23 +557,24 @@ function buildAssetReplacementsAndEdits(resolveTargetUrl) {
     targetUrl: resolveTargetUrl(asset),
   }));
 
-  for (const asset of latestByPath.values()) {
+  for (const { asset, isMetadata, originalSrc } of resolvedAssets) {
     const finalUrl = resolveTargetUrl(asset);
     if (!asset.elementPath || !finalUrl) continue; // eslint-disable-line no-continue
+    const trackingPath = isMetadata ? 'metadata' : asset.elementPath;
     const existingEdit = store.getEasyEditByElement(
-      asset.elementRef || '', asset.elementPath, asset.elementProps,
+      asset.elementRef || '', trackingPath, asset.elementProps,
     );
     if (!existingEdit || existingEdit.editType === 'image-src') {
       store.upsertEasyEdit({
         ...(existingEdit || {}),
         editType: 'image-src',
-        elementPath: asset.elementPath,
+        elementPath: trackingPath,
         elementProps: asset.elementProps || {},
         elementRef: asset.elementRef || '',
-        from: existingEdit?.from || asset.originalSrc,
+        from: isMetadata ? originalSrc : (existingEdit?.from || originalSrc),
         to: finalUrl,
-        fromHtml: '',
-        toHtml: '',
+        fromHtml: isMetadata ? (cachedMetadata?.outerHTML || '') : '',
+        toHtml: isMetadata ? buildMetadataToHtml() : '',
         // Keep the original replacement time so panel ordering stays chronological.
         updatedAt: existingEdit?.updatedAt || new Date().toISOString(),
       });
@@ -586,8 +617,6 @@ export async function annotationOperation(options = {}) {
     });
   }
 
-  if (!cachedCleanHtml) cachedCleanHtml = mainEl.innerHTML || '';
-
   if (window.streamConfig?.source === 'da') {
     const insertedFragments = await hydrateFragmentLinksInDaBlocks(mainEl);
     for (const root of insertedFragments) {
@@ -598,42 +627,39 @@ export async function annotationOperation(options = {}) {
 
   await miloLoadArea();
 
-  const metadataDom = document.body.querySelector('.page-metadata');
-  const metadataSeparator = document.createElement('div');
-  metadataSeparator.classList.add('section', 'stream-annotation-page-metadata');
-  metadataSeparator.innerHTML = '<h3>Page Metadata</h3>';
-  metadataSeparator.append(metadataDom);
-
-  const addAndRegisterRow = (row) => {
-    metadataDom.append(row);
-    row.querySelectorAll('p').forEach((p) => inlineEditing.registerNewEditableElement(p));
-  };
-
-  const addTextBtn = document.createElement('button');
-  addTextBtn.className = 'stream-annotation-add-metadata-row';
-  addTextBtn.textContent = '+ Add text/link row';
-  addTextBtn.addEventListener('click', () => {
-    const row = document.createElement('div');
-    row.innerHTML = '<div><p>add metadata key</p></div><div><p>add text or link value</p></div>';
-    addAndRegisterRow(row);
-  });
-
-  const addImageBtn = document.createElement('button');
-  addImageBtn.className = 'stream-annotation-add-metadata-row';
-  addImageBtn.textContent = '+ Add image row';
-  addImageBtn.addEventListener('click', () => {
-    const row = document.createElement('div');
-    row.innerHTML = '<div><p>key</p></div><div><picture><img src="https://main--stream-mapper--adobecom.aem.live/assets/media_1bf6f8fe5a340bb3f4e022b300d7013821fe5ff89.png"></picture></div>';
-    addAndRegisterRow(row);
-  });
-
-  const metadataActions = document.createElement('div');
-  metadataActions.className = 'stream-annotation-metadata-actions';
-  metadataActions.append(addTextBtn, addImageBtn);
-  metadataSeparator.append(metadataActions);
-  mainEl.append(metadataSeparator);
-
   await finishAnnotationSession(mainEl, { preserveRemoteEditState, shouldRestoreInlineMode });
+
+  if (cachedMetadata) {
+    const divWrapper = document.createElement('div');
+    divWrapper.classList.add('section');
+    divWrapper.classList.add('stream-metadata-section');
+    const blocktitle = document.createElement('h3');
+    blocktitle.innerHTML += 'Page Metadata';
+    divWrapper.appendChild(blocktitle);
+    divWrapper.innerHTML += cachedMetadata.outerHTML;
+    mainEl.appendChild(divWrapper);
+
+    const metadataSection = mainEl.querySelector('.stream-metadata-section');
+    if (metadataSection) {
+      const imgResolves = [...metadataSection.querySelectorAll('img')].map(async (img) => {
+        const originalSrc = img.getAttribute('src') || '';
+        const resolved = await resolvePreviewUrl(originalSrc);
+        if (resolved && resolved !== originalSrc) {
+          img.setAttribute('data-stream-original-src', originalSrc);
+          img.setAttribute('src', resolved);
+        }
+      });
+      const sourceResolves = [...metadataSection.querySelectorAll('source')].map(async (source) => {
+        const originalSrcset = source.getAttribute('srcset') || '';
+        const resolved = await resolvePreviewUrl(originalSrcset);
+        if (resolved && resolved !== originalSrcset) {
+          source.setAttribute('data-stream-original-srcset', originalSrcset);
+          source.setAttribute('srcset', resolved);
+        }
+      });
+      await Promise.all([...imgResolves, ...sourceResolves]);
+    }
+  }
 }
 
 export async function annotationOperationOnHostPage(options = {}) {

--- a/streamlibs/operations/annotation.js
+++ b/streamlibs/operations/annotation.js
@@ -571,7 +571,6 @@ async function finishAnnotationSession(mainEl, {
     commentsPanel.renderThreadMarkers({ resolveTargets: true });
     commentsPanel.renderCommentsPanel();
   }
-  await store.applyEasyEditsToDom();
 
   for (const blockClass of cachedMetadataBlocks.keys()) {
     const divWrapper = document.createElement('div');
@@ -611,6 +610,11 @@ async function finishAnnotationSession(mainEl, {
         blockEl.append(row);
         row.querySelectorAll('p').forEach((p) => inlineEditing.registerNewEditableElement(p));
         ensureUserMetadataRowDeleteButton(row);
+        const toHtml = buildBlockToHtml(blockClass);
+        (annotationState.store.easyEdits || []).forEach((e) => {
+          if (e.blockClass === blockClass && e.toHtml) e.toHtml = toHtml;
+        });
+        store.saveAnnotationStore();
       };
       const addTextBtn = document.createElement('button');
       addTextBtn.className = 'stream-annotation-add-metadata-row';
@@ -634,8 +638,8 @@ async function finishAnnotationSession(mainEl, {
       divWrapper.append(metadataActions);
     }
   }
+  await store.applyEasyEditsToDom();
 
-  if (cachedMetadataBlocks.size > 0) await store.applyEasyEditsToDom();
 }
 
 // ── Asset / edit processing (shared by persist and save) ──────────────────────

--- a/streamlibs/operations/annotation.js
+++ b/streamlibs/operations/annotation.js
@@ -20,6 +20,7 @@ import createAssetServiceClient from './annotation/asset-service.js';
 import createAssetsPanelController from './annotation/assets-panel.js';
 import requestParentCollabRefresh from './annotation/collab-sync.js';
 import { handleError } from '../utils/error-handler.js';
+import { BLOCK_CLASSES, BLOCK_CLASS_TEMPLATES } from '../utils/constants.js';
 
 // ── Module singletons ────────────────────────────────────────────────────────
 
@@ -92,13 +93,14 @@ const commentsPanel = createCommentsPanelController({
 commentsPanel.setImageRegenHandler(recordImageRegenAsLocalAsset);
 
 let cachedCleanHtml = '';
-let cachedMetadata = null;
+// blockClass -> combined <div> holding the original HTML for that block.
+const cachedMetadataBlocks = new Map();
 const regenReplacements = [];
-
-function buildMetadataToHtml() {
-  const liveMetadata = document.querySelector('main div.metadata');
-  if (!liveMetadata) return '';
-  const clone = liveMetadata.cloneNode(true);
+//Looks on the page for the live metadata block and makes copy 
+function buildBlockToHtml(blockClass) {
+  const liveBlock = document.querySelector(`main div.${blockClass}`);
+  if (!liveBlock) return '';
+  const clone = liveBlock.cloneNode(true);
   clone.querySelectorAll('picture').forEach((picture) => {
     const img = picture.querySelector('img');
     if (img) picture.replaceWith(img);
@@ -124,8 +126,8 @@ const inlineEditing = createInlineEditingController({
   renderThreadMarkers: commentsPanel.renderThreadMarkers,
   renderCommentsPanel: commentsPanel.renderCommentsPanel,
   removePopup: commentsPanel.removePopup,
-  getMetadataFromHtml: () => (cachedMetadata ? cachedMetadata.outerHTML : ''),
-  buildMetadataToHtml,
+  getBlockFromHtml: (blockClass) => cachedMetadataBlocks.get(blockClass)?.outerHTML || '',
+  buildBlockToHtml,
 });
 
 commentsPanel.setInlineModeHandlers({
@@ -137,21 +139,32 @@ assetsPanel.setOnAssetsChanged(() => {
   commentsPanel.renderThreadMarkers({ resolveTargets: true });
   commentsPanel.renderCommentsPanel();
 });
-
+//pull mtdt/card-mtdt blocks out saves for later and keeps rest of html as cleaned page
 function parseAndCacheCleanHtml(htmlDom) {
-  const metadataBlocks = [...htmlDom.querySelectorAll('div.metadata')];
-  let combinedInnerHtml = '';
-  metadataBlocks.forEach((block) => {
-    combinedInnerHtml += block.innerHTML;
-    const parent = block.parentElement;
-    block.remove();
-    if (parent && parent.children.length === 0) parent.remove();
+  cachedMetadataBlocks.clear();
+  BLOCK_CLASSES.forEach((blockClass) => {
+    const blocks = [...htmlDom.querySelectorAll(`div.${blockClass}`)];
+    let combinedInnerHtml = '';
+    blocks.forEach((block) => {
+      combinedInnerHtml += block.innerHTML;
+      const parent = block.parentElement;
+      block.remove();
+      if (parent && parent.children.length === 0) parent.remove();
+    });
+    if (blocks.length === 0) {
+      const template = BLOCK_CLASS_TEMPLATES[blockClass];
+      if (template){
+           // template: seed keys table (card-metadata)
+      combinedInnerHtml = template
+        .map((key) => `<div><div>${key}</div><div></div></div>`)
+        .join('');
+      }
+    }
+    const cached = document.createElement('div');
+    cached.className = blockClass;
+    cached.innerHTML = combinedInnerHtml;
+    cachedMetadataBlocks.set(blockClass, cached);
   });
-  if (metadataBlocks.length > 0) {
-    cachedMetadata = document.createElement('div');
-    cachedMetadata.className = 'metadata';
-    cachedMetadata.innerHTML = combinedInnerHtml;
-  }
   cachedCleanHtml = htmlDom.innerHTML;
 }
 
@@ -449,6 +462,18 @@ function buildHtmlWithEditsAndAssets(assetReplacements) {
   rewriteMediaUrls(container);
   const mainEl = container.querySelector('main');
 
+  // Metadata-like blocks live outside the page body: for each block we pulled out, clean
+  // any separate inline instances then re-append its edited HTML  at
+  // the end before pushing.
+  cachedMetadataBlocks.forEach((cachedBlock, blockClass) => {
+    mainEl.querySelectorAll(`div.${blockClass}`).forEach((block) => block.remove());
+    //picks the most recent saved edit for that metadata block (elementPath matches blockClass and has toHtml), so that version is used when re-appending the block on save instead of the original cached HTML.
+    const blockEdit = easyEdits.filter((e) => e.elementPath === blockClass && e.toHtml).at(-1);
+    const finalHtml = blockEdit?.toHtml
+      || (cachedBlock.innerHTML.trim() ? cachedBlock.outerHTML : '');
+    if (finalHtml) mainEl.insertAdjacentHTML('beforeend', finalHtml);
+  });
+
   return { easyEdits, daCompatibleHtml: getDACompatibleHtml(mainEl.innerHTML) };
 }
 
@@ -534,19 +559,24 @@ function buildAssetReplacementsAndEdits(resolveTargetUrl) {
     const liveEl = asset.elementRef
       ? document.querySelector(`[data-annotation-ref="${asset.elementRef}"]`)
       : null;
-    const isMetadata = Boolean(liveEl?.closest('main div.metadata'));
+      //checks if this image inside a metadata block?
+      //fig out real ori da img url instead or using preview url shown  onscreen
+    const liveBlock = liveEl?.closest(BLOCK_CLASSES.map((c) => `main div.${c}`).join(', '));
+    const blockClass = liveBlock
+      ? (BLOCK_CLASSES.find((c) => liveBlock.classList.contains(c)) || '') : '';
     const imgEl = liveEl?.tagName === 'IMG' ? liveEl : liveEl?.querySelector('img');
     let { originalSrc } = asset;
-    if (isMetadata) {
+    if (blockClass) {
       const fromAttr = imgEl?.getAttribute('data-stream-original-src');
+      const cachedBlock = cachedMetadataBlocks.get(blockClass);
       if (fromAttr) {
         originalSrc = fromAttr;
-      } else if (cachedMetadata) {
-        const cachedImg = cachedMetadata.querySelector('img[src*="content.da.live"]');
+      } else if (cachedBlock) {
+        const cachedImg = cachedBlock.querySelector('img[src*="content.da.live"]');
         if (cachedImg) originalSrc = cachedImg.getAttribute('src') || asset.originalSrc;
       }
     }
-    return { asset, isMetadata, originalSrc };
+    return { asset, blockClass, originalSrc };
   });
 
   const assetReplacements = resolvedAssets.map(({ asset }) => ({
@@ -557,10 +587,10 @@ function buildAssetReplacementsAndEdits(resolveTargetUrl) {
     targetUrl: resolveTargetUrl(asset),
   }));
 
-  for (const { asset, isMetadata, originalSrc } of resolvedAssets) {
+  for (const { asset, blockClass, originalSrc } of resolvedAssets) {
     const finalUrl = resolveTargetUrl(asset);
     if (!asset.elementPath || !finalUrl) continue; // eslint-disable-line no-continue
-    const trackingPath = isMetadata ? 'metadata' : asset.elementPath;
+    const trackingPath = blockClass || asset.elementPath;
     const existingEdit = store.getEasyEditByElement(
       asset.elementRef || '', trackingPath, asset.elementProps,
     );
@@ -571,10 +601,10 @@ function buildAssetReplacementsAndEdits(resolveTargetUrl) {
         elementPath: trackingPath,
         elementProps: asset.elementProps || {},
         elementRef: asset.elementRef || '',
-        from: isMetadata ? originalSrc : (existingEdit?.from || originalSrc),
+        from: blockClass ? originalSrc : (existingEdit?.from || originalSrc),
         to: finalUrl,
-        fromHtml: isMetadata ? (cachedMetadata?.outerHTML || '') : '',
-        toHtml: isMetadata ? buildMetadataToHtml() : '',
+        fromHtml: blockClass ? (cachedMetadataBlocks.get(blockClass)?.outerHTML || '') : '',
+        toHtml: blockClass ? buildBlockToHtml(blockClass) : '',
         // Keep the original replacement time so panel ordering stays chronological.
         updatedAt: existingEdit?.updatedAt || new Date().toISOString(),
       });
@@ -629,37 +659,39 @@ export async function annotationOperation(options = {}) {
 
   await finishAnnotationSession(mainEl, { preserveRemoteEditState, shouldRestoreInlineMode });
 
-  if (cachedMetadata) {
+  for (const blockClass of cachedMetadataBlocks.keys()) {
     const divWrapper = document.createElement('div');
     divWrapper.classList.add('section');
     divWrapper.classList.add('stream-metadata-section');
     const blocktitle = document.createElement('h3');
-    blocktitle.innerHTML += 'Page Metadata';
+    blocktitle.textContent = blockClass.replace(/-/g, ' ').replace(/\b\w/g, (m) => m.toUpperCase());
     divWrapper.appendChild(blocktitle);
-    divWrapper.innerHTML += cachedMetadata.outerHTML;
+    divWrapper.innerHTML += cachedMetadataBlocks.get(blockClass).outerHTML;
     mainEl.appendChild(divWrapper);
 
-    const metadataSection = mainEl.querySelector('.stream-metadata-section');
-    if (metadataSection) {
-      const imgResolves = [...metadataSection.querySelectorAll('img')].map(async (img) => {
-        const originalSrc = img.getAttribute('src') || '';
-        const resolved = await resolvePreviewUrl(originalSrc);
-        if (resolved && resolved !== originalSrc) {
-          img.setAttribute('data-stream-original-src', originalSrc);
-          img.setAttribute('src', resolved);
-        }
-      });
-      const sourceResolves = [...metadataSection.querySelectorAll('source')].map(async (source) => {
-        const originalSrcset = source.getAttribute('srcset') || '';
-        const resolved = await resolvePreviewUrl(originalSrcset);
-        if (resolved && resolved !== originalSrcset) {
-          source.setAttribute('data-stream-original-srcset', originalSrcset);
-          source.setAttribute('srcset', resolved);
-        }
-      });
-      await Promise.all([...imgResolves, ...sourceResolves]);
-    }
+    const imgResolves = [...divWrapper.querySelectorAll('img')].map(async (img) => {
+      const originalSrc = img.getAttribute('src') || '';
+      const resolved = await resolvePreviewUrl(originalSrc);
+      if (resolved && resolved !== originalSrc) {
+        img.setAttribute('data-stream-original-src', originalSrc);
+        img.setAttribute('src', resolved);
+      }
+    });
+    const sourceResolves = [...divWrapper.querySelectorAll('source')].map(async (source) => {
+      const originalSrcset = source.getAttribute('srcset') || '';
+      const resolved = await resolvePreviewUrl(originalSrcset);
+      if (resolved && resolved !== originalSrcset) {
+        source.setAttribute('data-stream-original-srcset', originalSrcset);
+        source.setAttribute('srcset', resolved);
+      }
+    });
+    // eslint-disable-next-line no-await-in-loop
+    await Promise.all([...imgResolves, ...sourceResolves]);
   }
+
+  // Sections now exist in the DOM: re-apply edits so saved metadata-like edits replace
+  // their block with toHtml on initial load (handled by store.applyEasyEditsToDom).
+  if (cachedMetadataBlocks.size > 0) await store.applyEasyEditsToDom();
 }
 
 export async function annotationOperationOnHostPage(options = {}) {

--- a/streamlibs/operations/annotation.js
+++ b/streamlibs/operations/annotation.js
@@ -107,6 +107,7 @@ function buildBlockToHtml(blockClass) {
   const liveBlock = document.querySelector(`main div.${blockClass}`);
   if (!liveBlock) return '';
   const clone = liveBlock.cloneNode(true);
+  clone.querySelectorAll('.stream-annotation-delete-metadata-row').forEach((el) => el.remove());
   clone.querySelectorAll('picture').forEach((picture) => {
     const img = picture.querySelector('img');
     if (img) picture.replaceWith(img);
@@ -124,6 +125,56 @@ function buildBlockToHtml(blockClass) {
   });
   return getDACompatibleHtml(clone.outerHTML);
 }
+const METADATA_USER_ROW_CLASS = 'stream-metadata-user-row';
+const METADATA_ROW_DELETE_BTN_CLASS = 'stream-annotation-delete-metadata-row';
+
+function removeUserMetadataRow(row) {
+  if (!(row instanceof HTMLElement) || !row.classList.contains(METADATA_USER_ROW_CLASS)) return;
+  const blockClass = isMetadata(row);
+  row.remove();
+  if (blockClass) {
+    // Refresh the block's edit(s) so the deletion is reflected in toHtml (display + push).
+    const toHtml = buildBlockToHtml(blockClass);
+    (annotationState.store.easyEdits || []).forEach((e) => {
+      if (e.blockClass === blockClass && e.toHtml) e.toHtml = toHtml;
+    });
+    store.saveAnnotationStore();
+  }
+  commentsPanel.renderThreadMarkers({ resolveTargets: true });
+}
+
+function ensureUserMetadataRowDeleteButton(row) {
+  if (!(row instanceof HTMLElement) || !row.classList.contains(METADATA_USER_ROW_CLASS)) return;
+  if (row.querySelector(`:scope > .${METADATA_ROW_DELETE_BTN_CLASS}`)) return;
+  const deleteBtn = document.createElement('button');
+  deleteBtn.type = 'button';
+  deleteBtn.className = METADATA_ROW_DELETE_BTN_CLASS;
+  deleteBtn.setAttribute('aria-label', 'Delete metadata row');
+  deleteBtn.textContent = '×';
+  deleteBtn.addEventListener('click', (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+    removeUserMetadataRow(row);
+  });
+  row.append(deleteBtn);
+}
+
+// Re-attach delete controls after a block re-render (called via store callback).
+function decorateMetadataUserRows(block) {
+  if (!(block instanceof HTMLElement)) return;
+  block.querySelectorAll(`:scope > .${METADATA_USER_ROW_CLASS}`).forEach(ensureUserMetadataRowDeleteButton);
+}
+
+// On Save, user-added rows become permanent: drop the marker + delete control.
+function commitMetadataRows() {
+  if (!annotationUI.mainEl) return;
+  annotationUI.mainEl.querySelectorAll(`.stream-metadata-section .${METADATA_USER_ROW_CLASS}`).forEach((row) => {
+    row.querySelectorAll(`.${METADATA_ROW_DELETE_BTN_CLASS}`).forEach((b) => b.remove());
+    row.classList.remove(METADATA_USER_ROW_CLASS);
+  });
+}
+
+store.setOnMetadataBlockRendered(decorateMetadataUserRows);
 
 const inlineEditing = createInlineEditingController({
   annotationState,
@@ -473,6 +524,9 @@ function buildHtmlWithEditsAndAssets(assetReplacements) {
     if (finalHtml) mainEl.insertAdjacentHTML('beforeend', `<div>${finalHtml}</div>`);
   });
 
+  mainEl.querySelectorAll('.stream-metadata-user-row').forEach((el) => el.classList.remove('stream-metadata-user-row'));
+  mainEl.querySelectorAll('.stream-annotation-delete-metadata-row').forEach((el) => el.remove());
+
   return { easyEdits, daCompatibleHtml: getDACompatibleHtml(mainEl.innerHTML) };
 }
 
@@ -547,6 +601,38 @@ async function finishAnnotationSession(mainEl, {
     });
     // eslint-disable-next-line no-await-in-loop
     await Promise.all([...imgResolves, ...sourceResolves]);
+
+    // Add-row controls — generalized for any BLOCK_CLASSES block (rows append to this
+    // block's live DOM; new <p> cells register as editable so edits persist via toHtml).
+    const blockEl = divWrapper.querySelector(`div.${blockClass}`);
+    if (blockEl) {
+      const addAndRegisterRow = (row) => {
+        row.classList.add(METADATA_USER_ROW_CLASS);
+        blockEl.append(row);
+        row.querySelectorAll('p').forEach((p) => inlineEditing.registerNewEditableElement(p));
+        ensureUserMetadataRowDeleteButton(row);
+      };
+      const addTextBtn = document.createElement('button');
+      addTextBtn.className = 'stream-annotation-add-metadata-row';
+      addTextBtn.textContent = '+ Add text/link row';
+      addTextBtn.addEventListener('click', () => {
+        const row = document.createElement('div');
+        row.innerHTML = '<div><p>add metadata key</p></div><div><p>add text or link value</p></div>';
+        addAndRegisterRow(row);
+      });
+      const addImageBtn = document.createElement('button');
+      addImageBtn.className = 'stream-annotation-add-metadata-row';
+      addImageBtn.textContent = '+ Add image row';
+      addImageBtn.addEventListener('click', () => {
+        const row = document.createElement('div');
+        row.innerHTML = '<div><p>key</p></div><div><picture><img src="https://main--stream-mapper--adobecom.aem.live/assets/media_1bf6f8fe5a340bb3f4e022b300d7013821fe5ff89.png"></picture></div>';
+        addAndRegisterRow(row);
+      });
+      const metadataActions = document.createElement('div');
+      metadataActions.className = 'stream-annotation-metadata-actions';
+      metadataActions.append(addTextBtn, addImageBtn);
+      divWrapper.append(metadataActions);
+    }
   }
 
   if (cachedMetadataBlocks.size > 0) await store.applyEasyEditsToDom();
@@ -622,18 +708,23 @@ function buildAssetReplacementsAndEdits(resolveTargetUrl) {
     const existingEdit = store.getEasyEditByElement(
       asset.elementRef || '', asset.elementPath, asset.elementProps,
     );
+    // Keep the metadata classification even when the live ref didn't resolve (e.g. an added
+    // image row whose data-annotation-ref was stripped + <picture> flattened on re-render) —
+    // otherwise the edit downgrades to non-metadata and skips the metadata preview path → 401.
+    const effectiveBlockClass = blockClass || existingEdit?.blockClass || '';
     if (!existingEdit || existingEdit.editType === 'image-src') {
       store.upsertEasyEdit({
         ...(existingEdit || {}),
         editType: 'image-src',
         elementPath: asset.elementPath,
-        blockClass,
+        blockClass: effectiveBlockClass,
         elementProps: asset.elementProps || {},
         elementRef: asset.elementRef || '',
-        from: blockClass ? originalSrc : (existingEdit?.from || originalSrc),
+        from: effectiveBlockClass ? originalSrc : (existingEdit?.from || originalSrc),
         to: finalUrl,
-        fromHtml: blockClass ? (cachedMetadataBlocks.get(blockClass)?.outerHTML || '') : '',
-        toHtml: blockClass ? buildBlockToHtml(blockClass) : '',
+        fromHtml: effectiveBlockClass
+          ? (cachedMetadataBlocks.get(effectiveBlockClass)?.outerHTML || '') : '',
+        toHtml: effectiveBlockClass ? buildBlockToHtml(effectiveBlockClass) : '',
         // Keep the original replacement time so panel ordering stays chronological.
         updatedAt: existingEdit?.updatedAt || new Date().toISOString(),
       });
@@ -806,6 +897,8 @@ async function persistEditsToDb() {
 }
 
 export async function saveAnnotationChanges(reportProgress = () => {}) {
+  
+  commitMetadataRows();
   await inlineEditing.syncInlineEditsBeforePersist();
   await uploadAndDecideAssets();
   // Save assigns each image edit its content.da.live URL (no DA push here).

--- a/streamlibs/operations/annotation.js
+++ b/streamlibs/operations/annotation.js
@@ -471,7 +471,9 @@ function buildHtmlWithEditsAndAssets(assetReplacements) {
     const blockEdit = easyEdits.filter((e) => e.elementPath === blockClass && e.toHtml).at(-1);
     const finalHtml = blockEdit?.toHtml
       || (cachedBlock.innerHTML.trim() ? cachedBlock.outerHTML : '');
-    if (finalHtml) mainEl.insertAdjacentHTML('beforeend', finalHtml);
+    // Wrap in a section <div> so DA treats it as a block inside a section (not a bare
+    // section), otherwise the block's rows flatten into plain paragraphs on the page.
+    if (finalHtml) mainEl.insertAdjacentHTML('beforeend', `<div>${finalHtml}</div>`);
   });
 
   return { easyEdits, daCompatibleHtml: getDACompatibleHtml(mainEl.innerHTML) };
@@ -519,6 +521,38 @@ async function finishAnnotationSession(mainEl, {
     commentsPanel.renderCommentsPanel();
   }
   await store.applyEasyEditsToDom();
+
+  for (const blockClass of cachedMetadataBlocks.keys()) {
+    const divWrapper = document.createElement('div');
+    divWrapper.classList.add('section');
+    divWrapper.classList.add('stream-metadata-section');
+    const blocktitle = document.createElement('h3');
+    blocktitle.textContent = blockClass.replace(/-/g, ' ').replace(/\b\w/g, (m) => m.toUpperCase());
+    divWrapper.appendChild(blocktitle);
+    divWrapper.innerHTML += cachedMetadataBlocks.get(blockClass).outerHTML;
+    mainEl.appendChild(divWrapper);
+
+    const imgResolves = [...divWrapper.querySelectorAll('img')].map(async (img) => {
+      const originalSrc = img.getAttribute('src') || '';
+      const resolved = await resolvePreviewUrl(originalSrc);
+      if (resolved && resolved !== originalSrc) {
+        img.setAttribute('data-stream-original-src', originalSrc);
+        img.setAttribute('src', resolved);
+      }
+    });
+    const sourceResolves = [...divWrapper.querySelectorAll('source')].map(async (source) => {
+      const originalSrcset = source.getAttribute('srcset') || '';
+      const resolved = await resolvePreviewUrl(originalSrcset);
+      if (resolved && resolved !== originalSrcset) {
+        source.setAttribute('data-stream-original-srcset', originalSrcset);
+        source.setAttribute('srcset', resolved);
+      }
+    });
+    // eslint-disable-next-line no-await-in-loop
+    await Promise.all([...imgResolves, ...sourceResolves]);
+  }
+
+  if (cachedMetadataBlocks.size > 0) await store.applyEasyEditsToDom();
 }
 
 // ── Asset / edit processing (shared by persist and save) ──────────────────────
@@ -658,40 +692,6 @@ export async function annotationOperation(options = {}) {
   await miloLoadArea();
 
   await finishAnnotationSession(mainEl, { preserveRemoteEditState, shouldRestoreInlineMode });
-
-  for (const blockClass of cachedMetadataBlocks.keys()) {
-    const divWrapper = document.createElement('div');
-    divWrapper.classList.add('section');
-    divWrapper.classList.add('stream-metadata-section');
-    const blocktitle = document.createElement('h3');
-    blocktitle.textContent = blockClass.replace(/-/g, ' ').replace(/\b\w/g, (m) => m.toUpperCase());
-    divWrapper.appendChild(blocktitle);
-    divWrapper.innerHTML += cachedMetadataBlocks.get(blockClass).outerHTML;
-    mainEl.appendChild(divWrapper);
-
-    const imgResolves = [...divWrapper.querySelectorAll('img')].map(async (img) => {
-      const originalSrc = img.getAttribute('src') || '';
-      const resolved = await resolvePreviewUrl(originalSrc);
-      if (resolved && resolved !== originalSrc) {
-        img.setAttribute('data-stream-original-src', originalSrc);
-        img.setAttribute('src', resolved);
-      }
-    });
-    const sourceResolves = [...divWrapper.querySelectorAll('source')].map(async (source) => {
-      const originalSrcset = source.getAttribute('srcset') || '';
-      const resolved = await resolvePreviewUrl(originalSrcset);
-      if (resolved && resolved !== originalSrcset) {
-        source.setAttribute('data-stream-original-srcset', originalSrcset);
-        source.setAttribute('srcset', resolved);
-      }
-    });
-    // eslint-disable-next-line no-await-in-loop
-    await Promise.all([...imgResolves, ...sourceResolves]);
-  }
-
-  // Sections now exist in the DOM: re-apply edits so saved metadata-like edits replace
-  // their block with toHtml on initial load (handled by store.applyEasyEditsToDom).
-  if (cachedMetadataBlocks.size > 0) await store.applyEasyEditsToDom();
 }
 
 export async function annotationOperationOnHostPage(options = {}) {
@@ -720,7 +720,8 @@ export async function annotationOperationOnHostPage(options = {}) {
       try {
         const cfg = window.streamConfig;
         const daMain = await fetchDAContent(cfg.draftLocation || cfg.contentUrl);
-        cachedCleanHtml = daMain?.innerHTML || '';
+        if (daMain) parseAndCacheCleanHtml(daMain);
+        else cachedCleanHtml = '';
       } catch (err) {
         console.warn('[annotation] Failed to fetch DA baseline HTML, falling back to live DOM:', err);
         cachedCleanHtml = '';

--- a/streamlibs/operations/annotation/annotation.css
+++ b/streamlibs/operations/annotation/annotation.css
@@ -2400,91 +2400,42 @@ body.editor-mode .figma-panel .has-block-action .block-action-btn.block-action-b
     outline-offset: 2px;
   }
 
-  .annotation-mode .stream-annotation-page-metadata {
+  .annotation-mode .stream-metadata-section {
+    justify-self: center;
+    width: 80%;
+  }
+
+  .annotation-mode main div.metadata {
     width: 100%;
-    border-top: 2px dashed #ababab;
-    margin-top: 10px;
-    background: #eff5ff;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    padding: 10px;
-    background: #fff;
-    padding-bottom: 50px;
+    border-collapse: collapse;
+    display: table;
+    margin-top: 16px;
+    font-size: 14px;
   }
 
-  .annotation-mode .stream-annotation-page-metadata h3 {
-    display: flex;
-    align-items: start;
-    width: 80%;
-    padding: 20px;
-    color: #1d4ed8;
+  .annotation-mode main div.metadata > div {
+    display: table-row;
   }
 
-  .annotation-mode .page-metadata {
-    width: 80%;
-    display: flex;
-    flex-wrap: wrap;
+  .annotation-mode main div.metadata > div > div {
+    display: table-cell;
+    border: 1px solid #d1d5db;
+    padding: 8px 16px;
+    vertical-align: top;
   }
 
-  .annotation-mode .page-metadata > div {
-    display: flex;
-    width: 100%;
-    box-sizing: border-box;
-  }
-
-  .annotation-mode .page-metadata > div > div:first-child {
-    font-weight: bold;
-  }
-
-  .annotation-mode .page-metadata > div > div {
-    flex: 1 1 0;
-    min-width: 0;
-    border: 0.5px solid #cacaca;
-    padding: 10px;
-    padding-left: 20px;
-  }
-
-  .annotation-mode .page-metadata > div > div img {
-    width: 100px;
-    height: auto;
-    max-width: 100px;
-  }
-
-  .annotation-mode .stream-annotation-metadata-actions {
-    display: none;
-    width: 80%;
-    flex-direction: row;
-    gap: 8px;
-    margin-top: 10px;
-  }
-
-  .annotation-inline-edit-mode .stream-annotation-metadata-actions {
-    display: flex;
-  }
-
-  .annotation-mode .stream-annotation-add-metadata-row {
-    padding: 5px 14px;
-    background: #fff;
-    border: 1px solid #3d63ae;
-    border-radius: 4px;
-    color: #3d63ae;
-    font-size: 12px;
-    cursor: pointer;
+  .annotation-mode main div.metadata > div > div:first-child {
+    font-weight: 600;
+    width: 30%;
+    background: #f8fafc;
+    color: #374151;
     white-space: nowrap;
   }
 
-  .annotation-inline-edit-mode .stream-annotation-add-metadata-row:hover {
-    background: #3d63ae;
-    color: #fff;
-  }
-
-  .page-metadata .annotation-asset-pending-badge {
-    display: none;
-  }
-
-  main > .section, .fragment > .section {
-    min-height: 50px;
+  .annotation-mode main div.metadata > div > div img {
+    width: 50px;
+    height: auto;
+    max-width: 80px;
   }
 
 

--- a/streamlibs/operations/annotation/annotation.css
+++ b/streamlibs/operations/annotation/annotation.css
@@ -2483,7 +2483,7 @@ body.editor-mode .figma-panel .has-block-action .block-action-btn.block-action-b
     display: none;
   }
 
-  .fragment > .section {
+  main > .section, .fragment > .section {
     min-height: 50px;
   }
 

--- a/streamlibs/operations/annotation/annotation.css
+++ b/streamlibs/operations/annotation/annotation.css
@@ -2411,35 +2411,86 @@ body.editor-mode .figma-panel .has-block-action .block-action-btn.block-action-b
   
   .annotation-mode .stream-metadata-section > div {
     width: 100%;
-    border-collapse: collapse;
-    display: table;
+    display: flex;
+    flex-wrap: wrap;
     margin-top: 16px;
     font-size: 14px;
   }
 
   .annotation-mode .stream-metadata-section > div > div {
-    display: table-row;
+    display: flex;
+    width: 100%;
+    box-sizing: border-box;
+    position: relative;
   }
 
   .annotation-mode .stream-metadata-section > div > div > div {
-    display: table-cell;
-    border: 1px solid #d1d5db;
-    padding: 8px 16px;
-    vertical-align: top;
+    flex: 1 1 0;
+    min-width: 0;
+    border: 0.5px solid #cacaca;
+    padding: 10px;
+    padding-left: 20px;
   }
 
   .annotation-mode .stream-metadata-section > div > div > div:first-child {
-    font-weight: 600;
-    width: 30%;
-    background: #f8fafc;
-    color: #374151;
-    white-space: nowrap;
+    font-weight: bold;
   }
 
   .annotation-mode .stream-metadata-section > div > div > div img {
-    width: 50px;
+    width: 100px;
     height: auto;
-    max-width: 80px;
+    max-width: 100px;
+  }
+
+  .annotation-mode .stream-metadata-section .stream-annotation-metadata-actions {
+    display: none;
+    width: 80%;
+    flex-direction: row;
+    gap: 8px;
+    margin-top: 10px;
+  }
+
+  .annotation-inline-edit-mode .stream-metadata-section .stream-annotation-metadata-actions {
+    display: flex;
+  }
+
+  .annotation-mode .stream-annotation-add-metadata-row {
+    padding: 5px 14px;
+    background: #fff;
+    border: 1px solid #3d63ae;
+    border-radius: 4px;
+    color: #3d63ae;
+    font-size: 12px;
+    cursor: pointer;
+    white-space: nowrap;
+  }
+
+  .annotation-inline-edit-mode .stream-annotation-add-metadata-row:hover {
+    background: #3d63ae;
+    color: #fff;
+  }
+
+  .annotation-inline-edit-mode .stream-metadata-section .stream-annotation-delete-metadata-row {
+    position: absolute;
+    top: 6px;
+    right: 6px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0 6px;
+    min-width: 22px;
+    height: 22px;
+    border: 1px solid #b3b3b3;
+    border-radius: 4px;
+    background: #fff;
+    color: #505050;
+    font-size: 14px;
+    line-height: 1;
+    cursor: pointer;
+  }
+
+  .annotation-mode:not(.annotation-inline-edit-mode) .stream-metadata-section .stream-annotation-delete-metadata-row {
+    display: none;
   }
 
 

--- a/streamlibs/operations/annotation/annotation.css
+++ b/streamlibs/operations/annotation/annotation.css
@@ -2405,7 +2405,11 @@ body.editor-mode .figma-panel .has-block-action .block-action-btn.block-action-b
     width: 80%;
   }
 
-  .annotation-mode main div.metadata {
+  .annotation-mode .stream-metadata-section h3 {
+    color: #1d4ed8;
+  }
+  
+  .annotation-mode .stream-metadata-section > div {
     width: 100%;
     border-collapse: collapse;
     display: table;
@@ -2413,18 +2417,18 @@ body.editor-mode .figma-panel .has-block-action .block-action-btn.block-action-b
     font-size: 14px;
   }
 
-  .annotation-mode main div.metadata > div {
+  .annotation-mode .stream-metadata-section > div > div {
     display: table-row;
   }
 
-  .annotation-mode main div.metadata > div > div {
+  .annotation-mode .stream-metadata-section > div > div > div {
     display: table-cell;
     border: 1px solid #d1d5db;
     padding: 8px 16px;
     vertical-align: top;
   }
 
-  .annotation-mode main div.metadata > div > div:first-child {
+  .annotation-mode .stream-metadata-section > div > div > div:first-child {
     font-weight: 600;
     width: 30%;
     background: #f8fafc;
@@ -2432,7 +2436,7 @@ body.editor-mode .figma-panel .has-block-action .block-action-btn.block-action-b
     white-space: nowrap;
   }
 
-  .annotation-mode main div.metadata > div > div img {
+  .annotation-mode .stream-metadata-section > div > div > div img {
     width: 50px;
     height: auto;
     max-width: 80px;

--- a/streamlibs/operations/annotation/assets-panel.js
+++ b/streamlibs/operations/annotation/assets-panel.js
@@ -101,6 +101,9 @@ export default function createAssetsPanelController({
   // Sets href on an anchor to realUrl when it's a proper URL, or attaches a
   // blob-URL click handler when only a data URL (previewSrc) is available.
   function setAssetLinkHref(anchorEl, previewSrc, realUrl) {
+    if (realUrl && realUrl.includes('fpo.svg#')) {
+      realUrl = realUrl.split('#')[1].replace('admin.da.live/source/', 'content.da.live/');
+    }
     if (realUrl && !realUrl.startsWith('data:')) {
       anchorEl.href = realUrl;
       return;
@@ -449,7 +452,7 @@ export default function createAssetsPanelController({
       return;
     }
 
-    const originalSrc = targetImg.dataset.streamOriginalSrc || targetImg.dataset.originalSrc || elementProps?.src || targetImg.src || '';
+    const originalSrc = targetImg.dataset.originalSrc || elementProps?.src || targetImg.src || '';
 
     // Cache the absolute loaded URL so a page-relative originalSrc still renders.
     const fromDisplaySrc = targetImg.currentSrc || targetImg.src || '';

--- a/streamlibs/operations/annotation/assets-panel.js
+++ b/streamlibs/operations/annotation/assets-panel.js
@@ -4,6 +4,7 @@
 /* eslint-disable no-restricted-syntax */
 import { showGlobalSnackbar } from '../../utils/snackbar.js';
 import { formatCardTimestamp, ARROW_ICON_SVG } from '../../utils/utils.js';
+import { BLOCK_CLASSES } from '../../utils/constants.js';
 
 const ALLOWED_MIME_TYPES = [
   'image/png', 'image/jpeg',
@@ -499,13 +500,15 @@ export default function createAssetsPanelController({
     const assetFileKey = store.generateId('asset-file');
     store.registerAssetFile(assetFileKey, file, base64Data);
     localAsset.assetFileKey = assetFileKey;
-    const isInMetadata = Boolean(targetImg.closest('main div.metadata'));
+    const metaBlock = targetImg.closest(BLOCK_CLASSES.map((c) => `main div.${c}`).join(', '));
+    const blockClass = metaBlock
+      ? (BLOCK_CLASSES.find((c) => metaBlock.classList.contains(c)) || '') : '';
     store.upsertEasyEdit({
       editType: 'image-src',
-      elementPath: isInMetadata ? 'metadata' : elementPath,
+      elementPath: blockClass || elementPath,
       elementProps,
       elementRef,
-      from: isInMetadata ? targetImg.dataset.streamOriginalSrc : originalSrc,
+      from: blockClass ? targetImg.dataset.streamOriginalSrc : originalSrc,
       to: '',
       fromHtml: '',
       toHtml: '',

--- a/streamlibs/operations/annotation/assets-panel.js
+++ b/streamlibs/operations/annotation/assets-panel.js
@@ -448,7 +448,7 @@ export default function createAssetsPanelController({
       return;
     }
 
-    const originalSrc = targetImg.dataset.originalSrc || elementProps?.src || targetImg.src || '';
+    const originalSrc = targetImg.dataset.streamOriginalSrc || targetImg.dataset.originalSrc || elementProps?.src || targetImg.src || '';
 
     // Cache the absolute loaded URL so a page-relative originalSrc still renders.
     const fromDisplaySrc = targetImg.currentSrc || targetImg.src || '';
@@ -499,12 +499,13 @@ export default function createAssetsPanelController({
     const assetFileKey = store.generateId('asset-file');
     store.registerAssetFile(assetFileKey, file, base64Data);
     localAsset.assetFileKey = assetFileKey;
+    const isInMetadata = Boolean(targetImg.closest('main div.metadata'));
     store.upsertEasyEdit({
       editType: 'image-src',
-      elementPath,
+      elementPath: isInMetadata ? 'metadata' : elementPath,
       elementProps,
       elementRef,
-      from: originalSrc,
+      from: isInMetadata ? targetImg.dataset.streamOriginalSrc : originalSrc,
       to: '',
       fromHtml: '',
       toHtml: '',

--- a/streamlibs/operations/annotation/assets-panel.js
+++ b/streamlibs/operations/annotation/assets-panel.js
@@ -4,7 +4,7 @@
 /* eslint-disable no-restricted-syntax */
 import { showGlobalSnackbar } from '../../utils/snackbar.js';
 import { formatCardTimestamp, ARROW_ICON_SVG } from '../../utils/utils.js';
-import { BLOCK_CLASSES } from '../../utils/constants.js';
+import { isMetadata } from '../../utils/constants.js';
 
 const ALLOWED_MIME_TYPES = [
   'image/png', 'image/jpeg',
@@ -503,12 +503,11 @@ export default function createAssetsPanelController({
     const assetFileKey = store.generateId('asset-file');
     store.registerAssetFile(assetFileKey, file, base64Data);
     localAsset.assetFileKey = assetFileKey;
-    const metaBlock = targetImg.closest(BLOCK_CLASSES.map((c) => `main div.${c}`).join(', '));
-    const blockClass = metaBlock
-      ? (BLOCK_CLASSES.find((c) => metaBlock.classList.contains(c)) || '') : '';
+    const blockClass = isMetadata(targetImg);
     store.upsertEasyEdit({
       editType: 'image-src',
-      elementPath: blockClass || elementPath,
+      elementPath,
+      blockClass,
       elementProps,
       elementRef,
       from: blockClass ? targetImg.dataset.streamOriginalSrc : originalSrc,

--- a/streamlibs/operations/annotation/inline-editing.js
+++ b/streamlibs/operations/annotation/inline-editing.js
@@ -12,6 +12,7 @@ export default function createInlineEditingController({
   renderThreadMarkers,
   renderCommentsPanel,
   removePopup,
+  getMetadataFromHtml,
 }) {
   const annotationService = createAnnotationServiceClient();
   const isInlineEditingAllowed = () => window.streamConfig?.inlineEditingAllowed !== false || window.streamConfig?.collabRole === 'owner';
@@ -232,8 +233,9 @@ export default function createInlineEditingController({
       return;
     }
 
+    const isInMetadata = Boolean(element.closest('main div.metadata'));
     const editAnchor = store.buildEditElementAnchor(element, annotationUI.mainEl);
-    const easyEditElementPath = editAnchor.elementPath;
+    const easyEditElementPath = isInMetadata ? 'metadata' : editAnchor.elementPath;
     const existing = store.getEasyEditByElement(
       elementRef,
       easyEditElementPath,
@@ -248,6 +250,10 @@ export default function createInlineEditingController({
     const baselineText = existing?.from ?? stampedOriginal?.from ?? snapshot.originalText;
     const baselineHtml = existing?.fromHtml ?? stampedOriginal?.fromHtml ?? snapshot.originalHtml;
     const segments = store.getChangedSegments(baselineText, currentText);
+    const resolvedFromHtml = (isInMetadata && getMetadataFromHtml)
+      ? getMetadataFromHtml()
+      : baselineHtml;
+    const resolvedToHtml = currentHtml;
     const editRecord = {
       id: existing?.id || store.generateId('easy-edit'),
       editType: 'text',
@@ -257,8 +263,8 @@ export default function createInlineEditingController({
       elementRef,
       from: baselineText,
       to: currentText,
-      fromHtml: baselineHtml,
-      toHtml: currentHtml,
+      fromHtml: resolvedFromHtml,
+      toHtml: resolvedToHtml,
       changedFrom: segments.changedFrom,
       changedTo: segments.changedTo,
       updatedAt: new Date().toISOString(),
@@ -322,7 +328,8 @@ export default function createInlineEditingController({
 
     const elementRef = store.ensureElementRef(imageElement);
     const editAnchor = store.buildEditElementAnchor(imageElement, annotationUI.mainEl);
-    const easyEditElementPath = editAnchor.elementPath;
+    const isInMetadata = Boolean(imageElement.closest('main div.metadata'));
+    const easyEditElementPath = isInMetadata ? 'metadata' : editAnchor.elementPath;
     const snapshotAlt = annotationUI.inlineImageAltSnapshot.get(elementRef);
     const originalAlt = snapshotAlt !== undefined ? `${snapshotAlt}` : (imageElement.getAttribute('alt') || '');
     const currentAlt = `${imageElement.getAttribute('alt') || ''}`;

--- a/streamlibs/operations/annotation/inline-editing.js
+++ b/streamlibs/operations/annotation/inline-editing.js
@@ -1,5 +1,5 @@
 import createAnnotationServiceClient from './service.js';
-import { ANNOTATION_MESSAGES } from '../../utils/constants.js';
+import { ANNOTATION_MESSAGES, BLOCK_CLASSES } from '../../utils/constants.js';
 import { showGlobalSnackbar } from '../../utils/snackbar.js';
 
 const MEDIUM_EDITOR_CSS_URL = 'https://cdn.jsdelivr.net/npm/medium-editor@5.23.3/dist/css/medium-editor.min.css';
@@ -12,9 +12,11 @@ export default function createInlineEditingController({
   renderThreadMarkers,
   renderCommentsPanel,
   removePopup,
-  getMetadataFromHtml,
+  getBlockFromHtml,
+  buildBlockToHtml,
 }) {
   const annotationService = createAnnotationServiceClient();
+  const blockClassSelector = BLOCK_CLASSES.map((c) => `main div.${c}`).join(', ');
   const isInlineEditingAllowed = () => window.streamConfig?.inlineEditingAllowed !== false || window.streamConfig?.collabRole === 'owner';
   const EXPLICIT_FORMATTING_TOOLBAR_ACTIONS = new Set([
     'bold',
@@ -116,6 +118,14 @@ export default function createInlineEditingController({
         if (isInsideStreamFragment(el)) return false;
         return true;
       });
+      // Metadata-like block cells are editable even when empty so authors can fill values.
+    //works for any BLOCK_CLASSES entry, no class names here.
+    Array.from(annotationUI.mainEl.querySelectorAll('.stream-metadata-section > div > div > div'))
+    .forEach((el) => {
+      if (el instanceof HTMLElement && !isInsideStreamFragment(el) && !candidates.includes(el)) {
+        candidates.push(el);
+      }
+    });
     const candidateSet = new Set(candidates);
     const nonLeafCandidates = new Set();
 
@@ -233,9 +243,11 @@ export default function createInlineEditingController({
       return;
     }
 
-    const isInMetadata = Boolean(element.closest('main div.metadata'));
+    const metaBlock = element.closest(blockClassSelector);
+    const metaBlockClass = metaBlock
+      ? (BLOCK_CLASSES.find((c) => metaBlock.classList.contains(c)) || '') : '';
     const editAnchor = store.buildEditElementAnchor(element, annotationUI.mainEl);
-    const easyEditElementPath = isInMetadata ? 'metadata' : editAnchor.elementPath;
+    const easyEditElementPath = metaBlockClass || editAnchor.elementPath;
     const existing = store.getEasyEditByElement(
       elementRef,
       easyEditElementPath,
@@ -250,10 +262,14 @@ export default function createInlineEditingController({
     const baselineText = existing?.from ?? stampedOriginal?.from ?? snapshot.originalText;
     const baselineHtml = existing?.fromHtml ?? stampedOriginal?.fromHtml ?? snapshot.originalHtml;
     const segments = store.getChangedSegments(baselineText, currentText);
-    const resolvedFromHtml = (isInMetadata && getMetadataFromHtml)
-      ? getMetadataFromHtml()
+    // For metadata-like blocks, fromHtml/toHtml track the whole sanitized block so the
+    // block can be replaced on apply and re-appended on push.
+    const resolvedFromHtml = (metaBlockClass && getBlockFromHtml)
+      ? getBlockFromHtml(metaBlockClass)
       : baselineHtml;
-    const resolvedToHtml = currentHtml;
+    const resolvedToHtml = (metaBlockClass && buildBlockToHtml)
+      ? buildBlockToHtml(metaBlockClass)
+      : currentHtml;
     const editRecord = {
       id: existing?.id || store.generateId('easy-edit'),
       editType: 'text',
@@ -328,8 +344,10 @@ export default function createInlineEditingController({
 
     const elementRef = store.ensureElementRef(imageElement);
     const editAnchor = store.buildEditElementAnchor(imageElement, annotationUI.mainEl);
-    const isInMetadata = Boolean(imageElement.closest('main div.metadata'));
-    const easyEditElementPath = isInMetadata ? 'metadata' : editAnchor.elementPath;
+    const metaBlock = imageElement.closest(blockClassSelector);
+    const metaBlockClass = metaBlock
+      ? (BLOCK_CLASSES.find((c) => metaBlock.classList.contains(c)) || '') : '';
+    const easyEditElementPath = metaBlockClass || editAnchor.elementPath;
     const snapshotAlt = annotationUI.inlineImageAltSnapshot.get(elementRef);
     const originalAlt = snapshotAlt !== undefined ? `${snapshotAlt}` : (imageElement.getAttribute('alt') || '');
     const currentAlt = `${imageElement.getAttribute('alt') || ''}`;

--- a/streamlibs/operations/annotation/inline-editing.js
+++ b/streamlibs/operations/annotation/inline-editing.js
@@ -1,5 +1,5 @@
 import createAnnotationServiceClient from './service.js';
-import { ANNOTATION_MESSAGES, BLOCK_CLASSES } from '../../utils/constants.js';
+import { ANNOTATION_MESSAGES, isMetadata } from '../../utils/constants.js';
 import { showGlobalSnackbar } from '../../utils/snackbar.js';
 
 const MEDIUM_EDITOR_CSS_URL = 'https://cdn.jsdelivr.net/npm/medium-editor@5.23.3/dist/css/medium-editor.min.css';
@@ -16,7 +16,6 @@ export default function createInlineEditingController({
   buildBlockToHtml,
 }) {
   const annotationService = createAnnotationServiceClient();
-  const blockClassSelector = BLOCK_CLASSES.map((c) => `main div.${c}`).join(', ');
   const isInlineEditingAllowed = () => window.streamConfig?.inlineEditingAllowed !== false || window.streamConfig?.collabRole === 'owner';
   const EXPLICIT_FORMATTING_TOOLBAR_ACTIONS = new Set([
     'bold',
@@ -243,11 +242,9 @@ export default function createInlineEditingController({
       return;
     }
 
-    const metaBlock = element.closest(blockClassSelector);
-    const metaBlockClass = metaBlock
-      ? (BLOCK_CLASSES.find((c) => metaBlock.classList.contains(c)) || '') : '';
+    const metaBlockClass = isMetadata(element);
     const editAnchor = store.buildEditElementAnchor(element, annotationUI.mainEl);
-    const easyEditElementPath = metaBlockClass || editAnchor.elementPath;
+    const easyEditElementPath = editAnchor.elementPath;
     const existing = store.getEasyEditByElement(
       elementRef,
       easyEditElementPath,
@@ -275,6 +272,7 @@ export default function createInlineEditingController({
       editType: 'text',
       attrName: '',
       elementPath: easyEditElementPath,
+      blockClass: metaBlockClass,
       elementProps: editAnchor.elementProps,
       elementRef,
       from: baselineText,
@@ -344,10 +342,8 @@ export default function createInlineEditingController({
 
     const elementRef = store.ensureElementRef(imageElement);
     const editAnchor = store.buildEditElementAnchor(imageElement, annotationUI.mainEl);
-    const metaBlock = imageElement.closest(blockClassSelector);
-    const metaBlockClass = metaBlock
-      ? (BLOCK_CLASSES.find((c) => metaBlock.classList.contains(c)) || '') : '';
-    const easyEditElementPath = metaBlockClass || editAnchor.elementPath;
+    const metaBlockClass = isMetadata(imageElement);
+    const easyEditElementPath = editAnchor.elementPath;
     const snapshotAlt = annotationUI.inlineImageAltSnapshot.get(elementRef);
     const originalAlt = snapshotAlt !== undefined ? `${snapshotAlt}` : (imageElement.getAttribute('alt') || '');
     const currentAlt = `${imageElement.getAttribute('alt') || ''}`;
@@ -363,6 +359,7 @@ export default function createInlineEditingController({
       editType: 'image-alt',
       attrName: 'alt',
       elementPath: easyEditElementPath,
+      blockClass: metaBlockClass,
       elementProps: editAnchor.elementProps,
       elementRef,
       from: originalAlt,

--- a/streamlibs/operations/annotation/store.js
+++ b/streamlibs/operations/annotation/store.js
@@ -501,7 +501,7 @@ export function createAnnotationStore({ annotationState, annotationUI }) {
 
       // Metadata-like blocks are stripped from this HTML and re-appended at the end of
       // the page separately, so skip them here to avoid matching inline.
-      if (BLOCK_CLASSES.includes(edit.elementPath)) return;
+      if (BLOCK_CLASSES.includes(edit.blockClass)) return;
 
       if (edit.editType === 'image-src') {
         const fromSrc = `${edit.from || ''}`;
@@ -1503,12 +1503,12 @@ export function createAnnotationStore({ annotationState, annotationUI }) {
       // Metadata-like edit: replace the whole block on the DOM with the edited toHtml.
       // Resolved by block class (not the inner element ref) since these blocks render
       // in their own section.
-      if (BLOCK_CLASSES.includes(edit.elementPath)) {
-        const block = annotationUI.mainEl.querySelector(`div.${edit.elementPath}`);
+      if (BLOCK_CLASSES.includes(edit.blockClass)) {
+        const block = annotationUI.mainEl.querySelector(`div.${edit.blockClass}`);
         if (block && edit.toHtml) {
           const tmp = document.createElement('div');
           tmp.innerHTML = edit.toHtml;
-          const newBlock = tmp.querySelector(`div.${edit.elementPath}`) || tmp.firstElementChild;
+          const newBlock = tmp.querySelector(`div.${edit.blockClass}`) || tmp.firstElementChild;
           if (newBlock && block.innerHTML !== newBlock.innerHTML) {
             block.innerHTML = newBlock.innerHTML;
           }

--- a/streamlibs/operations/annotation/store.js
+++ b/streamlibs/operations/annotation/store.js
@@ -1512,6 +1512,16 @@ export function createAnnotationStore({ annotationState, annotationUI }) {
           if (newBlock && block.innerHTML !== newBlock.innerHTML) {
             block.innerHTML = newBlock.innerHTML;
           }
+          // toHtml carries raw DA URLs; a bare <img> can't send the token (401), so resolve
+          // them to base64 here — runs on every re-render so the preview never reverts.
+          if (previewUrlResolverFn) {
+            block.querySelectorAll('img').forEach((img) => {
+              const src = img.getAttribute('src') || '';
+              previewUrlResolverFn(src).then((b64) => {
+                if (b64 && b64 !== src) img.setAttribute('src', b64);
+              });
+            });
+          }
         }
         return;
       }

--- a/streamlibs/operations/annotation/store.js
+++ b/streamlibs/operations/annotation/store.js
@@ -1,4 +1,8 @@
-import { ANNOTATION_COMMENT_STATUSES, ANNOTATION_DEFAULT_USERNAME } from '../../utils/constants.js';
+import {
+  ANNOTATION_COMMENT_STATUSES,
+  ANNOTATION_DEFAULT_USERNAME,
+  BLOCK_CLASSES,
+} from '../../utils/constants.js';
 
 const ANNOTATION_STORE_KEY = 'stream-annotation-comments';
 export const DEFAULT_USERNAME = ANNOTATION_DEFAULT_USERNAME;
@@ -494,6 +498,10 @@ export function createAnnotationStore({ annotationState, annotationUI }) {
     const origMainEl = origWrapper.querySelector('main');
     effectiveEdits.forEach((edit) => {
       if (!edit || typeof edit !== 'object') return;
+
+      // Metadata-like blocks are stripped from this HTML and re-appended at the end of
+      // the page separately, so skip them here to avoid matching inline.
+      if (BLOCK_CLASSES.includes(edit.elementPath)) return;
 
       if (edit.editType === 'image-src') {
         const fromSrc = `${edit.from || ''}`;
@@ -1490,11 +1498,27 @@ export function createAnnotationStore({ annotationState, annotationUI }) {
     }
 
     keepLatestImageEdits(annotationState.store.easyEdits).forEach((edit) => {
+      if (edit.from === edit.to && (edit.fromHtml || '') === (edit.toHtml || '')) return;
+
+      // Metadata-like edit: replace the whole block on the DOM with the edited toHtml.
+      // Resolved by block class (not the inner element ref) since these blocks render
+      // in their own section.
+      if (BLOCK_CLASSES.includes(edit.elementPath)) {
+        const block = annotationUI.mainEl.querySelector(`div.${edit.elementPath}`);
+        if (block && edit.toHtml) {
+          const tmp = document.createElement('div');
+          tmp.innerHTML = edit.toHtml;
+          const newBlock = tmp.querySelector(`div.${edit.elementPath}`) || tmp.firstElementChild;
+          if (newBlock && block.innerHTML !== newBlock.innerHTML) {
+            block.innerHTML = newBlock.innerHTML;
+          }
+        }
+        return;
+      }
+
       const target = getElementForEdit(edit);
       if (!(target instanceof HTMLElement)) return;
       if (target.closest('[data-class="fragment"]')) return;
-
-      if (edit.from === edit.to && (edit.fromHtml || '') === (edit.toHtml || '')) return;
 
       // Pending asset edit (empty `to`): keep the existing base64 preview.
       if ((edit.editType === 'image-src' || edit.editType === 'image-alt') && !edit.to) return;

--- a/streamlibs/operations/annotation/store.js
+++ b/streamlibs/operations/annotation/store.js
@@ -30,6 +30,12 @@ export function createAnnotationStore({ annotationState, annotationUI }) {
     previewUrlResolverFn = fn;
   }
 
+  let onMetadataBlockRenderedFn = null;
+
+  function setOnMetadataBlockRendered(fn) {
+    onMetadataBlockRenderedFn = fn;
+  }
+
   function generateId(prefix) {
     return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
   }
@@ -1335,7 +1341,7 @@ export function createAnnotationStore({ annotationState, annotationUI }) {
   }
 
   function buildSavePayload() {
-    return annotationState.store.easyEdits
+    const edits = annotationState.store.easyEdits
       .filter((edit) => {
         if (!edit) return false;
         // Don't persist a pending asset edit that hasn't been assigned a URL yet.
@@ -1348,6 +1354,22 @@ export function createAnnotationStore({ annotationState, annotationUI }) {
         const { changeHistory, assetFileKey, ...rest } = edit;
         return rest;
       });
+
+    const lastIdxByBlock = {};
+    edits.forEach((edit, i) => {
+      if (BLOCK_CLASSES.includes(edit.blockClass) && edit.toHtml) {
+        lastIdxByBlock[edit.blockClass] = i;
+      }
+    });
+    return edits.map((edit, i) => {
+      const isRedundantBlockCopy = BLOCK_CLASSES.includes(edit.blockClass)
+        && edit.toHtml && lastIdxByBlock[edit.blockClass] !== i;
+      if (isRedundantBlockCopy) {
+        const { toHtml, fromHtml, ...rest } = edit;
+        return rest;
+      }
+      return edit;
+    });
   }
 
   function replaceEasyEdits(nextEasyEdits = []) {
@@ -1518,10 +1540,18 @@ export function createAnnotationStore({ annotationState, annotationUI }) {
             block.querySelectorAll('img').forEach((img) => {
               const src = img.getAttribute('src') || '';
               previewUrlResolverFn(src).then((b64) => {
-                if (b64 && b64 !== src) img.setAttribute('src', b64);
+                if (b64 && b64 !== src) {
+                  // Preserve the original (resolvable) URL so buildBlockToHtml restores it on
+                  // save. Without this the base64 lands in toHtml and bloats the payload (413).
+                  if (!img.getAttribute('data-stream-original-src')) {
+                    img.setAttribute('data-stream-original-src', src);
+                  }
+                  img.setAttribute('src', b64);
+                }
               });
             });
           }
+          if (onMetadataBlockRenderedFn) onMetadataBlockRenderedFn(block);
         }
         return;
       }
@@ -1582,6 +1612,7 @@ export function createAnnotationStore({ annotationState, annotationUI }) {
     applyEasyEditsToDom,
     applyEasyEditsToHtmlString,
     setPreviewUrlResolver,
+    setOnMetadataBlockRendered,
     buildElementPath,
     buildCommentElementPath,
     buildEditElementAnchor,

--- a/streamlibs/operations/annotation/store.js
+++ b/streamlibs/operations/annotation/store.js
@@ -1531,21 +1531,26 @@ export function createAnnotationStore({ annotationState, annotationUI }) {
           const tmp = document.createElement('div');
           tmp.innerHTML = edit.toHtml;
           const newBlock = tmp.querySelector(`div.${edit.blockClass}`) || tmp.firstElementChild;
-          if (newBlock && block.innerHTML !== newBlock.innerHTML) {
-            block.innerHTML = newBlock.innerHTML;
+          if (newBlock) {
+            const liveClone = block.cloneNode(true);
+            liveClone.querySelectorAll('img').forEach((img) => {
+              const orig = img.getAttribute('data-stream-original-src');
+              if (orig) img.setAttribute('src', orig);
+              [...img.attributes].filter((a) => a.name.startsWith('data-')).forEach((a) => img.removeAttribute(a.name));
+            });
+            if (liveClone.innerHTML !== newBlock.innerHTML) {
+              block.innerHTML = newBlock.innerHTML;
+            }
           }
-          // toHtml carries raw DA URLs; a bare <img> can't send the token (401), so resolve
-          // them to base64 here — runs on every re-render so the preview never reverts.
+          
           if (previewUrlResolverFn) {
             block.querySelectorAll('img').forEach((img) => {
               const src = img.getAttribute('src') || '';
+              if (src && !src.startsWith('data:') && !img.getAttribute('data-stream-original-src')) {
+                img.setAttribute('data-stream-original-src', src);
+              }
               previewUrlResolverFn(src).then((b64) => {
-                if (b64 && b64 !== src) {
-                  // Preserve the original (resolvable) URL so buildBlockToHtml restores it on
-                  // save. Without this the base64 lands in toHtml and bloats the payload (413).
-                  if (!img.getAttribute('data-stream-original-src')) {
-                    img.setAttribute('data-stream-original-src', src);
-                  }
+                if (b64 && b64 !== src && img.getAttribute('src') === src) {
                   img.setAttribute('src', b64);
                 }
               });

--- a/streamlibs/utils/config.js
+++ b/streamlibs/utils/config.js
@@ -40,7 +40,7 @@ export const CONFIG = {
   },
   dev: {
     streamMapper: {
-      serviceEP: 'http://localhost:8082',
+      serviceEP: 'https://adobe-acom-stream-service-deploy-ethos502-prod-or2-1de07c.cloud.adobe.io',
       figmaMappingUrl: '/api/fig-comps',
       figmaBlockContentUrl: '/api/fig-comp-details',
       pushToDaUrl: '/api/push-html',
@@ -54,7 +54,7 @@ export const CONFIG = {
   },
   dev02: {
     streamMapper: {
-      serviceEP: 'http://localhost:8082',
+      serviceEP: 'https://adobe-acom-stream-service-deploy-ethos501-prod-or2-b0c6b7.cloud.adobe.io',
       figmaMappingUrl: '/api/fig-comps',
       figmaBlockContentUrl: '/api/fig-comp-details',
       pushToDaUrl: '/api/push-html',

--- a/streamlibs/utils/config.js
+++ b/streamlibs/utils/config.js
@@ -40,7 +40,7 @@ export const CONFIG = {
   },
   dev: {
     streamMapper: {
-      serviceEP: 'https://adobe-acom-stream-service-deploy-ethos502-prod-or2-1de07c.cloud.adobe.io',
+      serviceEP: 'http://localhost:8082',
       figmaMappingUrl: '/api/fig-comps',
       figmaBlockContentUrl: '/api/fig-comp-details',
       pushToDaUrl: '/api/push-html',
@@ -54,7 +54,7 @@ export const CONFIG = {
   },
   dev02: {
     streamMapper: {
-      serviceEP: 'https://adobe-acom-stream-service-deploy-ethos501-prod-or2-b0c6b7.cloud.adobe.io',
+      serviceEP: 'http://localhost:8082',
       figmaMappingUrl: '/api/fig-comps',
       figmaBlockContentUrl: '/api/fig-comp-details',
       pushToDaUrl: '/api/push-html',

--- a/streamlibs/utils/constants.js
+++ b/streamlibs/utils/constants.js
@@ -5,16 +5,6 @@ export const DEFAULT_TMP_URL = 'https://main--stream-mapper--adobecom.aem.live/s
 // Add any class here to give it the same treatment 
 export const BLOCK_CLASSES = ['metadata', 'card-metadata'];
 
-// Default block templates, keyed by class. When a page has no such block, this seed
-// renders so authors can fill values. Classes with no entry render only if present.
-export const BLOCK_CLASS_TEMPLATES = {
-  'card-metadata': [
-    'CardTitle', 'CardImage', 'CardImageAltText', 'CardDescription',
-    'ContentType', 'Tags', 'Details', 'cta1Text', 'cta1URL',
-    'BadgeText', 'BadgeImage',
-  ],
-};
-
 export const ACCENT_BARS = {
   'Accent Bar / CC Gradient': 'linear-gradient(90deg, #FA0F00 0%, #E9740A 15.42%, #FFCE2E 39.44%, #009C3B 67.99%, #2799F6 85.76%, #6349E0 95.42%, #9999FC 100%)',
   'Accent Bar / CC Photo': '#31A8FF',

--- a/streamlibs/utils/constants.js
+++ b/streamlibs/utils/constants.js
@@ -5,6 +5,18 @@ export const DEFAULT_TMP_URL = 'https://main--stream-mapper--adobecom.aem.live/s
 // Add any class here to give it the same treatment 
 export const BLOCK_CLASSES = ['metadata', 'card-metadata'];
 
+// Returns the metadata-like block class the closest matching ancestor has
+// (e.g. 'card-metadata'), or '' if the element is not inside one.
+// Accepts an HTMLElement or a selector string.
+export function isMetadata(elementOrSelector) {
+  const el = typeof elementOrSelector === 'string'
+    ? document.querySelector(elementOrSelector)
+    : elementOrSelector;
+  if (!el || typeof el.closest !== 'function') return '';
+  const block = el.closest(BLOCK_CLASSES.map((c) => `main div.${c}`).join(', '));
+  return block ? (BLOCK_CLASSES.find((c) => block.classList.contains(c)) || '') : '';
+}
+
 export const ACCENT_BARS = {
   'Accent Bar / CC Gradient': 'linear-gradient(90deg, #FA0F00 0%, #E9740A 15.42%, #FFCE2E 39.44%, #009C3B 67.99%, #2799F6 85.76%, #6349E0 95.42%, #9999FC 100%)',
   'Accent Bar / CC Photo': '#31A8FF',

--- a/streamlibs/utils/constants.js
+++ b/streamlibs/utils/constants.js
@@ -1,5 +1,20 @@
 export const DEFAULT_TMP_URL = 'https://main--stream-mapper--adobecom.aem.live/stream';
 
+// Block classes handled like page metadata: pulled out of the page body, edited as a
+// whole-block unit (fromHtml/toHtml), and re-appended at the end of the page on push.
+// Add any class here to give it the same treatment 
+export const BLOCK_CLASSES = ['metadata', 'card-metadata'];
+
+// Default block templates, keyed by class. When a page has no such block, this seed
+// renders so authors can fill values. Classes with no entry render only if present.
+export const BLOCK_CLASS_TEMPLATES = {
+  'card-metadata': [
+    'CardTitle', 'CardImage', 'CardImageAltText', 'CardDescription',
+    'ContentType', 'Tags', 'Details', 'cta1Text', 'cta1URL',
+    'BadgeText', 'BadgeImage',
+  ],
+};
+
 export const ACCENT_BARS = {
   'Accent Bar / CC Gradient': 'linear-gradient(90deg, #FA0F00 0%, #E9740A 15.42%, #FFCE2E 39.44%, #009C3B 67.99%, #2799F6 85.76%, #6349E0 95.42%, #9999FC 100%)',
   'Accent Bar / CC Photo': '#31A8FF',


### PR DESCRIPTION
Jira: 
[MWPW-196579](https://jira.corp.adobe.com/browse/MWPW-196579)
[MWPW-195584](https://jira.corp.adobe.com/browse/MWPW-195584)
Add/Delete Metadata Rows

Adds the ability to insert and remove rows in metadata blocks during collab annotation. Generalized across BLOCK_CLASSES, so it works for both Page Metadata and Card Metadata.

What it does:

Add text/link row and + Add image row buttons under each metadata block (shown in inline-edit mode)
Delete (×) control on user-added rows to remove them before saving

Added rows become permanent on Save (marker + delete control stripped, clean HTML pushed to DA)

Stream-only chrome (markers, delete buttons) never reaches DA

413 fix: dedupes redundant full-block copies in the save payload so adding many images no longer bloats the request

-Metadata & Card-Metadata support in collab:
Approach (generalized, no per-block hardcoding)
One array BLOCK_CLASSES = ['metadata', 'card-metadata'] drives everything — add a class to get the same treatment.
Shared isMetadata() util replaces all duplicated detection.
Blocks are pulled out of the page, cached, edited as a whole block (fromHtml/toHtml), and re-appended at page end on push.
Changes
utils/constants.js — added BLOCK_CLASSES and isMetadata(elementOrSelector) (returns the metadata block class for an element/selector).

operations/annotation.js

parseAndCacheCleanHtml() — pulls blocks out, caches by class, leaves cleaned page HTML.
buildBlockToHtml() — clones block, flattens →, restores src, strips data-*.resolvePreviewUrl() — decodes DA fpo.svg# images, fetches content.da.live as base64.Section render + push — renders cached blocks as .stream-metadata-section; re-appends edited block wrapped in a

(no row-flattening); selects edit via blockClass.
Removed dead excludeBlockClasses option.
operations/annotation/assets-panel.js — uses isMetadata; keeps real elementPath + adds blockClass; setAssetLinkHref() decodes fpo.svg# so From/To links open the real image.
operations/annotation/inline-editing.js — uses isMetadata for text + image-alt edits; keeps real elementPath + adds blockClass.

operations/annotation/store.js — normalizeEasyEdit carries a persisted blockClass; metadata detected via BLOCK_CLASSES.includes(edit.blockClass); metadata block re-renders from toHtml and resolves its s to base64 on every render (fixes card-metadata snapped image — a bare  can't send the token → 401).
<img width="1728" height="1117" alt="localvsdev-multiedit" src="https://github.com/user-attachments/assets/926c4ac0-df98-4f20-b3ec-3759a0ae40e8" />
<img width="1728" height="1117" alt="localvsdev-multiedit-2" src="https://github.com/user-attachments/assets/8500ba3d-bc02-453e-8daa-89cc1bf36bf4" />
<img width="1728" height="1117" alt="localvsdev-multiedit3" src="https://github.com/user-attachments/assets/3549d513-fd8b-4719-a398-355f0ba48e7b" />
<img width="1728" height="1117" alt="localvsdev-multiedit4" src="https://github.com/user-attachments/assets/4730b125-9fa7-4bd2-a2ea-e3d039a84bb7" />
<img width="1728" height="1117" alt="localvsdev-single edit2" src="https://github.com/user-attachments/assets/6f0e1a10-53ac-416a-a617-eed48468c238" />
<img width="1728" height="1117" alt="localvsdev-single-edit" src="https://github.com/user-attachments/assets/b7078866-39bc-4df4-b1e3-f1506a55f4c6" />


demo: https://adobe-my.sharepoint.com/my?id=%2Fpersonal%2Fketakid%5Fadobe%5Fcom%2FDocuments%2FMetadata&ga=1