### PR TITLE
[MWPW-197196]Fragment highlight

### DIFF
--- a/streamlibs/operations/aiSeoAnnotation/ai-seo-annotation.css
+++ b/streamlibs/operations/aiSeoAnnotation/ai-seo-annotation.css
@@ -166,16 +166,17 @@
 
 .stream-img-model-select:focus { border-color: #1d4ed8; }
 
-main div.fragment {
+/* Collab fragments use stream-fragment-readonly in annotation.css (fragment-hints.js). */
+body:not(.annotation-mode) main div.fragment {
     position: relative;
     pointer-events: none;
 }
 
-main div.fragment:not([data-path$="fragments/stream-block-placeholder"]) div {
+body:not(.annotation-mode) main div.fragment:not([data-path$="fragments/stream-block-placeholder"]) div {
     filter: blur(2px);
 }
 
-main div.fragment:not([data-path$="fragments/stream-block-placeholder"])::before {
+body:not(.annotation-mode) main div.fragment:not([data-path$="fragments/stream-block-placeholder"])::before {
     content: 'Fragment edit blocked';
     position: absolute;
     inset: 0;

--- a/streamlibs/operations/annotation.js
+++ b/streamlibs/operations/annotation.js
@@ -8,6 +8,7 @@ import {
   copyDaPage,
 } from '../sources/da.js';
 import { hydrateFragmentLinksInDaBlocks } from './edit/fragment-hydrate.js';
+import syncFragmentEditDisabledHints from './annotation/fragment-hints.js';
 import { miloLoadArea } from '../utils/utils.js';
 import { getDACompatibleHtml, postData } from '../target/da.js';
 import { fetchImageAsBase64 } from './edit/dom.js';
@@ -801,6 +802,7 @@ export async function annotationOperation(options = {}) {
   await miloLoadArea();
 
   await finishAnnotationSession(mainEl, { preserveRemoteEditState, shouldRestoreInlineMode });
+  syncFragmentEditDisabledHints(mainEl, true);
 }
 
 export async function annotationOperationOnHostPage(options = {}) {
@@ -841,6 +843,7 @@ export async function annotationOperationOnHostPage(options = {}) {
   }
 
   await finishAnnotationSession(mainEl, { preserveRemoteEditState, shouldRestoreInlineMode });
+  syncFragmentEditDisabledHints(mainEl, true);
 
   const stripBase64QueryParam = (el) => {
     const attr = el.tagName === 'SOURCE' ? 'srcset' : 'src';

--- a/streamlibs/operations/annotation/annotation.css
+++ b/streamlibs/operations/annotation/annotation.css
@@ -1476,37 +1476,89 @@ body.annotation-inline-edit-mode .annotation-selected-element {
   cursor: text;
 }
 
-/* Embedded Milo fragments: not editable in annotation (source of truth is the fragment doc). */
-body.annotation-mode main [data-class="fragment"] {
+/* Embedded Milo fragments: blocked banner + link, blurred body, centered overlay. */
+body.annotation-mode main [data-class="fragment"].stream-fragment-readonly {
   position: relative;
-  opacity: 0.86;
   border-radius: 6px;
-  box-shadow: inset 0 0 0 1px rgb(107 114 128 / 0.45);
-  background: rgb(243 244 246 / 0.5);
+  overflow: hidden;
 }
 
-body.annotation-inline-edit-mode main [data-class="fragment"] {
-  opacity: 0.78;
-  /* Block text/link interaction; fragment source of truth is the fragment doc. */
+body.annotation-inline-edit-mode main [data-class="fragment"].stream-fragment-readonly,
+body.annotation-asset-select-mode main [data-class="fragment"].stream-fragment-readonly {
   pointer-events: none;
 }
 
-/* Asset select: block all interaction inside embedded fragments (incl. image upload). */
-body.annotation-asset-select-mode main [data-class="fragment"] {
-  pointer-events: none;
+body.annotation-inline-edit-mode main [data-class="fragment"].stream-fragment-readonly > .stream-fragment-path-label,
+body.annotation-asset-select-mode main [data-class="fragment"].stream-fragment-readonly > .stream-fragment-path-label {
+  pointer-events: auto;
 }
 
-body.annotation-mode main [data-class="fragment"] > .annotation-fragment-readonly-hint {
+body.annotation-mode main [data-class="fragment"].stream-fragment-readonly > .stream-fragment-path-label {
   display: block;
-  padding: 8px 12px;
-  margin: 0 0 12px;
+  padding: 10px 14px;
+  margin: 0;
   font-size: 12px;
-  line-height: 1.4;
+  line-height: 1.45;
+  color: #1e40af;
+  background: #eff6ff;
+  border-bottom: 1px solid #bfdbfe;
+  font-family: 'Adobe Clean', 'Trebuchet MS', sans-serif;
+  pointer-events: auto;
+  position: relative;
+  z-index: 12;
+}
+
+body.annotation-mode main [data-class="fragment"] .stream-fragment-blocked-title {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: #1e3a8a;
+  margin-bottom: 6px;
+}
+
+body.annotation-mode main [data-class="fragment"] .stream-fragment-path-link {
+  color: #1d4ed8;
+  text-decoration: underline;
+  word-break: break-all;
+  font-weight: 500;
+}
+
+body.annotation-mode main [data-class="fragment"] .stream-fragment-path-link:hover {
+  color: #1e3a8a;
+}
+
+body.annotation-mode main [data-class="fragment"] .stream-fragment-path-fallback {
+  color: #475569;
+  word-break: break-all;
+  font-family: ui-monospace, monospace;
+  font-size: 11px;
+}
+
+body.annotation-mode main [data-class="fragment"] .stream-fragment-readonly-body {
+  position: relative;
+  min-height: 120px;
+}
+
+body.annotation-mode main [data-class="fragment"] .stream-fragment-readonly-body > :not(.stream-fragment-readonly-overlay) {
+  filter: blur(2px);
+  pointer-events: none;
+  user-select: none;
+}
+
+body.annotation-mode main [data-class="fragment"] .stream-fragment-readonly-overlay {
+  position: absolute;
+  inset: 0;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgb(107 114 128 / 50%);
+  color: #bed9ff;
+  font-size: clamp(22px, 3.5vw, 40px);
   font-weight: 600;
-  color: #374151;
-  background: linear-gradient(to bottom, #eef0f2, #e5e7eb);
-  border-radius: 4px;
-  border: 1px solid rgb(107 114 128 / 0.45);
+  letter-spacing: 0.03em;
+  pointer-events: none;
   font-family: 'Adobe Clean', 'Trebuchet MS', sans-serif;
 }
 

--- a/streamlibs/operations/annotation/comments-panel.js
+++ b/streamlibs/operations/annotation/comments-panel.js
@@ -1273,12 +1273,7 @@ export default function createCommentsPanelController({
     renderRefreshAction();
     updateModeButtonStates();
 
-    const finalizeFragmentHints = () => syncFragmentEditDisabledHints(
-      annotationUI.mainEl,
-      annotationUI.annotationMode === 'edit'
-        || annotationUI.inlineMode
-        || annotationUI.assetSelectMode,
-    );
+    const finalizeFragmentHints = () => syncFragmentEditDisabledHints(annotationUI.mainEl, true);
 
     const activePopupThreadId = `${annotationUI.popupEl?.dataset.threadId || ''}`.trim();
     if (activePopupThreadId) {
@@ -2690,6 +2685,7 @@ export default function createCommentsPanelController({
       const { target } = event;
       if (!(target instanceof HTMLElement)) return;
       if (target === mainEl) return;
+      if (target.closest('.stream-fragment-path-label a')) return;
       if (target.closest('a')) event.preventDefault();
       event.stopPropagation();
       openPopupForElement(target);

--- a/streamlibs/operations/annotation/fragment-hints.js
+++ b/streamlibs/operations/annotation/fragment-hints.js
@@ -1,38 +1,384 @@
 /* eslint-disable max-len */
-/* eslint-disable import/prefer-default-export */
 
-import { ANNOTATION_MESSAGES } from '../../utils/constants.js';
+import { helixPreviewUrlFromRepoPath } from '../edit/fragment-hydrate.js';
 
-const HINT_CLASS = 'annotation-fragment-readonly-hint';
+export const FRAGMENT_LABEL_CLASS = 'stream-fragment-path-label';
+export const FRAGMENT_HIGHLIGHT_CLASS = 'stream-fragment-highlight';
+export const FRAGMENT_READONLY_CLASS = 'stream-fragment-readonly';
+const FRAGMENT_READONLY_BODY_CLASS = 'stream-fragment-readonly-body';
+const FRAGMENT_READONLY_OVERLAY_CLASS = 'stream-fragment-readonly-overlay';
+const FRAGMENT_BLOCKED_TITLE_CLASS = 'stream-fragment-blocked-title';
 
-/**
- * True when this fragment is nested inside another fragment root.
- * (Banner only on the outer wrapper.)
- */
+function getRepoOrgFromPageLocation() {
+  try {
+    const segs = window.location.hostname.toLowerCase().split('.');
+    const aemIdx = segs.findIndex((s) => s === 'aem');
+    if (aemIdx < 1) return null;
+    const hostParts = segs[aemIdx - 1].split('--');
+    if (hostParts.length < 3) return null;
+    const org = hostParts[hostParts.length - 1];
+    const repo = hostParts[hostParts.length - 2];
+    return org && repo ? { org, repo } : null;
+  } catch {
+    return null;
+  }
+}
+
+function getRepoOrgFromConfig() {
+  const candidates = [
+    window.streamConfig?.targetUrl,
+    window.streamConfig?.pageUrl,
+    window.streamConfig?.contentUrl,
+    window.streamConfig?.draftLocation,
+  ].filter(Boolean);
+
+  for (const raw of candidates) {
+    const trimmed = `${raw}`.trim();
+    if (/^https?:\/\//i.test(trimmed)) {
+      const hostMatch = trimmed.match(/main--([^-]+)--([^./]+)\.aem\.(?:page|live)/i);
+      if (hostMatch) {
+        return { org: hostMatch[2], repo: hostMatch[1] };
+      }
+    }
+    const path = trimmed.replace(/^\/+/, '').split('?')[0];
+    const parts = path.split('/').filter(Boolean);
+    if (parts.length >= 2) return { org: parts[0], repo: parts[1] };
+  }
+
+  return getRepoOrgFromPageLocation() || { org: '', repo: '' };
+}
+
+function resolveRepoOrg() {
+  const fromConfig = getRepoOrgFromConfig();
+  if (fromConfig.org && fromConfig.repo) return fromConfig;
+  return getRepoOrgFromPageLocation() || fromConfig;
+}
+
+function readFragmentDataPath(fragmentEl) {
+  if (!(fragmentEl instanceof HTMLElement)) return '';
+
+  const ownPath = fragmentEl.getAttribute('data-path');
+  if (ownPath) return ownPath;
+
+  const innerFragment = fragmentEl.querySelector(':scope .fragment[data-path]');
+  if (innerFragment?.getAttribute('data-path')) {
+    return innerFragment.getAttribute('data-path') || '';
+  }
+
+  const nestedPath = fragmentEl.querySelector(':scope [data-path]');
+  if (nestedPath?.getAttribute('data-path')) {
+    return nestedPath.getAttribute('data-path') || '';
+  }
+
+  return '';
+}
+
+function buildPreviewUrlFromDataPath(dataPath) {
+  if (!dataPath) return '';
+  const pagePath = dataPath.startsWith('/') ? dataPath : `/${dataPath}`;
+  const { org, repo } = resolveRepoOrg();
+  if (org && repo) {
+    return `https://main--${repo}--${org}.aem.page${pagePath}`;
+  }
+  return '';
+}
+
 function isNestedFragmentRoot(fragmentEl) {
   const parent = fragmentEl.parentElement;
   if (!parent) return false;
-  return Boolean(parent.closest('[data-class="fragment"]'));
+  return Boolean(
+    parent.closest('[data-class="fragment"]')
+    || parent.closest('div.fragment[data-path]'),
+  );
+}
+
+function findAnnotationFragmentRoots(mainEl) {
+  const roots = [];
+  const seen = new Set();
+
+  mainEl.querySelectorAll('[data-class="fragment"]').forEach((el) => {
+    if (!(el instanceof HTMLElement)) return;
+    if (isNestedFragmentRoot(el)) return;
+    if (seen.has(el)) return;
+    seen.add(el);
+    roots.push(el);
+  });
+
+  mainEl.querySelectorAll('div.fragment[data-path]').forEach((el) => {
+    if (!(el instanceof HTMLElement)) return;
+    if (seen.has(el)) return;
+    if (isNestedFragmentRoot(el)) return;
+    if (el.closest('[data-class="fragment"]')) return;
+    seen.add(el);
+    roots.push(el);
+  });
+
+  mainEl.querySelectorAll('a[href*="/fragments/"]').forEach((anchor) => {
+    if (!(anchor instanceof HTMLAnchorElement)) return;
+    const fragmentEl = anchor.closest('[data-class="fragment"]')
+      || anchor.closest('div.fragment[data-path]');
+    if (!(fragmentEl instanceof HTMLElement)) return;
+    if (isNestedFragmentRoot(fragmentEl)) return;
+    if (seen.has(fragmentEl)) return;
+    seen.add(fragmentEl);
+    roots.push(fragmentEl);
+  });
+
+  return roots;
+}
+
+/** True when a panel row already embeds a fragment (including after reprocess from DA). */
+export function isFragmentPanelRow(blockEl) {
+  if (!(blockEl instanceof HTMLElement)) return false;
+  if (blockEl.getAttribute('data-class') === 'fragment') return true;
+  if (blockEl.dataset.fragmentBlock === 'true') return true;
+  if (blockEl.classList.contains('fragment') && blockEl.hasAttribute('data-path')) return true;
+  if (blockEl.querySelector(`.${FRAGMENT_LABEL_CLASS}`)) return true;
+  return Boolean(
+    blockEl.querySelector(
+      '[data-class="fragment"], .fragment[data-path], a[href*="/fragments/"]',
+    ),
+  );
+}
+
+/** Disable create-fragment on rows that already embed a fragment. */
+export function syncFragmentBlockControls() {
+  document.querySelectorAll(
+    '.da-panel > [data-source], .figma-panel > [data-source], .da-panel > [id^="block-"], .figma-panel > [id^="block-"]',
+  ).forEach((row) => {
+    if (!(row instanceof HTMLElement) || !isFragmentPanelRow(row)) return;
+    row.dataset.fragmentBlock = 'true';
+    row.querySelectorAll('.block-action-btn').forEach((btn) => btn.remove());
+    row.classList.remove('has-block-action');
+  });
+}
+
+function getEditFragmentIndicatorHost(fragmentEl) {
+  const panelRow = fragmentEl.closest(
+    '.da-panel > [data-source], .figma-panel > [data-source], .da-panel > [id^="block-"], .figma-panel > [id^="block-"]',
+  );
+  if (panelRow instanceof HTMLElement) return panelRow;
+
+  const main = fragmentEl.closest('main');
+  if (main) {
+    let node = fragmentEl;
+    while (node.parentElement && node.parentElement !== main) {
+      node = node.parentElement;
+    }
+    if (node.parentElement === main) return node;
+  }
+
+  if (fragmentEl.matches('[data-source], [id^="block-"]')) return fragmentEl;
+  return fragmentEl;
+}
+
+function resolveFragmentPreviewUrl(fragmentEl) {
+  if (!(fragmentEl instanceof HTMLElement)) return '';
+
+  const dataPath = readFragmentDataPath(fragmentEl);
+  const fromPath = buildPreviewUrlFromDataPath(dataPath);
+  if (fromPath) return fromPath;
+
+  const anchor = fragmentEl.querySelector(
+    'a[href*="/fragments/"], a[href*="fragments"], a[href*=".aem.page"], a[href*=".aem.live"]',
+  );
+  if (anchor) {
+    try {
+      const href = anchor.getAttribute('href') || '';
+      return new URL(href, window.location.href).href.replace(/\.html$/, '');
+    } catch {
+      /* ignore */
+    }
+  }
+
+  const repoPath = fragmentEl.getAttribute('data-fragment-repo-path');
+  if (repoPath) {
+    return helixPreviewUrlFromRepoPath(repoPath);
+  }
+
+  return '';
+}
+
+function truncateUrl(url, max = 72) {
+  if (!url || url.length <= max) return url;
+  return `${url.slice(0, max)}…`;
+}
+
+function createFragmentLink(previewUrl) {
+  const link = document.createElement('a');
+  link.href = previewUrl;
+  link.target = '_blank';
+  link.rel = 'noopener noreferrer';
+  link.className = 'stream-fragment-path-link';
+  link.title = previewUrl;
+  link.textContent = truncateUrl(previewUrl);
+  return link;
+}
+
+function createFragmentLabel(previewUrl, { linkOnly = false } = {}) {
+  const label = document.createElement('div');
+  label.className = FRAGMENT_LABEL_CLASS;
+  label.setAttribute('role', 'note');
+
+  if (linkOnly) {
+    label.appendChild(createFragmentLink(previewUrl));
+  } else {
+    const prefix = document.createElement('span');
+    prefix.className = 'stream-fragment-path-prefix';
+    prefix.textContent = 'Fragment';
+    label.append(prefix, createFragmentLink(previewUrl));
+  }
+
+  return label;
+}
+
+function createAnnotationFragmentBanner(previewUrl, dataPath) {
+  const label = document.createElement('div');
+  label.className = FRAGMENT_LABEL_CLASS;
+  label.setAttribute('role', 'note');
+
+  const title = document.createElement('div');
+  title.className = FRAGMENT_BLOCKED_TITLE_CLASS;
+  title.textContent = 'Fragment edit blocked';
+  label.appendChild(title);
+
+  if (previewUrl) {
+    label.appendChild(createFragmentLink(previewUrl));
+    return label;
+  }
+
+  const fallbackUrl = buildPreviewUrlFromDataPath(dataPath);
+  if (fallbackUrl) {
+    label.appendChild(createFragmentLink(fallbackUrl));
+    return label;
+  }
+
+  if (dataPath) {
+    const pathNote = document.createElement('span');
+    pathNote.className = 'stream-fragment-path-fallback';
+    pathNote.textContent = dataPath;
+    label.appendChild(pathNote);
+  }
+
+  return label;
+}
+
+function clearAnnotationFragmentChrome(fragmentEl) {
+  if (!(fragmentEl instanceof HTMLElement)) return;
+
+  fragmentEl.querySelectorAll(`:scope > .${FRAGMENT_LABEL_CLASS}`).forEach((el) => el.remove());
+
+  const body = fragmentEl.querySelector(`:scope > .${FRAGMENT_READONLY_BODY_CLASS}`);
+  if (body) {
+    [...body.childNodes].forEach((child) => {
+      if (child instanceof HTMLElement && child.classList.contains(FRAGMENT_READONLY_OVERLAY_CLASS)) {
+        child.remove();
+        return;
+      }
+      fragmentEl.appendChild(child);
+    });
+    body.remove();
+  }
+
+  fragmentEl.classList.remove(FRAGMENT_READONLY_CLASS);
+}
+
+function mountAnnotationFragmentChrome(fragmentEl) {
+  if (!(fragmentEl instanceof HTMLElement)) return;
+  if (fragmentEl.querySelector(`:scope > .${FRAGMENT_READONLY_BODY_CLASS}`)) return;
+
+  clearAnnotationFragmentChrome(fragmentEl);
+  fragmentEl.classList.add(FRAGMENT_READONLY_CLASS);
+
+  const previewUrl = resolveFragmentPreviewUrl(fragmentEl);
+  const dataPath = readFragmentDataPath(fragmentEl);
+  const banner = createAnnotationFragmentBanner(previewUrl, dataPath);
+  fragmentEl.insertBefore(banner, fragmentEl.firstChild);
+
+  const body = document.createElement('div');
+  body.className = FRAGMENT_READONLY_BODY_CLASS;
+
+  const overlay = document.createElement('div');
+  overlay.className = FRAGMENT_READONLY_OVERLAY_CLASS;
+  overlay.setAttribute('aria-hidden', 'true');
+  overlay.textContent = 'Fragment edit blocked';
+
+  const movable = [...fragmentEl.children].filter((child) => child !== banner);
+  movable.forEach((child) => body.appendChild(child));
+  body.appendChild(overlay);
+  fragmentEl.appendChild(body);
+}
+
+function clearFragmentIndicators(rootEl) {
+  if (!(rootEl instanceof HTMLElement)) return;
+  rootEl.querySelectorAll('[data-class="fragment"]').forEach((fragmentEl) => {
+    if (fragmentEl instanceof HTMLElement) clearAnnotationFragmentChrome(fragmentEl);
+  });
+  rootEl.querySelectorAll(`.${FRAGMENT_LABEL_CLASS}`).forEach((el) => el.remove());
+  rootEl.querySelectorAll(`.${FRAGMENT_HIGHLIGHT_CLASS}`).forEach((el) => {
+    el.classList.remove(FRAGMENT_HIGHLIGHT_CLASS);
+  });
 }
 
 /**
- * Keeps fragment “editing disabled” banners in sync: one hint per outermost fragment,
- * only while the Edits tab is active.
+ * @param {HTMLElement} rootEl
+ * @param {{ variant?: 'highlight' | 'link-only', clearOnly?: boolean, blockControls?: boolean }} options
  */
-export default function syncFragmentEditDisabledHints(mainEl, showHints) {
+export function syncFragmentPathIndicators(rootEl, options = {}) {
+  const {
+    variant = 'highlight',
+    clearOnly = false,
+    blockControls = false,
+  } = options;
+
+  if (!(rootEl instanceof HTMLElement)) return;
+
+  clearFragmentIndicators(rootEl);
+  if (clearOnly) return;
+
+  const highlight = variant === 'highlight';
+
+  findAnnotationFragmentRoots(rootEl).forEach((fragmentEl) => {
+    const host = highlight ? getEditFragmentIndicatorHost(fragmentEl) : fragmentEl;
+    const previewUrl = resolveFragmentPreviewUrl(fragmentEl);
+    if (!previewUrl) return;
+
+    if (highlight) host.classList.add(FRAGMENT_HIGHLIGHT_CLASS);
+    if (!host.querySelector(`:scope > .${FRAGMENT_LABEL_CLASS}`)) {
+      host.insertBefore(
+        createFragmentLabel(previewUrl, { linkOnly: !highlight }),
+        host.firstChild,
+      );
+    }
+  });
+
+  if (blockControls) syncFragmentBlockControls();
+}
+
+/** Strip UI-only fragment labels/highlights before cloning blocks into preview HTML. */
+export function stripFragmentIndicatorChrome(block) {
+  if (!(block instanceof Element)) return;
+  if (block.matches('[data-class="fragment"]')) {
+    clearAnnotationFragmentChrome(block);
+  }
+  block.querySelectorAll('[data-class="fragment"]').forEach((fragmentEl) => {
+    clearAnnotationFragmentChrome(fragmentEl);
+  });
+  block.querySelectorAll(`.${FRAGMENT_LABEL_CLASS}`).forEach((el) => el.remove());
+  block.classList.remove(
+    FRAGMENT_HIGHLIGHT_CLASS,
+    FRAGMENT_READONLY_CLASS,
+  );
+}
+
+/**
+ * Annotation / collab canvas: every fragment gets blocked banner, DA link, blur, and overlay.
+ */
+export default function syncFragmentEditDisabledHints(mainEl, showHints = true) {
   if (!(mainEl instanceof HTMLElement)) return;
 
-  mainEl.querySelectorAll(`.${HINT_CLASS}`).forEach((hint) => hint.remove());
-  if (!showHints) return;
-
-  mainEl.querySelectorAll('[data-class="fragment"]').forEach((fragmentEl) => {
-    if (!(fragmentEl instanceof HTMLElement)) return;
-    if (isNestedFragmentRoot(fragmentEl)) return;
-
-    const hint = document.createElement('div');
-    hint.className = HINT_CLASS;
-    hint.setAttribute('role', 'note');
-    hint.textContent = ANNOTATION_MESSAGES.fragmentEditDisabledHint;
-    fragmentEl.insertBefore(hint, fragmentEl.firstChild);
+  findAnnotationFragmentRoots(mainEl).forEach((fragmentEl) => {
+    clearAnnotationFragmentChrome(fragmentEl);
+    if (showHints) mountAnnotationFragmentChrome(fragmentEl);
   });
 }

--- a/streamlibs/operations/edit/edit.css
+++ b/streamlibs/operations/edit/edit.css
@@ -256,3 +256,59 @@ div.figma-panel.hidden {
   70% { box-shadow: 0 0 0 20px rgba(253, 94, 83, 0%); }
   100% { box-shadow: 0 0 0 0 rgba(253, 94, 83, 0%); }
 }
+
+/* Fragment path indicators (edit mode + editor preview) */
+.stream-fragment-highlight {
+  position: relative;
+  border-radius: 6px;
+  box-sizing: border-box;
+  border: 3px solid #2563eb;
+}
+
+body.editor-mode .da-panel > .stream-fragment-highlight {
+  border-width: 6px;
+}
+
+main > .stream-fragment-highlight {
+  display: flow-root;
+  margin-block: 8px;
+}
+
+.stream-fragment-path-label {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  padding: 10px 14px;
+  margin: 0 0 12px;
+  font-size: 13px;
+  line-height: 1.4;
+  font-weight: 600;
+  color: #1e3a8a;
+  background: linear-gradient(to bottom, #eff6ff, #dbeafe);
+  border: 1px solid #93c5fd;
+  border-radius: 6px;
+  font-family: 'Adobe Clean', 'Trebuchet MS', sans-serif;
+  position: relative;
+  z-index: 7000;
+  pointer-events: auto;
+}
+
+.stream-fragment-path-prefix {
+  flex: 0 0 auto;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-size: 11px;
+  color: #1d4ed8;
+}
+
+.stream-fragment-path-link {
+  color: #1d4ed8;
+  text-decoration: underline;
+  word-break: break-all;
+  font-weight: 500;
+}
+
+.stream-fragment-path-link:hover {
+  color: #1e40af;
+}

--- a/streamlibs/operations/edit/edit.js
+++ b/streamlibs/operations/edit/edit.js
@@ -22,7 +22,8 @@ import {
 } from './dom.js';
 import createEditDragDropController from './drag-drop.js';
 import buildCombinedHtml from './serialize.js';
-import { hydrateFragmentLinksInDaBlocks } from './fragment-hydrate.js';
+import { buildFragmentBlockEntry, hydrateFragmentLinksInDaBlocks } from './fragment-hydrate.js';
+import { isFragmentPanelRow, stripFragmentIndicatorChrome, syncFragmentPathIndicators } from '../annotation/fragment-hints.js';
 
 const editState = createEditState();
 const dragDropController = createEditDragDropController({
@@ -66,7 +67,11 @@ function appendDABlocks(main, daMain) {
     div.dataset.source = 'da';
     div.dataset.sectionIndex = String(index);
     div.id = `block-da-${index}`;
-    appendBlockActionButton(div);
+    if (!isFragmentPanelRow(div)) {
+      appendBlockActionButton(div);
+    } else {
+      div.dataset.fragmentBlock = 'true';
+    }
     main.appendChild(div);
   });
 }
@@ -115,14 +120,28 @@ export function syncEditStateAfterFragmentReplace({
   minIdx,
   removeCount,
   fragmentEl,
+  fragmentRepoPath,
   pointerHtml,
 }) {
-  let originalEntry;
-  if (typeof pointerHtml === 'string' && pointerHtml.trim()) {
+  const templateBlock = editState.originalDABlocks[minIdx] || null;
+  let originalEntry = null;
+
+  if (fragmentRepoPath) {
+    originalEntry = buildFragmentBlockEntry(fragmentRepoPath, templateBlock);
+  }
+
+  if (!originalEntry && typeof pointerHtml === 'string' && pointerHtml.trim()) {
     const tmp = document.createElement('div');
     tmp.innerHTML = pointerHtml.trim();
     originalEntry = tmp.firstElementChild;
+    if (templateBlock && originalEntry?.getAttribute?.('data-class') === 'fragment') {
+      const shell = templateBlock.cloneNode(false);
+      shell.removeAttribute('id');
+      shell.innerHTML = originalEntry.outerHTML;
+      originalEntry = shell;
+    }
   }
+
   if (!originalEntry) {
     const clone = fragmentEl.cloneNode(true);
     clone.querySelectorAll('.broken-placeholder-fragment, [data-failed="true"]').forEach((n) => n.remove());
@@ -145,6 +164,7 @@ export function syncEditStateAfterFragmentReplace({
 
 export function handleBackToEditor() {
   showEditorShell(editState);
+  syncFragmentPathIndicators(document.body, { variant: 'highlight', blockControls: true });
 }
 
 /**
@@ -155,6 +175,7 @@ function stripEditorChromeOnBlock(block) {
   if (!(block instanceof Element)) return;
   block.querySelectorAll('.block-action-btn, .da-section-delete, .edit-fragment-btn, .block-selection-bar')
     .forEach((b) => b.remove());
+  stripFragmentIndicatorChrome(block);
   block.classList.remove('has-block-action', 'has-edit-fragment', 'block-selected', 'da-section-removed');
   delete block.dataset.deleteEnabled;
   delete block.dataset.removed;
@@ -200,6 +221,12 @@ export async function applyEditChanges() {
 
   exitEditorMode(editState);
   commitEditedDomToMain(editState);
+  const previewMain = editState.mainEl?.isConnected
+    ? editState.mainEl
+    : document.querySelector('main');
+  if (previewMain) {
+    syncFragmentPathIndicators(previewMain, { variant: 'highlight' });
+  }
 }
 
 export async function editStreamOperation() {
@@ -232,4 +259,5 @@ export async function editStreamOperation() {
   elevateBlockFragmentControls(editState.daPanelEl);
   elevateBlockFragmentControls(editState.figmaPanelEl);
   rebuildTargetStoreFromEditor();
+  syncFragmentPathIndicators(document.body, { variant: 'highlight', blockControls: true });
 }

--- a/streamlibs/operations/edit/fragment-hydrate.js
+++ b/streamlibs/operations/edit/fragment-hydrate.js
@@ -151,6 +151,36 @@ function insertFailureBlock(anchorEl) {
   host.replaceWith(wrap);
 }
 
+/** Inner Milo/DA fragment pointer markup (embed inside a section block shell). */
+export function buildFragmentPointerInnerHtml(previewUrl) {
+  if (!previewUrl) return '';
+  return `<div data-class="fragment"><div><div><a href="${previewUrl}">${previewUrl}</a></div></div></div>`;
+}
+
+/**
+ * Build a DA page block that references a fragment. Keeps the outer shell of the merged
+ * section(s) so Push to DA persists a recognizable embed.
+ */
+export function buildFragmentBlockEntry(fragmentRepoPath, templateBlock = null) {
+  const previewUrl = helixPreviewUrlFromRepoPath(
+    String(fragmentRepoPath || '').trim().replace(/\.html$/i, ''),
+  );
+  if (!previewUrl) return null;
+
+  const pointerInner = buildFragmentPointerInnerHtml(previewUrl);
+
+  if (templateBlock instanceof HTMLElement) {
+    const shell = templateBlock.cloneNode(false);
+    shell.removeAttribute('id');
+    shell.innerHTML = pointerInner;
+    return shell;
+  }
+
+  const tmp = document.createElement('div');
+  tmp.innerHTML = pointerInner;
+  return tmp.firstElementChild;
+}
+
 /** Helix preview URL for repo path `org/repo/drafts/...` (matches fragment preview links). */
 export function helixPreviewUrlFromRepoPath(repoPath) {
   let path = typeof repoPath === 'string' ? repoPath.trim() : '';
@@ -264,6 +294,7 @@ function mountFragmentFromPlain(anchorEl, plainHtml, dataPathAttr, repoPath) {
   const wrap = document.createElement('div');
   wrap.setAttribute('data-class', 'fragment');
   wrap.setAttribute('data-path', dataPathAttr.startsWith('/') ? dataPathAttr : `/${dataPathAttr}`);
+  if (repoPath) wrap.setAttribute('data-fragment-repo-path', repoPath);
   wrap.setAttribute('data-block-status', 'loaded');
   wrap.appendChild(inner);
 
@@ -298,6 +329,7 @@ export async function fillFragmentWrapperFromRepo(fragmentWrapEl, repoPath) {
   fragmentWrapEl.appendChild(inner);
   fragmentWrapEl.setAttribute('data-class', 'fragment');
   fragmentWrapEl.setAttribute('data-path', dataPathAttr.startsWith('/') ? dataPathAttr : `/${dataPathAttr}`);
+  fragmentWrapEl.setAttribute('data-fragment-repo-path', cleanPath);
   fragmentWrapEl.setAttribute('data-block-status', 'loaded');
   return true;
 }

--- a/streamlibs/operations/edit/serialize.js
+++ b/streamlibs/operations/edit/serialize.js
@@ -1,4 +1,5 @@
 import { handleError } from '../../utils/error-handler.js';
+import { buildFragmentBlockEntry } from './fragment-hydrate.js';
 
 /**
  * Concatenates per-row markup from edits. Rows use `dataset.sectionIndex` into
@@ -7,17 +8,34 @@ import { handleError } from '../../utils/error-handler.js';
  */
 export default function buildCombinedHtml(editState) {
   let html = '';
-  const editChanges = document.querySelectorAll('.da-panel > div');
+  const daPanel = document.querySelector('.da-panel');
+  const editChanges = daPanel
+    ? daPanel.querySelectorAll(':scope > [data-source="da"], :scope > [data-source="figma"]')
+    : [];
 
   try {
     editChanges.forEach((change) => {
       if (change.dataset.removed === 'true') return;
 
       const { source, sectionIndex } = change.dataset;
+      const idx = parseInt(sectionIndex, 10);
+      if (Number.isNaN(idx)) return;
+
       if (source === 'figma') {
-        html += editState.originalFigmaBlocks[sectionIndex].outerHTML;
+        const block = editState.originalFigmaBlocks[idx];
+        if (block) html += block.outerHTML;
       } else if (source === 'da') {
-        html += editState.originalDABlocks[sectionIndex].outerHTML;
+        const block = editState.originalDABlocks[idx];
+        if (block) {
+          html += block.outerHTML;
+        } else {
+          const repoPath = change.getAttribute('data-fragment-repo-path')
+            || change.querySelector('[data-fragment-repo-path]')?.getAttribute('data-fragment-repo-path');
+          if (repoPath) {
+            const fallback = buildFragmentBlockEntry(repoPath, null);
+            if (fallback) html += fallback.outerHTML;
+          }
+        }
       }
     });
   } catch (error) {

--- a/streamlibs/previewer.js
+++ b/streamlibs/previewer.js
@@ -2,6 +2,7 @@
 /* eslint-disable no-use-before-define */
 import {
   persistOnTarget,
+  postData,
   targetCompatibleHtml,
 } from './target/da.js';
 import {
@@ -28,6 +29,7 @@ import {
   editStreamOperation,
   applyEditChanges,
   handleBackToEditor,
+  rebuildTargetStoreFromEditor,
   preflightOperation,
   annotationOperation,
   annotationOperationOnHostPage,
@@ -394,7 +396,20 @@ export async function persist(versionLabel = null) {
     if (isAnnotationOp()) {
       await persistAnnotationChangesToDA(versionLabel);
     } else {
+      if (window.streamConfig?.operation === 'edit') {
+        rebuildTargetStoreFromEditor();
+      }
       await persistOnTarget(versionLabel);
+      const draftLoc = window.streamConfig?.draftLocation;
+      const pageTarget = window.streamConfig?.pageUrl || window.streamConfig?.targetUrl;
+      const pushedHtml = fetchTargetHtmlFromStore();
+      if (draftLoc && pushedHtml && draftLoc !== pageTarget) {
+        try {
+          await postData(draftLoc, pushedHtml, { suppressErrorPage: true, versionLabel });
+        } catch (syncErr) {
+          console.warn('[stream-mapper] Could not sync collab draft after push', syncErr);
+        }
+      }
     }
     hideLoader();
     showDOMElements([document.querySelector('main')]);

--- a/streamlibs/utils/block-action-modal.js
+++ b/streamlibs/utils/block-action-modal.js
@@ -1,10 +1,10 @@
 /* eslint-disable no-console */
 /* eslint-disable no-use-before-define */
 import { pushBlockFragmentToDa, extractRepoPath, fragmentExistsOnDa } from '../target/da.js';
+import { buildFragmentBlockEntry } from '../operations/edit/fragment-hydrate.js';
 import { previewDAPage } from '../sources/da.js';
 import { fetchTargetHtmlFromStore, pushTargetHtmlToStore } from '../store/store.js';
 import { mountBlockActionUi } from './block-action-modal-ui.js';
-import { appendBlockActionButton } from './block-action-button.js';
 import { attachSectionDeleteControls } from '../operations/edit/dom.js';
 import {
   getEditBlockHtmlForFragmentFromOriginals,
@@ -13,6 +13,7 @@ import {
 } from '../operations/edit/edit.js';
 import { fillFragmentWrapperFromRepo } from '../operations/edit/fragment-hydrate.js';
 import { miloLoadArea } from './utils.js';
+import { isFragmentPanelRow, syncFragmentBlockControls, syncFragmentPathIndicators } from '../operations/annotation/fragment-hints.js';
 
 const MODAL_ID = 'block-action-modal';
 
@@ -123,6 +124,7 @@ function updateSelectionBar() {
 
 /** Call after the edit UI mounts (or returning to editor) so the selection bar state is correct. */
 export function syncBlockSelectionChrome() {
+  syncFragmentBlockControls();
   updateSelectionBar();
 }
 
@@ -141,6 +143,11 @@ function showSelectionToast(message) {
 
 function toggleBlockSelection(blockId) {
   if (!blockId) return;
+  const blockEl = document.getElementById(blockId);
+  if (isFragmentPanelRow(blockEl)) {
+    showSelectionToast('This section is already a fragment.');
+    return;
+  }
   const idx = selectedBlockIds.indexOf(blockId);
   if (idx !== -1) {
     selectedBlockIds.splice(idx, 1);
@@ -313,9 +320,9 @@ function getFragmentPreviewUrl(repoPath) {
   return `https://main--${repo}--${org}.aem.page${pagePath}`;
 }
 
-function buildFragmentBlockHtml(fragmentPath) {
-  const previewUrl = getFragmentPreviewUrl(fragmentPath);
-  return `<div data-class='fragment'><div><div><a href='${previewUrl}'>${previewUrl}</a></div></div></div>`;
+function buildFragmentBlockHtml(fragmentPath, templateBlock = null) {
+  const entry = buildFragmentBlockEntry(fragmentPath, templateBlock);
+  return entry?.outerHTML || '';
 }
 
 /* ------------------------------------------------------------------ */
@@ -375,8 +382,9 @@ async function replaceBlocksInPreview(fragmentPath, options = {}) {
     if (isEditDa) {
       fragmentEl.dataset.source = 'da';
       fragmentEl.dataset.sectionIndex = String(minSectionIdx);
+      fragmentEl.dataset.fragmentSpan = String(orderedIds.length);
       fragmentEl.id = `block-da-frag-${minSectionIdx}-${Date.now()}`;
-      appendBlockActionButton(fragmentEl);
+      fragmentEl.dataset.fragmentBlock = 'true';
       const daPanel = document.querySelector('.da-panel');
       if (daPanel) attachSectionDeleteControls(daPanel);
       return { fragmentEl, minIdx: minSectionIdx, removeCount: orderedIds.length };
@@ -410,6 +418,7 @@ async function replaceBlocksInPreview(fragmentPath, options = {}) {
     if (firstEl) firstEl.replaceWith(fragmentEl);
 
     await fillFragmentWrapperFromRepo(fragmentEl, fragmentPath);
+    fragmentEl.setAttribute('data-fragment-repo-path', fragmentPath);
     await miloLoadArea(fragmentEl);
     await miloLoadArea();
 
@@ -419,6 +428,7 @@ async function replaceBlocksInPreview(fragmentPath, options = {}) {
   const fragmentEl = document.createElement('div');
   fragmentEl.setAttribute('data-class', 'fragment');
   fragmentEl.setAttribute('data-path', pagePath);
+  fragmentEl.setAttribute('data-fragment-repo-path', fragmentPath);
   fragmentEl.setAttribute('data-block-status', 'loaded');
   fragmentEl.style.display = 'block';
 
@@ -461,10 +471,15 @@ function updateTargetHtmlWithFragments(blockIds, fragmentPath) {
   const firstEl = doc.getElementById(orderedIds[0]);
   if (!firstEl) return;
 
-  const fragmentHtml = buildFragmentBlockHtml(fragmentPath);
-  const tempDiv = doc.createElement('div');
-  tempDiv.innerHTML = fragmentHtml;
-  firstEl.replaceWith(tempDiv.firstElementChild);
+  const fragmentEntry = buildFragmentBlockEntry(fragmentPath, firstEl);
+  if (fragmentEntry) {
+    firstEl.replaceWith(fragmentEntry);
+  } else {
+    const fragmentHtml = buildFragmentBlockHtml(fragmentPath, firstEl);
+    const tempDiv = doc.createElement('div');
+    tempDiv.innerHTML = fragmentHtml;
+    if (tempDiv.firstElementChild) firstEl.replaceWith(tempDiv.firstElementChild);
+  }
 
   orderedIds.slice(1).forEach((id) => {
     const el = doc.getElementById(id);
@@ -650,9 +665,7 @@ async function handleProceed() {
       minIdx,
       removeCount,
       fragmentEl,
-      // Persist the lightweight "<a href=…>" pointer in originalDABlocks so Push to DA
-      // and applyEditChanges serialize the fragment link form, not the inlined Milo DOM.
-      pointerHtml: buildFragmentBlockHtml(createdFragmentPath),
+      fragmentRepoPath: createdFragmentPath,
     });
     rebuildTargetStoreFromEditor();
   } else if (hydrateRemote && window.streamConfig?.operation === 'edit') {
@@ -661,6 +674,7 @@ async function handleProceed() {
     updateTargetHtmlWithFragments(selectedBlockIds, createdFragmentPath);
   }
   dispatchFragmentAction('replace', { fragmentPath: createdFragmentPath });
+  syncFragmentPathIndicators(document.body, { variant: 'highlight', blockControls: true });
   applyPendingButtonDisable();
   const msg = pendingReplacedMessage || 'Fragment replaced.';
   pendingReplacedMessage = '';
@@ -682,6 +696,11 @@ function resetFormInputs() {
 function openBlockActionModal() {
   const els = getModalElements();
   if (!els || selectedBlockIds.length === 0) return;
+  if (selectedBlockIds.some((id) => isFragmentPanelRow(document.getElementById(id)))) {
+    showSelectionToast('This section is already a fragment.');
+    clearBlockSelection();
+    return;
+  }
   if (!selectionIsConsecutive()) {
     showSelectionToast('Only consecutive blocks can be selected.');
     clearBlockSelection();
@@ -741,8 +760,12 @@ export function setupBlockActionModal() {
 
   document.addEventListener('click', (e) => {
     const btn = e.target.closest('.block-action-btn');
-    if (!btn) return;
-    const block = btn.closest('[id^="block-"]');
+    if (!btn || btn.disabled || btn.classList.contains('block-action-btn--disabled')) return;
+    const block = btn.closest('[id^="block-"], [data-source="da"], [data-source="figma"]');
+    if (isFragmentPanelRow(block)) {
+      showSelectionToast('This section is already a fragment.');
+      return;
+    }
     if (block?.id) toggleBlockSelection(block.id);
     e.preventDefault();
     e.stopPropagation();

--- a/streamlibs/utils/operations.js
+++ b/streamlibs/utils/operations.js
@@ -6,6 +6,7 @@ export {
   editStreamOperation,
   applyEditChanges,
   handleBackToEditor,
+  rebuildTargetStoreFromEditor,
 } from '../operations/edit/edit.js';
 export { preflightOperation } from '../operations/preflight/preflight.js';
 export {


### PR DESCRIPTION
JIRA: [MWPW-197196](https://jira.corp.adobe.com/browse/MWPW-197196)

- **Edit / Editor Preview:** Fragment sections show a blue border, “Fragment” label, and clickable DA preview link on the DA column and after Apply (not on the Figma panel).
- **Collab / Content Review:** Fragments show “Fragment edit blocked”, DA link, blurred content, and overlay; fragment links are clickable in the comments panel.
- **Fragment create guard:** Rows that already embed a fragment no longer get a create-fragment button and cannot be re-selected for fragment creation (including after ticket reprocess).
- **Push to DA:** Fragment embeds are serialized inside the original section shell (not a bare `data-class="fragment"` row) so DA and collab can hydrate them on reload. Target HTML is rebuilt before push; existing collab drafts are synced after push.

<img width="720" height="426" alt="image_720" src="https://github.com/user-attachments/assets/60a2eefc-fbf2-4bea-9e78-fe7fefcfe54e" />
<img width="720" height="420" alt="image_720" src="https://github.com/user-attachments/assets/4899d155-fe80-49ee-8791-ffdb24bb1105" />

<img width="480" height="351" alt="image_480" src="https://github.com/user-attachments/assets/42d8a072-1005-4bcb-b30d-d37c2b1664d2" />


Fix #<gh-issue-id>

Test URLs:
- Before: https://main--{repo}--{owner}.aem.live/
- After: https://<branch>--{repo}--{owner}.aem.live/
