### PR TITLE
MWPW-194452  Observing Flickering effect while performing drag and drop

### DIFF
--- a/streamlibs/operations/edit/drag-drop.js
+++ b/streamlibs/operations/edit/drag-drop.js
@@ -49,7 +49,11 @@ export default function createEditDragDropController({
       targetBlock = targetBlock.parentNode;
     }
 
-    if (targetBlock && currentDropContainer.contains(targetBlock)) {
+    if (
+      targetBlock
+      && targetBlock !== editState.draggedMainBlock
+      && currentDropContainer.contains(targetBlock)
+    ) {
       const rect = targetBlock.getBoundingClientRect();
       const shouldInsertBefore = event.clientY < rect.top + rect.height / 2;
       if (shouldInsertBefore && targetBlock.previousSibling !== dropPlaceholder) {
@@ -60,8 +64,8 @@ export default function createEditDragDropController({
       return;
     }
 
-    // eslint-disable-next-line max-len
-    if (dropPlaceholder.parentNode !== currentDropContainer || dropPlaceholder !== currentDropContainer.lastChild) {
+   // eslint-disable-next-line max-len
+    if (dropPlaceholder.parentNode !== currentDropContainer) {
       currentDropContainer.appendChild(dropPlaceholder);
     }
   }

--- a/streamlibs/operations/edit/edit.css
+++ b/streamlibs/operations/edit/edit.css
@@ -221,6 +221,7 @@ div[data-source="figma"].do-not-drag {
   background-repeat: no-repeat;
   background-position: center;
   background-size: 36px 36px;
+  pointer-events: none;
 }
 
 .da-section-delete {


### PR DESCRIPTION
Jira: [MWPW-194452](https://jira.corp.adobe.com/browse/MWPW-194452) 

Fixes flicker during drag-and-drop in Editor Preview when inserting Figma blocks into the DA panel and when reordering blocks in the right-hand pane.

Issue
During drag, the drop placeholder was repositioned incorrectly on every pointermove:

Figma → DA drop: When the cursor hovered the placeholder gap, elementFromPoint() found no [data-source] block, so the fallback forced the placeholder to the end of .da-panel and back — causing visible flicker.
Right-pane reorder: The dragged block itself was treated as the insertion target, so the placeholder ping-ponged above/below it as layout shifted under the cursor.

Fix
drag-drop.js: Skip the currently dragged block as an insertion target (targetBlock !== editState.draggedMainBlock). Only append the placeholder when it is not yet in the container; do not force-move it to lastChild on every move.
edit.css: Add pointer-events: none on .da-drop-placeholder so the placeholder does not intercept hit-testing.
Before: 

https://github.com/user-attachments/assets/a01b9328-df15-47d6-863f-18f40bdd8360

After:

https://github.com/user-attachments/assets/8555e584-4300-49b6-9f2e-f338f63f8959




