### PR TITLE
Standalone Collab Annotation

### DIFF
--- a/streamlibs/operations/annotation.js
+++ b/streamlibs/operations/annotation.js
@@ -811,12 +811,13 @@ export async function annotationOperationOnHostPage(options = {}) {
   } = options;
 
   await new Promise((resolve) => {
+    if (document.getElementById('page-load-ok-milo')) { resolve(); return; }
     const observer = new MutationObserver(() => {
       if (!document.getElementById('page-load-ok-milo')) return;
       observer.disconnect();
       resolve();
     });
-    observer.observe(document.body, { childList: true });
+    observer.observe(document.body, { childList: true, subtree: true });
   });
 
   const { shouldRestoreInlineMode } = prepareAnnotationSession({ preserveRemoteEditState });

--- a/streamlibs/operations/annotation/annotation.css
+++ b/streamlibs/operations/annotation/annotation.css
@@ -381,6 +381,28 @@ body.annotation-mode main::-webkit-scrollbar {
   color: #475569;
 }
 
+.annotation-mode-btn-save {
+  background: #2563eb;
+  border-color: #1d4ed8;
+  color: #fff;
+}
+
+.annotation-mode-btn-save:hover {
+  background: #1d4ed8;
+  border-color: #1e40af;
+}
+
+.annotation-mode-btn-publish {
+  background: #16a34a;
+  border-color: #15803d;
+  color: #fff;
+}
+
+.annotation-mode-btn-publish:hover {
+  background: #15803d;
+  border-color: #166534;
+}
+
 @container comments-panel (max-width: 260px) {
   .annotation-comments-panel-header {
     align-items: flex-start;

--- a/streamlibs/operations/annotation/asset-service.js
+++ b/streamlibs/operations/annotation/asset-service.js
@@ -11,6 +11,10 @@ export default function createAssetServiceClient() {
     };
     const token = normalizeToken(window.streamConfig?.token);
     if (token) headers.Authorization = token;
+    // Service tokens have no user email in IMS; send the resolved identity so the
+    // backend's resolveUserProfile() can fall back to it (matches annotationServiceFetch).
+    if (window.streamConfig?.userEmail) headers['X-User-Email'] = window.streamConfig.userEmail;
+    if (window.streamConfig?.userName) headers['X-User-Name'] = window.streamConfig.userName;
 
     if (options.body && !(options.body instanceof FormData) && !headers['Content-Type']) {
       headers['Content-Type'] = 'application/json';

--- a/streamlibs/operations/annotation/comments-panel.js
+++ b/streamlibs/operations/annotation/comments-panel.js
@@ -4,6 +4,8 @@ import {
   ANNOTATION_MESSAGES,
   ANNOTATION_DEFAULT_USERNAME,
   ANNOTATION_REFRESH_EVENT,
+  ANNOTATION_SAVE_EVENT,
+  ANNOTATION_PUBLISH_EVENT,
 } from '../../utils/constants.js';
 import { COMMENT_STATUSES } from './store.js';
 import createAnnotationServiceClient from './service.js';
@@ -157,6 +159,26 @@ export default function createCommentsPanelController({
               </defs>
             </svg>
           </button>
+          <button
+            type="button"
+            class="annotation-mode-btn annotation-mode-btn-save"
+            aria-label="Save annotation changes"
+            title="Save annotation changes"
+          >
+            <svg viewBox="0 0 24 24" aria-hidden="true">
+              <path d="M17 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V7l-4-4zm-5 16c-1.66 0-3-1.34-3-3s1.34-3 3-3 3 1.34 3 3-1.34 3-3 3zm3-10H5V5h10v4z"></path>
+            </svg>
+          </button>
+          <button
+            type="button"
+            class="annotation-mode-btn annotation-mode-btn-publish"
+            aria-label="Publish to DA"
+            title="Publish to DA"
+          >
+            <svg viewBox="0 0 24 24" aria-hidden="true">
+              <path d="M5 4v2h14V4H5zm0 10h4v6h6v-6h4l-7-7-7 7z"></path>
+            </svg>
+          </button>
         </div>
       </div>
       <div class="annotation-panel-filter-tabs" role="tablist" aria-label="Filter annotations">
@@ -198,6 +220,14 @@ export default function createCommentsPanelController({
       }
     });
 
+    panel.querySelector('.annotation-mode-btn-save').addEventListener('click', () => {
+      window.dispatchEvent(new CustomEvent(ANNOTATION_SAVE_EVENT));
+    });
+
+    panel.querySelector('.annotation-mode-btn-publish').addEventListener('click', () => {
+      window.dispatchEvent(new CustomEvent(ANNOTATION_PUBLISH_EVENT));
+    });
+
     panel.querySelector('.annotation-panel-filter-tabs').addEventListener('click', (event) => {
       const tab = event.target.closest('.annotation-panel-filter-tab');
       if (!(tab instanceof HTMLButtonElement)) return;
@@ -212,6 +242,7 @@ export default function createCommentsPanelController({
 
     updateModeButtonStates();
     applyOwnerOnlyToggleState();
+    applyDisableEditsState();
   }
 
   function applyOwnerOnlyToggleState() {
@@ -245,6 +276,19 @@ export default function createCommentsPanelController({
         annotationUI.inlineAssetsToggleEl.setAttribute('aria-disabled', 'true');
       }
     }
+  }
+
+  function applyDisableEditsState() {
+    const noToken = !new URLSearchParams(window.location.search).get('token') && !window.streamConfig?.token;
+    if (!window.streamConfig?.disableEdits && !noToken) return;
+    const toolbar = annotationUI.panelEl?.querySelector('.annotation-mode-toolbar');
+    if (!toolbar) return;
+    toolbar.querySelectorAll('.annotation-mode-btn').forEach((btn) => {
+      if (btn instanceof HTMLButtonElement) {
+        btn.disabled = true;
+        btn.setAttribute('aria-disabled', 'true');
+      }
+    });
   }
 
   function ensureCanvasRefreshBar() {
@@ -1272,6 +1316,7 @@ export default function createCommentsPanelController({
     captureTransientDraftsFromDom();
     renderRefreshAction();
     updateModeButtonStates();
+    applyDisableEditsState();
 
     const finalizeFragmentHints = () => syncFragmentEditDisabledHints(
       annotationUI.mainEl,

--- a/streamlibs/operations/annotation/service.js
+++ b/streamlibs/operations/annotation/service.js
@@ -172,6 +172,8 @@ export default function createAnnotationServiceClient() {
     };
     const token = normalizeToken(window.streamConfig?.token);
     if (token) headers.Authorization = token;
+    if (window.streamConfig?.userEmail) headers['X-User-Email'] = window.streamConfig.userEmail;
+    if (window.streamConfig?.userName) headers['X-User-Name'] = window.streamConfig.userName;
     if (options.body && !headers['Content-Type']) {
       headers['Content-Type'] = 'application/json';
     }

--- a/streamlibs/operations/annotation/store.js
+++ b/streamlibs/operations/annotation/store.js
@@ -533,17 +533,37 @@ export function createAnnotationStore({ annotationState, annotationUI }) {
             const origAllPics = origBlock
               ? Array.from(origBlock.querySelectorAll('picture'))
               : [];
-            const origCandidates = origAllPics.filter(
+            let origCandidates = origAllPics.filter(
               (pic) => pic.innerHTML.includes(fromSrc),
             );
-            // Fall back to all pictures when `from` is no longer in the baseline.
+            // In the iframe flow the live src matches the baseline directly. In
+            // standalone the host renderer re-hashes media URLs (media_<hash>.jpg),
+            // so the src never matches — fall back to the stable alt text, which is
+            // identical on both sides and unique per picture.
+            const fromAlt = `${edit.imgAlt || edit.elementProps?.imgAlt || ''}`.trim();
+            if (!origCandidates.length && fromAlt) {
+              origCandidates = origAllPics.filter(
+                (pic) => (pic.querySelector('img')?.getAttribute('alt') || '').trim() === fromAlt,
+              );
+            }
+            // Fall back to all pictures when neither src nor alt is in the baseline.
             const candidatePool = origCandidates.length ? origCandidates : origAllPics;
 
             const storedIdx = edit.picIndexInBlock ?? edit.elementProps?.picIndexInBlock ?? null;
+            const contentIdx = edit.contentPicIndexInBlock
+              ?? edit.elementProps?.contentPicIndexInBlock ?? null;
             let origTarget = null;
 
-            if (storedIdx !== null && storedIdx >= 0 && storedIdx < candidatePool.length) {
+            if (origCandidates.length === 1) {
+              // src or alt uniquely identified the picture.
+              origTarget = origCandidates[0];
+            } else if (storedIdx !== null && storedIdx >= 0 && storedIdx < candidatePool.length) {
               origTarget = candidatePool[storedIdx];
+            } else if (!origCandidates.length
+              && contentIdx !== null && contentIdx >= 0 && contentIdx < origAllPics.length) {
+              // No src/alt match: baseline pictures are all content pictures, so the
+              // absolute content-picture index from the live block maps directly.
+              origTarget = origAllPics[contentIdx];
             } else {
               const picIdx = getViewportOccurrenceIndex(
                 candidatePool.length || 1,
@@ -850,7 +870,9 @@ export function createAnnotationStore({ annotationState, annotationUI }) {
     // Index among pictures in the block that share the same persisted source URL.
     // Using same-src siblings avoids counting extra pictures that the render layer
     // adds (icons, logos) which do not exist in DA HTML.
-    const imgEl = picEl ? picEl.querySelector('img') : null;
+    const imgEl = picEl
+      ? (picEl.tagName === 'IMG' ? picEl : picEl.querySelector('img'))
+      : null;
     const picSrc = imgEl ? getPersistedElementSource(imgEl) : '';
     const sameSrcPics = picEl && picSrc
       ? Array.from(context.block.querySelectorAll('picture')).filter((pic) => {
@@ -859,6 +881,22 @@ export function createAnnotationStore({ annotationState, annotationUI }) {
       })
       : [];
     const picIndexInBlock = sameSrcPics.length > 0 ? sameSrcPics.indexOf(picEl) : -1;
+
+    // Absolute index among content pictures (raster images, excluding SVG
+    // icons/logos). The DA baseline only stores content images as <picture>, so
+    // this index maps directly when the live src/alt can't be matched (standalone:
+    // the renderer re-hashes media URLs so neither src nor filename lines up).
+    const contentBlockPics = picEl
+      ? Array.from(context.block.querySelectorAll('picture')).filter((pic) => {
+        const cImg = pic.querySelector('img');
+        const cSrc = `${cImg?.getAttribute('src') || ''}`.split('?')[0].toLowerCase();
+        return cSrc && !cSrc.endsWith('.svg');
+      })
+      : [];
+    const contentPicIndexInBlock = picEl ? contentBlockPics.indexOf(picEl) : -1;
+    // Alt text is identical on the live page and in the DA baseline and is unique
+    // per picture, so it's the most reliable cross-render image identifier.
+    const imgAlt = imgEl ? imgEl.getAttribute('alt') || '' : '';
 
     return JSON.stringify({
       selector,
@@ -870,6 +908,8 @@ export function createAnnotationStore({ annotationState, annotationUI }) {
       blockGlobalIndex: context.blockGlobalIndex,
       pathWithinBlock: buildRelativeElementPath(element, context.block),
       picIndexInBlock: picIndexInBlock > -1 ? picIndexInBlock : null,
+      contentPicIndexInBlock: contentPicIndexInBlock > -1 ? contentPicIndexInBlock : null,
+      imgAlt,
       ...getCommentElementDescriptor(element),
     });
   }

--- a/streamlibs/operations/standaloneAnnotation/milo-collab-init.js
+++ b/streamlibs/operations/standaloneAnnotation/milo-collab-init.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
 import { CONFIG } from '../../utils/config.js';
-import { getMapperEnv, initializeTokens } from '../../utils/utils.js';
+import { getMapperEnv, initializeTokens, getEnvFromRef } from '../../utils/utils.js';
 import {
   resetTargetHtmlInStore,
   resetPreviewHtmlInStore,
@@ -11,7 +11,7 @@ import { initiatePreviewer, setupMessageListener } from '../../previewer.js';
 import { setupBlockActionModal } from '../../utils/block-action-modal.js';
 import { applyRemoteCollabSnapshot } from '../../utils/operations.js';
 
-const API_ENDPOINT = 'https://adobe-acom-stream-service-deploy-ethos501-prod-or2-b0c6b7.cloud.adobe.io/api';
+const API_ENDPOINT = `${CONFIG[getEnvFromRef()].streamMapper.serviceEP}/api`;
 const SEARCH_DEBOUNCE_MS = 250;
 const SEARCH_MIN_LENGTH = 3;
 
@@ -102,7 +102,7 @@ async function fetchAndApplyCollabSnapshot(collabId) {
 async function startAnnotation(createdCollabId = null) {
   const params = new URLSearchParams(window.location.search);
   loadCssFiles('https://standaloneAnnotation--stream-mapper--adobecom.aem.live/streamlibs/styles/styles.css');
-  const env = getMapperEnv();
+  const env = getEnvFromRef();
   const collabId = createdCollabId || params.get('miloCollabId');
   const { host, pathname } = window.location;
   if (!host.includes('.aem.')) return;

--- a/streamlibs/operations/standaloneAnnotation/milo-collab-init.js
+++ b/streamlibs/operations/standaloneAnnotation/milo-collab-init.js
@@ -1,0 +1,743 @@
+/* eslint-disable no-console */
+import { CONFIG } from '../../utils/config.js';
+import { getMapperEnv, initializeTokens } from '../../utils/utils.js';
+import {
+  resetTargetHtmlInStore,
+  resetPreviewHtmlInStore,
+  resetEditChangesInStore,
+} from '../../store/store.js';
+import { initializeLoader } from '../../utils/loader.js';
+import { initiatePreviewer, setupMessageListener } from '../../previewer.js';
+import { setupBlockActionModal } from '../../utils/block-action-modal.js';
+import { applyRemoteCollabSnapshot } from '../../utils/operations.js';
+
+const API_ENDPOINT = 'https://adobe-acom-stream-service-deploy-ethos501-prod-or2-b0c6b7.cloud.adobe.io/api';
+const SEARCH_DEBOUNCE_MS = 250;
+const SEARCH_MIN_LENGTH = 3;
+
+let resolvedToken = '';
+let resolvedEmail = '';
+let resolvedName = '';
+
+function loadCssFiles(filePath) {
+  const link = document.createElement('link');
+  link.rel = 'stylesheet';
+  link.href = filePath;
+  link.dataset.streamMapperStyles = '';
+  document.head.appendChild(link);
+}
+
+function getToken() {
+  return resolvedToken || window.adobeIMS?.getAccessToken()?.token || '';
+}
+
+async function searchUsers(query) {
+  if (!query || query.length < SEARCH_MIN_LENGTH) return [];
+  const token = getToken();
+  if (!token) return [];
+  try {
+    const res = await fetch(
+      `${API_ENDPOINT}/search/groups-or-users?q=${encodeURIComponent(query)}`,
+      { headers: { Authorization: `Bearer ${token}` } },
+    );
+    if (!res.ok) return [];
+    const payload = await res.json();
+    const result = Array.isArray(payload?.result)
+      ? payload.result
+      : Array.isArray(payload) ? payload : [];
+    return result.filter((item) => item?.type === 'user' && item?.id).slice(0, 8);
+  } catch {
+    return [];
+  }
+}
+
+async function createCollab(collabData) {
+  const token = getToken();
+  const res = await fetch(`${API_ENDPOINT}/collabs`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}`, 'X-User-Email': resolvedEmail, 'X-User-Name': resolvedName },
+    body: JSON.stringify(collabData),
+  });
+  const result = await res.json().catch(() => ({}));
+  if (!res.ok) throw new Error(result?.error || `HTTP ${res.status}`);
+  return result;
+}
+
+async function assignCollabRoles(collabId, assignments) {
+  if (!assignments.length) return;
+  const token = getToken();
+  const res = await fetch(`${API_ENDPOINT}/collabs/${encodeURIComponent(collabId)}/roles/assign`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}`, 'X-User-Email': resolvedEmail, 'X-User-Name': resolvedName },
+    body: JSON.stringify({ assignments }),
+  });
+  if (!res.ok) {
+    const result = await res.json().catch(() => ({}));
+    throw new Error(result?.error || 'Failed to assign roles');
+  }
+}
+
+async function fetchAndApplyCollabSnapshot(collabId) {
+  const token = getToken();
+  if (!collabId || !token) return;
+  const serviceEP = window.streamConfig?.streamMapper?.serviceEP || '';
+  if (!serviceEP) return;
+  const headers = { Authorization: `Bearer ${token}`, 'X-User-Email': resolvedEmail, 'X-User-Name': resolvedName };
+  try {
+    const [collab, edits] = await Promise.all([
+      fetch(`${serviceEP}/api/collabs/${encodeURIComponent(collabId)}`, { headers })
+        .then((r) => (r.ok ? r.json() : null)),
+      fetch(`${serviceEP}/api/collabs/${encodeURIComponent(collabId)}/edits`, { headers })
+        .then((r) => {
+          if (r.status === 404) return { createdAt: null, updatedAt: null, authorUsername: '', editRecord: [] };
+          return r.ok ? r.json() : null;
+        }),
+    ]);
+    applyRemoteCollabSnapshot({ collab, edits });
+  } catch (err) {
+    console.warn('[milo-collab-init] Failed to fetch collab snapshot:', err);
+  }
+}
+
+async function startAnnotation(createdCollabId = null) {
+  const params = new URLSearchParams(window.location.search);
+  loadCssFiles('https://standaloneAnnotation--stream-mapper--adobecom.aem.live/streamlibs/styles/styles.css');
+  const env = getMapperEnv();
+  const collabId = createdCollabId || params.get('miloCollabId');
+  const { host, pathname } = window.location;
+  if (!host.includes('.aem.')) return;
+  const repo = host.split('--')[1];
+  const pageUrl = `adobecom/${repo}${pathname}`;
+  let filename = pathname.split('/');
+  filename = filename[filename.length - 1];
+  const draftLocation = `adobecom/${repo}/drafts/collab/${collabId}/${filename}`;
+  const username = resolvedName || resolvedEmail.split('@')[0] || 'Unknown';
+  window.streamConfig = {
+    streamMapper: { ...CONFIG[env].streamMapper },
+    figmaServiceRetry: CONFIG.figmaServiceRetry,
+    source: 'da',
+    contentUrl: draftLocation,
+    target: 'da',
+    targetUrl: pageUrl,
+    pageUrl,
+    token: getToken(),
+    userEmail: resolvedEmail,
+    userName: resolvedName,
+    profileId: '3',
+    collabId,
+    operation: 'aiSeoAnnotation',
+    username: params.get('username') || null,
+    reviewId: params.get('miloCollabId'),
+    collabRole: 'owner',
+    draftLocation: pageUrl,
+    username,
+  };
+
+  resetTargetHtmlInStore();
+  resetPreviewHtmlInStore();
+  resetEditChangesInStore();
+  initializeLoader();
+  await initializeTokens(window.streamConfig.token);
+  // Standalone mode: page is already loaded by Milo; inject the readiness signal that
+  // annotationOperationOnHostPage waits for (normally provided by miloLoadArea in iframe flow).
+  if (!document.getElementById('page-load-ok-milo')) {
+    const sig = document.createElement('div');
+    sig.id = 'page-load-ok-milo';
+    sig.style.display = 'none';
+    document.body.appendChild(sig);
+  }
+  await initiatePreviewer();
+  setupBlockActionModal();
+  await setupMessageListener();
+  await fetchAndApplyCollabSnapshot(collabId);
+
+  let pollId = null;
+  const startPolling = () => {
+    if (pollId || document.visibilityState !== 'visible') return;
+    pollId = window.setInterval(() => {
+      fetchAndApplyCollabSnapshot(collabId);
+    }, 20000);
+  };
+  const stopPolling = () => {
+    if (!pollId) return;
+    window.clearInterval(pollId);
+    pollId = null;
+  };
+  document.addEventListener('visibilitychange', () => {
+    if (document.visibilityState === 'visible') {
+      fetchAndApplyCollabSnapshot(collabId);
+      startPolling();
+    } else {
+      stopPolling();
+    }
+  });
+  startPolling();
+}
+
+function injectModalStyles() {
+  if (document.getElementById('sc-modal-styles')) return;
+  const style = document.createElement('style');
+  style.id = 'sc-modal-styles';
+  style.textContent = `
+    .sc-overlay {
+      position: fixed; inset: 0; z-index: 99999;
+      background: rgba(0,0,0,0.45);
+      display: flex; align-items: center; justify-content: center;
+      animation: sc-fade-in 0.2s ease;
+    }
+    @keyframes sc-fade-in { from { opacity: 0; } to { opacity: 1; } }
+    @keyframes sc-slide-up { from { opacity: 0; transform: translateY(16px); } to { opacity: 1; transform: translateY(0); } }
+    .sc-modal {
+      background: #fff; border-radius: 12px; box-shadow: 0 8px 32px rgba(0,0,0,0.18);
+      width: 100%; max-width: 520px; padding: 32px;
+      display: flex; flex-direction: column; gap: 20px;
+      animation: sc-slide-up 0.3s cubic-bezier(0.22,1,0.36,1) both;
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    }
+    .sc-modal h2 {
+      margin: 0; font-size: 20px; font-weight: 600; color: #1a1a1a;
+    }
+    .sc-field { display: flex; flex-direction: column; gap: 4px; }
+    .sc-label { font-size: 14px; font-weight: 600; color: #1a1a1a; }
+    .sc-required { color: #c0392b; margin-left: 2px; }
+    .sc-input {
+      width: 100%; min-height: 42px; border: 1px solid #d1d5db; border-radius: 10px;
+      background: #fff; color: #1a1a1a; font-size: 14px; padding: 10px 12px;
+      box-sizing: border-box; transition: border-color 0.2s, box-shadow 0.2s;
+      font-family: inherit;
+    }
+    .sc-input:focus { outline: none; border-color: #1473E6; box-shadow: 0 0 0 2px rgba(20,115,230,0.15); }
+    .sc-input--error { border-color: #c0392b; }
+    .sc-input--readonly { background: #f9fafb; color: #6b7280; cursor: default; }
+    .sc-error { font-size: 12px; color: #c0392b; margin-top: 2px; }
+    .sc-collab-wrap {
+      position: relative; width: 100%; min-height: 42px; border: 1px solid #d1d5db;
+      border-radius: 10px; padding: 6px 8px; display: flex; flex-wrap: wrap;
+      align-items: center; gap: 6px; background: #fff; box-sizing: border-box;
+      transition: border-color 0.2s, box-shadow 0.2s;
+    }
+    .sc-collab-wrap:focus-within { border-color: #1473E6; box-shadow: 0 0 0 2px rgba(20,115,230,0.15); }
+    .sc-pill {
+      display: inline-flex; align-items: center; gap: 6px;
+      padding: 4px 8px; background: #f3f4f6; border: 1px solid #d1d5db;
+      border-radius: 999px; font-size: 12px; color: #1a1a1a; line-height: 1;
+    }
+    .sc-pill--pinned { background: #d1fae5; border-color: #059669; color: #059669; }
+    .sc-pill-remove {
+      border: none; background: transparent; color: #6b7280; cursor: pointer;
+      font-size: 14px; line-height: 1; padding: 0;
+    }
+    .sc-collab-input {
+      flex: 1; min-width: 140px; border: none; outline: none; background: transparent;
+      font-size: 14px; color: #1a1a1a; padding: 4px 2px; font-family: inherit;
+    }
+    .sc-collab-input::placeholder { color: #9ca3af; }
+    .sc-suggestions {
+      position: absolute; left: 0; right: 0; top: 100%; margin-top: 4px;
+      border: 1px solid #d1d5db; border-radius: 10px; background: #fff;
+      max-height: 180px; overflow-y: auto; z-index: 10;
+      display: flex; flex-direction: column;
+    }
+    .sc-suggestion {
+      border: none; background: transparent; text-align: left;
+      padding: 10px 12px; font-size: 12px; color: #1a1a1a; cursor: pointer;
+      font-family: inherit; transition: background 0.15s;
+    }
+    .sc-suggestion:hover { background: #f3f4f6; }
+    .sc-tabs { display: flex; gap: 0; border-bottom: 2px solid #e5e7eb; margin-bottom: 4px; }
+    .sc-tab {
+      flex: 1; padding: 10px 16px; border: none; background: transparent;
+      font-size: 14px; font-weight: 600; color: #6b7280; cursor: pointer;
+      font-family: inherit; transition: color 0.15s, border-color 0.15s;
+      border-bottom: 2px solid transparent; margin-bottom: -2px;
+    }
+    .sc-tab:hover { color: #1a1a1a; }
+    .sc-tab--active { color: #1473E6; border-bottom-color: #1473E6; }
+    .sc-tab-content { display: none; flex-direction: column; gap: 16px; }
+    .sc-tab-content--active { display: flex; }
+    .sc-copy-box {
+      display: flex; align-items: center; gap: 8px;
+    }
+    .sc-copy-box input {
+      flex: 1; min-height: 42px; border: 1px solid #d1d5db; border-radius: 10px;
+      background: #f9fafb; color: #1a1a1a; font-size: 13px; padding: 10px 12px;
+      box-sizing: border-box; font-family: monospace;
+    }
+    .sc-copy-btn {
+      padding: 10px 16px; background: #1473E6; color: #fff; border: none;
+      border-radius: 8px; font-size: 13px; font-weight: 600; cursor: pointer;
+      font-family: inherit; white-space: nowrap; transition: background 0.15s;
+    }
+    .sc-copy-btn:hover { background: #0d66d0; }
+    .sc-actions { display: flex; justify-content: flex-end; gap: 10px; padding-top: 4px; }
+    .sc-btn-cancel {
+      padding: 10px 24px; background: #fff; color: #374151; border: 1px solid #d1d5db;
+      border-radius: 8px; font-size: 14px; font-weight: 600; cursor: pointer;
+      font-family: inherit; transition: background 0.15s;
+    }
+    .sc-btn-cancel:hover { background: #f3f4f6; }
+    .sc-btn-submit {
+      padding: 10px 24px; background: #1473E6; color: #fff; border: none;
+      border-radius: 8px; font-size: 14px; font-weight: 600; cursor: pointer;
+      font-family: inherit; transition: background 0.15s;
+    }
+    .sc-btn-submit:hover:not(:disabled) { background: #0d66d0; }
+    .sc-btn-submit:disabled { opacity: 0.45; cursor: not-allowed; }
+    .sc-success-msg { font-size: 14px; color: #059669; font-weight: 600; }
+  `;
+  document.head.appendChild(style);
+}
+
+function createCollaboratorField(label, placeholder) {
+  const ldaps = [];
+  const displayMap = {};
+  let debounceTimer = null;
+
+  const field = document.createElement('div');
+  field.className = 'sc-field';
+
+  const labelEl = document.createElement('label');
+  labelEl.className = 'sc-label';
+  labelEl.textContent = label;
+  field.appendChild(labelEl);
+
+  const wrap = document.createElement('div');
+  wrap.className = 'sc-collab-wrap';
+  field.appendChild(wrap);
+
+  const input = document.createElement('input');
+  input.type = 'text';
+  input.className = 'sc-collab-input';
+  input.placeholder = placeholder;
+  input.autocomplete = 'off';
+  wrap.appendChild(input);
+
+  const suggestionsEl = document.createElement('div');
+  suggestionsEl.className = 'sc-suggestions';
+  suggestionsEl.style.display = 'none';
+  wrap.appendChild(suggestionsEl);
+
+  function renderPills() {
+    wrap.querySelectorAll('.sc-pill').forEach((p) => p.remove());
+    ldaps.forEach((ldap, i) => {
+      const pill = document.createElement('span');
+      pill.className = 'sc-pill';
+      const text = document.createElement('span');
+      text.textContent = displayMap[ldap] || ldap;
+      pill.appendChild(text);
+      const removeBtn = document.createElement('button');
+      removeBtn.type = 'button';
+      removeBtn.className = 'sc-pill-remove';
+      removeBtn.setAttribute('aria-label', `Remove ${ldap}`);
+      removeBtn.textContent = '×';
+      removeBtn.addEventListener('click', () => {
+        ldaps.splice(i, 1);
+        renderPills();
+      });
+      pill.appendChild(removeBtn);
+      wrap.insertBefore(pill, input);
+    });
+  }
+
+  function showSuggestions(users) {
+    suggestionsEl.innerHTML = '';
+    if (!users.length) { suggestionsEl.style.display = 'none'; return; }
+    users.forEach((user) => {
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = 'sc-suggestion';
+      btn.textContent = `${user.displayName || user.id} (${user.id})`;
+      btn.addEventListener('mousedown', (e) => {
+        e.preventDefault();
+        if (!ldaps.some((l) => l.toLowerCase() === user.id.toLowerCase())) {
+          ldaps.push(user.id);
+          if (user.displayName) displayMap[user.id] = user.displayName;
+          renderPills();
+        }
+        input.value = '';
+        suggestionsEl.style.display = 'none';
+      });
+      suggestionsEl.appendChild(btn);
+    });
+    suggestionsEl.style.display = 'flex';
+  }
+
+  input.addEventListener('input', () => {
+    clearTimeout(debounceTimer);
+    const query = input.value.trim();
+    if (query.length < SEARCH_MIN_LENGTH) {
+      suggestionsEl.style.display = 'none';
+      return;
+    }
+    debounceTimer = setTimeout(async () => {
+      const users = await searchUsers(query);
+      showSuggestions(users);
+    }, SEARCH_DEBOUNCE_MS);
+  });
+
+  input.addEventListener('blur', () => {
+    setTimeout(() => { suggestionsEl.style.display = 'none'; }, 150);
+  });
+
+  return {
+    el: field,
+    getLdaps: () => [...ldaps],
+    getDisplayMap: () => ({ ...displayMap }),
+    addPinned: (ldap, name) => {
+      if (!ldaps.some((l) => l.toLowerCase() === ldap.toLowerCase())) {
+        ldaps.push(ldap);
+        if (name) displayMap[ldap] = name;
+        renderPills();
+      }
+      const pill = wrap.querySelector('.sc-pill');
+      if (pill) pill.classList.add('sc-pill--pinned');
+    },
+  };
+}
+
+function showCollabModal() {
+  if (document.querySelector('.sc-overlay')) return Promise.resolve(null);
+  return new Promise((resolve) => {
+    injectModalStyles();
+
+    const overlay = document.createElement('div');
+    overlay.className = 'sc-overlay';
+
+    const modal = document.createElement('div');
+    modal.className = 'sc-modal';
+    overlay.appendChild(modal);
+
+    const heading = document.createElement('h2');
+    heading.textContent = 'Collab';
+    modal.appendChild(heading);
+
+    // ── Tabs ──
+    const tabs = document.createElement('div');
+    tabs.className = 'sc-tabs';
+    const startTab = document.createElement('button');
+    startTab.type = 'button';
+    startTab.className = 'sc-tab sc-tab--active';
+    startTab.textContent = 'Start a Collab';
+    const openTab = document.createElement('button');
+    openTab.type = 'button';
+    openTab.className = 'sc-tab';
+    openTab.textContent = 'Open a Collab';
+    tabs.append(startTab, openTab);
+    modal.appendChild(tabs);
+
+    // ── Start Collab tab content ──
+    const startContent = document.createElement('div');
+    startContent.className = 'sc-tab-content sc-tab-content--active';
+
+    // Title field
+    const titleField = document.createElement('div');
+    titleField.className = 'sc-field';
+    const titleLabel = document.createElement('label');
+    titleLabel.className = 'sc-label';
+    titleLabel.innerHTML = 'Collab Title <span class="sc-required">*</span>';
+    const titleInput = document.createElement('input');
+    titleInput.type = 'text';
+    titleInput.className = 'sc-input';
+    titleInput.placeholder = 'Enter collab title';
+    const titleError = document.createElement('span');
+    titleError.className = 'sc-error';
+    titleError.style.display = 'none';
+    titleError.textContent = 'Collab title is required.';
+    titleField.append(titleLabel, titleInput, titleError);
+    startContent.appendChild(titleField);
+
+    // Page URL field (read-only)
+    const urlField = document.createElement('div');
+    urlField.className = 'sc-field';
+    const urlLabel = document.createElement('label');
+    urlLabel.className = 'sc-label';
+    urlLabel.textContent = 'Page URL';
+    const urlInput = document.createElement('input');
+    urlInput.type = 'text';
+    urlInput.className = 'sc-input sc-input--readonly';
+    urlInput.value = window.location.href.split('?')[0];
+    urlInput.readOnly = true;
+    urlField.append(urlLabel, urlInput);
+    startContent.appendChild(urlField);
+
+    // Reviewer field
+    const reviewerField = createCollaboratorField('Reviewers', 'Search reviewers...');
+    startContent.appendChild(reviewerField.el);
+
+    // Owner field
+    const ownerField = createCollaboratorField('Owners', 'Search owners...');
+    startContent.appendChild(ownerField.el);
+
+    // Pre-fill current user as pinned owner
+    try {
+      const profile = window.adobeIMS?.getProfile?.();
+      const userId = profile?.userId || profile?.email || '';
+      const displayName = profile?.displayName || profile?.name || userId;
+      if (userId) ownerField.addPinned(userId, displayName);
+    } catch { /* ignore */ }
+
+    // Result area (hidden initially, shown after creation)
+    const resultArea = document.createElement('div');
+    resultArea.className = 'sc-field';
+    resultArea.style.display = 'none';
+    const resultLabel = document.createElement('span');
+    resultLabel.className = 'sc-success-msg';
+    resultLabel.textContent = 'Collab created! Share this ID:';
+    const copyBox = document.createElement('div');
+    copyBox.className = 'sc-copy-box';
+    const copyInput = document.createElement('input');
+    copyInput.type = 'text';
+    copyInput.readOnly = true;
+    const copyBtn = document.createElement('button');
+    copyBtn.type = 'button';
+    copyBtn.className = 'sc-copy-btn';
+    copyBtn.textContent = 'Copy';
+    copyBtn.addEventListener('click', () => {
+      navigator.clipboard.writeText(copyInput.value).then(() => {
+        copyBtn.textContent = 'Copied!';
+        setTimeout(() => { copyBtn.textContent = 'Copy'; }, 2000);
+      });
+    });
+    copyBox.append(copyInput, copyBtn);
+    resultArea.append(resultLabel, copyBox);
+    startContent.appendChild(resultArea);
+
+    const startFormError = document.createElement('p');
+    startFormError.className = 'sc-error';
+    startFormError.style.display = 'none';
+    startContent.appendChild(startFormError);
+
+    const startActions = document.createElement('div');
+    startActions.className = 'sc-actions';
+    const startCancelBtn = document.createElement('button');
+    startCancelBtn.type = 'button';
+    startCancelBtn.className = 'sc-btn-cancel';
+    startCancelBtn.textContent = 'Cancel';
+    const startSubmitBtn = document.createElement('button');
+    startSubmitBtn.type = 'button';
+    startSubmitBtn.className = 'sc-btn-submit';
+    startSubmitBtn.textContent = 'Create Collab';
+    startActions.append(startCancelBtn, startSubmitBtn);
+    startContent.appendChild(startActions);
+
+    modal.appendChild(startContent);
+
+    // ── Open Collab tab content ──
+    const openContent = document.createElement('div');
+    openContent.className = 'sc-tab-content';
+
+    const openField = document.createElement('div');
+    openField.className = 'sc-field';
+    const openLabel = document.createElement('label');
+    openLabel.className = 'sc-label';
+    openLabel.innerHTML = 'Collab ID <span class="sc-required">*</span>';
+    const openInput = document.createElement('input');
+    openInput.type = 'text';
+    openInput.className = 'sc-input';
+    openInput.placeholder = 'Paste collab ID here';
+    const openError = document.createElement('span');
+    openError.className = 'sc-error';
+    openError.style.display = 'none';
+    openError.textContent = 'Collab ID is required.';
+    openField.append(openLabel, openInput, openError);
+    openContent.appendChild(openField);
+
+    const openFormError = document.createElement('p');
+    openFormError.className = 'sc-error';
+    openFormError.style.display = 'none';
+    openContent.appendChild(openFormError);
+
+    const openActions = document.createElement('div');
+    openActions.className = 'sc-actions';
+    const openCancelBtn = document.createElement('button');
+    openCancelBtn.type = 'button';
+    openCancelBtn.className = 'sc-btn-cancel';
+    openCancelBtn.textContent = 'Cancel';
+    const openSubmitBtn = document.createElement('button');
+    openSubmitBtn.type = 'button';
+    openSubmitBtn.className = 'sc-btn-submit';
+    openSubmitBtn.textContent = 'Open Collab';
+    openActions.append(openCancelBtn, openSubmitBtn);
+    openContent.appendChild(openActions);
+
+    modal.appendChild(openContent);
+
+    // ── Tab switching ──
+    function switchTab(activeTab) {
+      const isStart = activeTab === 'start';
+      startTab.classList.toggle('sc-tab--active', isStart);
+      openTab.classList.toggle('sc-tab--active', !isStart);
+      startContent.classList.toggle('sc-tab-content--active', isStart);
+      openContent.classList.toggle('sc-tab-content--active', !isStart);
+    }
+    startTab.addEventListener('click', () => switchTab('start'));
+    openTab.addEventListener('click', () => switchTab('open'));
+
+    // ── Close helper ──
+    function close(result) {
+      overlay.remove();
+      resolve(result);
+    }
+
+    startCancelBtn.addEventListener('click', () => close(null));
+    openCancelBtn.addEventListener('click', () => close(null));
+    overlay.addEventListener('click', (e) => { if (e.target === overlay) close(null); });
+
+    // ── Start Collab submit ──
+    let createdCollabId = null;
+    startSubmitBtn.addEventListener('click', async () => {
+      if (createdCollabId) {
+        close({ action: 'open', collabId: createdCollabId });
+        return;
+      }
+
+      titleError.style.display = 'none';
+      startFormError.style.display = 'none';
+      const title = titleInput.value.trim();
+      if (!title) {
+        titleInput.classList.add('sc-input--error');
+        titleError.style.display = 'block';
+        return;
+      }
+      titleInput.classList.remove('sc-input--error');
+
+      startSubmitBtn.disabled = true;
+      startSubmitBtn.textContent = 'Creating...';
+
+      try {
+        const { host, pathname } = window.location;
+        const repo = host.split('--')[1] || '';
+        const daPageUrl = `adobecom/${repo}${pathname}`;
+        const previewBase = `${window.location.origin}${pathname}`;
+        const previewUrl = `${previewBase}?martech=off&mepButton=off&georouting=off&daRenderingApp=stream`;
+
+        const collabData = {
+          title,
+          pageUrl: daPageUrl,
+          designUrl: null,
+          previewUrl,
+          jiraId: null,
+          metadata: { source: 'milo-collab-init' },
+        };
+
+        const collab = await createCollab(collabData);
+        const collabId = collab?.id;
+        if (!collabId) throw new Error('No collab id in response');
+
+        const reviewerLdaps = reviewerField.getLdaps();
+        const ownerLdaps = ownerField.getLdaps();
+        const ownerSet = new Set(ownerLdaps.map((l) => l.toLowerCase()));
+        const assignments = [
+          ...ownerLdaps.map((ldap) => ({ userId: ldap, role: 'owner', displayName: ownerField.getDisplayMap()[ldap] || ldap })),
+          ...reviewerLdaps
+            .filter((ldap) => !ownerSet.has(ldap.toLowerCase()))
+            .map((ldap) => ({ userId: ldap, role: 'reviewer', displayName: reviewerField.getDisplayMap()[ldap] || ldap })),
+        ];
+        await assignCollabRoles(collabId, assignments);
+
+        createdCollabId = collabId;
+        copyInput.value = collabId;
+        resultArea.style.display = 'flex';
+        startSubmitBtn.textContent = 'Open Collab';
+        startSubmitBtn.disabled = false;
+      } catch (err) {
+        console.error('[milo-collab-init] Failed to start collab:', err);
+        startFormError.textContent = err?.message || 'Failed to start collab. Please try again.';
+        startFormError.style.display = 'block';
+        startSubmitBtn.disabled = false;
+        startSubmitBtn.textContent = 'Create Collab';
+      }
+    });
+
+    // ── Open Collab submit ──
+    openSubmitBtn.addEventListener('click', () => {
+      openError.style.display = 'none';
+      openFormError.style.display = 'none';
+      const id = openInput.value.trim();
+      if (!id) {
+        openInput.classList.add('sc-input--error');
+        openError.style.display = 'block';
+        return;
+      }
+      openInput.classList.remove('sc-input--error');
+      close({ action: 'open', collabId: id });
+    });
+
+    document.body.appendChild(overlay);
+    titleInput.focus();
+  });
+}
+
+// (async function initMiloCollab() {
+//   const params = new URLSearchParams(window.location.search);
+
+//   const collabId = params.get('miloCollabId');
+//   if (collabId) {
+//     await startAnnotation();
+//     return;
+//   }
+
+//   const token = getToken();
+//   if (!token) {
+//     console.error('[milo-collab-init] No auth token found.');
+//     return;
+//   }
+
+//   const result = await showCollabModal();
+//   if (!result) return;
+
+//   if (result.action === 'open') {
+//     await startAnnotation(result.collabId);
+//   }
+// }());
+
+let initInProgress = false;
+export async function initializeStreamAnnotation(sidekickDetail = null) {
+  if (initInProgress) return;
+  initInProgress = true;
+  const profile = sidekickDetail?.status?.profile;
+
+  if (profile) {
+    try {
+      const response = await fetch(`${API_ENDPOINT}/auth/token`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ profile }),
+      });
+      if (response.ok) {
+        const data = await response.json();
+        resolvedToken = data.token || '';
+        resolvedEmail = data.email || '';
+        resolvedName = profile.name || profile.email?.split('@')[0] || '';
+      } else {
+        console.warn('[milo-collab-init] Token exchange failed:', response.status);
+      }
+    } catch (error) {
+      console.warn('[milo-collab-init] Token exchange error:', error);
+    }
+  }
+
+
+  if (!resolvedToken) {
+    resolvedToken = window.adobeIMS?.getAccessToken()?.token || '';
+  }
+  const params = new URLSearchParams(window.location.search);
+
+  const collabId = params.get('miloCollabId');
+  if (collabId) {
+    await startAnnotation(collabId);
+    return;
+  }
+
+  if (!resolvedToken) {
+    console.error('[milo-collab-init] No auth token found.');
+    return;
+  }
+
+  const result = await showCollabModal();
+  if (!result) return;
+
+  if (result.action === 'open') {
+    await startAnnotation(result.collabId);
+  }
+}

--- a/streamlibs/previewer.js
+++ b/streamlibs/previewer.js
@@ -191,7 +191,7 @@ export async function initiatePreviewer(forceOperation = null) {
       updateLoader({ percentage: 50, message: 'Loading Page' });
       await mergeImageUrls();
       updateLoader({ percentage: 80, message: 'Loading Page' });
-      annotationOperationOnHostPage();
+      await annotationOperationOnHostPage();
       updateLoader({ percentage: 100, message: 'Loading Page' });
       attachRegenHandlers();
       hideLoader();
@@ -512,6 +512,7 @@ export async function mergeImageUrls() {
   const searchParams = new URLSearchParams(window.location.search);
   if (searchParams.get('daRenderingApp') !== 'stream' && searchParams.get('darenderingapp') !== 'stream') return;
   const repo = host.split('--')[1];
+  if (!repo) return;
   const daUrl = `adobecom/${repo}${pathname}`;
   const daHtml = await fetchDAContent(daUrl);
   const daImg = daHtml.querySelectorAll('main img');
@@ -535,6 +536,7 @@ export async function selfRender() {
   const searchParams = new URLSearchParams(window.location.search);
   if (searchParams.get('daRenderingApp') !== 'stream' && searchParams.get('darenderingapp') !== 'stream') return;
   if (window.location.host.includes('stream-mapper--adobecom.aem')) return;
+  if (!document.querySelector('main')) return;
   const mapperOrigin = searchParams.get('mapperOrigin') || searchParams.get('mapperorigin');
   loadCssFiles(`${mapperOrigin}/streamlibs/styles/styles.css`);
   await initPreviewer();

--- a/streamlibs/previewer.js
+++ b/streamlibs/previewer.js
@@ -41,6 +41,8 @@ import {
 } from './utils/operations.js';
 import {
   ANNOTATION_REFRESH_EVENT,
+  ANNOTATION_SAVE_EVENT,
+  ANNOTATION_PUBLISH_EVENT,
   ANNOTATION_READY_EVENT,
   ANNOTATION_MESSAGES,
   LOADER_PROGRESS_STEPS,
@@ -185,9 +187,9 @@ export async function initiatePreviewer(forceOperation = null) {
       break;
     case 'aiSeoAnnotation':
       updateLoader({ percentage: 10, message: 'Loading Page' });
-      await mergeImageUrls();
-      updateLoader({ percentage: 50, message: 'Loading Page' });
       await setupCollabSpace();
+      updateLoader({ percentage: 50, message: 'Loading Page' });
+      await mergeImageUrls();
       updateLoader({ percentage: 80, message: 'Loading Page' });
       annotationOperationOnHostPage();
       updateLoader({ percentage: 100, message: 'Loading Page' });
@@ -287,7 +289,7 @@ async function requestStreamConfigFromParent() {
   });
 }
 
-async function setupMessageListener() {
+export async function setupMessageListener() {
   window.addEventListener('message', async (event) => {
     const allowedOrigins = window.streamConfig.streamMapper.allowMessagesFromDomains;
     const isOriginAllowed = allowedOrigins.some((pattern) => {
@@ -344,6 +346,18 @@ async function setupMessageListener() {
 
   window.addEventListener(ANNOTATION_REFRESH_EVENT, async () => {
     await refreshAnnotationCanvas();
+  });
+
+  window.addEventListener(ANNOTATION_SAVE_EVENT, async () => {
+    await saveChanges();
+  });
+
+  window.addEventListener(ANNOTATION_PUBLISH_EVENT, async () => {
+    try {
+      await persist();
+    } catch {
+      // persist() notifies the parent on failure
+    }
   });
 }
 

--- a/streamlibs/sources/da.js
+++ b/streamlibs/sources/da.js
@@ -1,5 +1,5 @@
+
 import { handleError, safeFetch } from '../utils/error-handler.js';
-import { postData } from '../target/da.js';
 
 function restoreImgToPicture(html) {
   const parser = new DOMParser();
@@ -33,22 +33,16 @@ export function getMiloCompatibleHtml(html) {
 }
 
 export async function daPageExists(path) {
-  let url = path;
-  if (!url.startsWith('/')) url = `/${url}`;
-  if (!url.endsWith('.html')) url += '.html';
-  const options = {
-    method: 'GET',
-    headers: {
-      'Content-Type': 'text/html',
-      Authorization: `Bearer ${window.streamConfig.token}`,
-    },
-  };
+  const serviceEP = window.streamConfig?.streamMapper?.serviceEP;
+  const token = window.streamConfig?.token;
   try {
-    const response = await fetch(`https://admin.da.live/source${url}`, options);
-    if (response.status !== 200) {
-      return false;
-    }
-    return true;
+    const response = await fetch(
+      `${serviceEP}/api/da/page-exists?path=${encodeURIComponent(path)}`,
+      { headers: { Authorization: `Bearer ${token}` } },
+    );
+    if (!response.ok) return false;
+    const data = await response.json();
+    return data.exists === true;
   } catch (error) {
     // pass
   }
@@ -56,41 +50,34 @@ export async function daPageExists(path) {
 }
 
 export async function copyDaPage(fromPath, toPath) {
-  let from = fromPath;
-  if (!from.startsWith('/')) from = `/${from}`;
-  if (!from.endsWith('.html')) from += '.html';
-  let html;
+  const serviceEP = window.streamConfig?.streamMapper?.serviceEP;
+  const token = window.streamConfig?.token;
   try {
-    const response = await safeFetch(`https://admin.da.live/source${from}`, {
-      method: 'GET',
+    const response = await safeFetch(`${serviceEP}/api/da/copy-page`, {
+      method: 'POST',
       headers: {
-        'Content-Type': 'text/html',
-        Authorization: `Bearer ${window.streamConfig.token}`,
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
       },
+      body: JSON.stringify({ fromPath, toPath }),
     });
-    html = await response.text();
-    await postData(toPath, html, {}, false);
-    return true;
+    const data = await response.json();
+    return data.success === true;
   } catch (error) {
     return false;
   }
 }
 
 async function getDAContent(path = false) {
-  let url = window.streamConfig.targetUrl;
-  if (path) url = path;
-  if (!url.startsWith('/')) url = `/${url}`;
-  if (!url.endsWith('.html')) url += '.html';
-  const options = {
-    method: 'GET',
-    headers: {
-      'Content-Type': 'text/html',
-      Authorization: `Bearer ${window.streamConfig.token}`,
-    },
-  };
+  const url = path || window.streamConfig.targetUrl;
+  const serviceEP = window.streamConfig?.streamMapper?.serviceEP;
+  const token = window.streamConfig?.token;
   let response = null;
   try {
-    response = await safeFetch(`https://admin.da.live/source${url}`, options);
+    response = await safeFetch(
+      `${serviceEP}/api/da/content?path=${encodeURIComponent(url)}`,
+      { headers: { Authorization: `Bearer ${token}` } },
+    );
   } catch (error) {
     handleError(error, 'getting html from DA page');
     throw error;

--- a/streamlibs/target/da.js
+++ b/streamlibs/target/da.js
@@ -52,11 +52,19 @@ export function getDACompatibleHtml(html) {
   return html;
 }
 
+function hasTokenParam() {
+  return Boolean(
+    new URLSearchParams(window.location.search).get('token')
+    || window.streamConfig?.token,
+  );
+}
+
 function wrapHTMLForDA(html) {
   return `<body><header></header><main>${html}</main><footer></footer>`;
 }
 
 export async function postData(url, html, options = {}, wrapHtml=true) {
+  if (!hasTokenParam()) return;
   const { streamMapper } = window.streamConfig;
   let wrappedHtml = html;
   if (wrapHtml) wrappedHtml = wrapHTMLForDA(html);
@@ -131,6 +139,7 @@ export function extractRepoPath(raw) {
  * Returns true if the document exists (HTTP 2xx), false otherwise.
  */
 export async function fragmentExistsOnDa(rawPath) {
+  if (!hasTokenParam()) return false;
   const repoPath = extractRepoPath(rawPath);
   if (!repoPath) return false;
   let url = `/${repoPath}`;

--- a/streamlibs/utils/config.js
+++ b/streamlibs/utils/config.js
@@ -40,7 +40,7 @@ export const CONFIG = {
   },
   dev: {
     streamMapper: {
-      serviceEP: 'https://adobe-acom-stream-service-deploy-ethos502-prod-or2-1de07c.cloud.adobe.io',
+      serviceEP: 'https://adobe-acom-stream-service-deploy-ethos501-prod-or2-b0c6b7.cloud.adobe.io',
       figmaMappingUrl: '/api/fig-comps',
       figmaBlockContentUrl: '/api/fig-comp-details',
       pushToDaUrl: '/api/push-html',

--- a/streamlibs/utils/config.js
+++ b/streamlibs/utils/config.js
@@ -40,7 +40,7 @@ export const CONFIG = {
   },
   dev: {
     streamMapper: {
-      serviceEP: 'https://adobe-acom-stream-service-deploy-ethos501-prod-or2-b0c6b7.cloud.adobe.io',
+      serviceEP: 'https://adobe-acom-stream-service-deploy-ethos502-prod-or2-1de07c.cloud.adobe.io',
       figmaMappingUrl: '/api/fig-comps',
       figmaBlockContentUrl: '/api/fig-comp-details',
       pushToDaUrl: '/api/push-html',

--- a/streamlibs/utils/constants.js
+++ b/streamlibs/utils/constants.js
@@ -210,6 +210,8 @@ export const LOADER_MSG_LIST = [
 
 export const LOADER_PROGRESS_EVENT = 'stream-mapper:loader-progress';
 export const ANNOTATION_REFRESH_EVENT = 'stream-mapper:annotation-refresh';
+export const ANNOTATION_SAVE_EVENT = 'stream-mapper:annotation-save';
+export const ANNOTATION_PUBLISH_EVENT = 'stream-mapper:annotation-publish';
 export const ANNOTATION_READY_EVENT = 'STREAM_ANNOTATION_READY';
 
 export const LOADER_PROGRESS_STEPS = {

--- a/streamlibs/utils/utils.js
+++ b/streamlibs/utils/utils.js
@@ -209,6 +209,14 @@ async function handleBrokenBlocks(placeholderHtml = BROKEN_PLACEHOLDER_HTML.defa
   handler();
 }
 
+export function getEnvFromRef() {
+  const ref = (new URLSearchParams(window.location.search).get('streamRef') || '').toLowerCase();
+  if (ref === 'prod') return 'prod';
+  if (ref === 'stage') return 'stage';
+  if (ref === 'dev02') return 'dev02';
+  return 'dev';
+}
+
 export function getMapperEnv() {
   const { origin } = window.location;
   let mapperOrigin = origin;

--- a/streamlibs/utils/utils.js
+++ b/streamlibs/utils/utils.js
@@ -216,10 +216,10 @@ export function getMapperEnv() {
   if (params.get('daRenderingApp') || params.get('darenderingapp')) {
     mapperOrigin = params.get('mapperOrigin') || params.get('mapperorigin');
   }
-  if (mapperOrigin.includes('https://dev--')) return 'dev';
-  if (mapperOrigin.includes('https://dev02--')) return 'dev02';
-  if (mapperOrigin.includes('https://stage--')) return 'stage';
-  if (mapperOrigin.includes('https://main--')) return 'prod';
+  if (mapperOrigin.includes('https://dev--stream-mapper')) return 'dev';
+  if (mapperOrigin.includes('https://dev02--stream-mapper')) return 'dev02';
+  if (mapperOrigin.includes('https://stage--stream-mapper')) return 'stage';
+  if (mapperOrigin.includes('https://main--stream-mapper')) return 'prod';
   return 'dev';
 }
 


### PR DESCRIPTION
## Summary
- Adds `milo-collab-init.js` — a new standalone annotation entry point that enables collab annotation directly on AEM content pages without the stream-mapper iframe, activated via the AEM sidekick's `custom` event
- Token exchange: on sidekick login, exchanges the sidekick IMS profile for a service token via `POST /api/auth/token`, then bootstraps the full annotation environment
- Collab modal: allows users to create a new collab or open an existing one by ID; after creation the button transforms to "Open Collab" so the user doesn't need to manually switch tabs
- `getEnvFromRef()` utility: resolves the service endpoint from a `?streamRef=` URL param (`prod`, `stage`, `dev02`, `dev`), making the standalone entry point environment-aware without relying on `import.meta.url` or mapper origin
