### PR TITLE
Fix/MWPW 194716

### DIFF
--- a/streamlibs/operations/annotation.js
+++ b/streamlibs/operations/annotation.js
@@ -516,7 +516,13 @@ function buildHtmlWithEditsAndAssets(assetReplacements) {
   cachedMetadataBlocks.forEach((cachedBlock, blockClass) => {
     mainEl.querySelectorAll(`div.${blockClass}`).forEach((block) => block.remove());
     //picks the most recent saved edit for that metadata block (elementPath matches blockClass and has toHtml), so that version is used when re-appending the block on save instead of the original cached HTML.
-    const blockEdit = easyEdits.filter((e) => e.blockClass === blockClass && e.toHtml).at(-1);
+    let blockEdit = null;
+    easyEdits.forEach((e) => {
+      if (e.blockClass !== blockClass || !e.toHtml) return;
+      if (!blockEdit || new Date(e.updatedAt || 0) >= new Date(blockEdit.updatedAt || 0)) {
+        blockEdit = e;
+      }
+    });
     const finalHtml = blockEdit?.toHtml
       || (cachedBlock.innerHTML.trim() ? cachedBlock.outerHTML : '');
     // Wrap in a section <div> so DA treats it as a block inside a section (not a bare
@@ -611,9 +617,22 @@ async function finishAnnotationSession(mainEl, {
         row.querySelectorAll('p').forEach((p) => inlineEditing.registerNewEditableElement(p));
         ensureUserMetadataRowDeleteButton(row);
         const toHtml = buildBlockToHtml(blockClass);
+        let updatedAny = false;
         (annotationState.store.easyEdits || []).forEach((e) => {
-          if (e.blockClass === blockClass && e.toHtml) e.toHtml = toHtml;
+          if (e.blockClass === blockClass && e.toHtml) { e.toHtml = toHtml; updatedAny = true; }
         });
+        if (!updatedAny) {
+          store.upsertEasyEdit({
+            editType: 'text',
+            elementPath: blockClass,
+            blockClass,
+            elementProps: {},
+            from: '',
+            to: '',
+            fromHtml: cachedMetadataBlocks.get(blockClass)?.outerHTML || '',
+            toHtml,
+          });
+        }
         store.saveAnnotationStore();
       };
       const addTextBtn = document.createElement('button');

--- a/streamlibs/operations/annotation/service.js
+++ b/streamlibs/operations/annotation/service.js
@@ -111,6 +111,7 @@ function normalizeEditRecord(edit) {
     attrName: edit?.attrName || '',
     elementPath: `${edit?.elementPath || normalizedAnchor?.selector || ''}`,
     elementProps: normalizedElementProps,
+    blockClass: `${edit?.blockClass || normalizedElementProps.blockClass || ''}`,
     elementRef: edit?.elementRef || '',
     from: `${edit?.from || ''}`,
     to: `${edit?.to || ''}`,

--- a/streamlibs/operations/annotation/store.js
+++ b/streamlibs/operations/annotation/store.js
@@ -1519,7 +1519,9 @@ export function createAnnotationStore({ annotationState, annotationUI }) {
       );
     }
 
-    keepLatestImageEdits(annotationState.store.easyEdits).forEach((edit) => {
+    keepLatestImageEdits(annotationState.store.easyEdits)
+      .sort((a, b) => new Date(a.updatedAt || 0) - new Date(b.updatedAt || 0))
+      .forEach((edit) => {
       if (edit.from === edit.to && (edit.fromHtml || '') === (edit.toHtml || '')) return;
 
       // Metadata-like edit: replace the whole block on the DOM with the edited toHtml.


### PR DESCRIPTION
Jira:
[MWPW-194716](https://jira.corp.adobe.com/browse/MWPW-194716)
[MWPW-195276](https://jira.corp.adobe.com/browse/MWPW-195276)

**Fix: Reviewer/co-owner not seeing metadata changes in metadata section**

**Problem**
When an owner added metadata rows in a collab session, reviewers and co-owners could see the changes in the annotations panel but not in the metadata section of the page. This happened due to three related issues:

1. If no prior image had been uploaded to the metadata block, no edit with `toHtml` existed — `addAndRegisterRow`'s forEach updated nothing and the snapshot was never saved.
2. After server reload, edits are returned newest-first. `applyEasyEditsToDom` applied them in that order, so the oldest block snapshot was applied last and won — overwriting the correct state on the reviewer's DOM.
3. `buildHtmlWithEditsAndAssets` used `.at(-1)` (position-based) to pick the metadata edit for the save payload, which picked the oldest edit after a server reload instead of the newest.

**Fix**
- `addAndRegisterRow`: added `updatedAny` flag + `upsertEasyEdit` fallback — creates the canonical metadata block snapshot edit when none exists yet.
- `applyEasyEditsToDom`: sort edits oldest→newest before applying, so the newest block snapshot is always last-applied and wins.
- `buildHtmlWithEditsAndAssets`: replaced `.at(-1)` with timestamp-based selection to always pick the newest edit regardless of array order.