### PR TITLE
AI Block Mapping | Icon block changes

### DIFF
--- a/streamlibs/blocks/icon-block-cards.js
+++ b/streamlibs/blocks/icon-block-cards.js
@@ -55,7 +55,7 @@ function handleGrid(acc) {
     finalArray.push(`grid width ${grid?.number}`);
   }
   if(!grid?.number && properties?.blocks?.length===2){
-    finalArray.push(`grid width 10`);
+    finalArray.push('grid width 10');
   }
   if(!grid?.number && properties?.blocks?.length>2){
     finalArray.push('grid width 12');

--- a/streamlibs/blocks/icon-block-cards.js
+++ b/streamlibs/blocks/icon-block-cards.js
@@ -54,6 +54,12 @@ function handleGrid(acc) {
   if (grid?.number) {
     finalArray.push(`grid width ${grid?.number}`);
   }
+  if(!grid?.number && properties?.blocks?.length===2){
+    finalArray.push(`grid width 10`);
+  }
+  if(!grid?.number && properties?.blocks?.length>2){
+    finalArray.push('grid width 12');
+  }
   return acc;
 }
 

--- a/streamlibs/blocks/icon-block.js
+++ b/streamlibs/blocks/icon-block.js
@@ -73,6 +73,18 @@ function handleAvatar(value, areaEl) {
   if (altText) imgEl.alt = altText;
 }
 
+function handleLogo(value, areaEl) {
+  if (!areaEl || !value) return;
+  const url = value.image || value.url || value;
+  if (!url) return;
+  areaEl.querySelectorAll('source').forEach((source) => { source.srcset = url; });
+  const imgEl = areaEl.querySelector('img');
+  if (imgEl) {
+    imgEl.src = url;
+    if (value.altText) imgEl.alt = value.altText;
+  }
+}
+
 export default async function mapBlockContent(
   sectionWrapper,
   blockContent,
@@ -97,7 +109,13 @@ export default async function mapBlockContent(
       const areaEl = handleComponents(blockContent, value, mappingConfig);
       switch (mappingConfig.key) {
         case 'productLockup':
-          handleProductLockup(value, areaEl);
+          if (value) {
+            handleProductLockup(value, areaEl);
+          } else if (properties.logo) {
+            const logoArea = areaEl || blockContent.querySelector(mappingConfig.selector);
+            logoArea?.classList.remove('to-remove');
+            handleLogo(properties.logo, logoArea);
+          }
           break;
         case 'actions':
           handleActionButtons(blockContent, properties, value, areaEl);

--- a/streamlibs/sources/figma.js
+++ b/streamlibs/sources/figma.js
@@ -313,6 +313,18 @@ function getBlockProp(block, ...keys) {
   return '';
 }
 
+function getBlockVariant(match) {
+  const variant = getBlockProp(match, 'variant', 'Variant');
+  return variant !== '' ? Number(variant) : 0;
+}
+
+function findSupportedBlock(comp, supportedBlocks) {
+  return supportedBlocks.find(
+    (b) => getBlockProp(b, 'name', 'Name') === comp.name
+      || getBlockProp(b, 'id', 'Id', 'ID') === comp.id,
+  );
+}
+
 // eslint-disable-next-line object-curly-newline
 function createSearchableSelect({ options, selected, disabled, onChange }) {
   const wrapper = document.createElement('div');
@@ -483,15 +495,20 @@ function applyBlockSelection(comp, name, supportedBlocks) {
   if (id) comp.id = id;
   if (miloId) comp.miloId = miloId;
   if (path) comp.path = path;
+  comp.variant = getBlockVariant(match);
 }
 
 // eslint-disable-next-line no-async-promise-executor
 async function showBlockMappingReview(blockMapping) {
   const supportedBlocks = await fetchSupportedBlocks();
-  const components = blockMapping.details.components.map((c) => ({
-    ...c,
-    aiMapping: c.aiMapping !== undefined ? c.aiMapping : (!c.c1lib && c.name !== 'NA'),
-  }));
+  const components = blockMapping.details.components.map((c) => {
+    const match = findSupportedBlock(c, supportedBlocks);
+    return {
+      ...c,
+      aiMapping: c.aiMapping !== undefined ? c.aiMapping : (!c.c1lib && c.name !== 'NA'),
+      variant: match ? getBlockVariant(match) : (c.variant ?? 0),
+    };
+  });
 
   const loaderContainer = document.querySelector('#loader-container');
   if (loaderContainer) {
@@ -608,7 +625,15 @@ async function showBlockMappingReview(blockMapping) {
       const miloId = match ? getBlockProp(match, 'miloId', 'milo-id', 'MiloId') : '';
       const path = match ? getBlockProp(match, 'path', 'Path') : '';
       components.push({
-        id, miloId, figId, name, path, tag: '', variant: 0, c1lib: false, sectionLink,
+        id,
+        miloId,
+        figId,
+        name,
+        path,
+        tag: '',
+        variant: match ? getBlockVariant(match) : 0,
+        c1lib: false,
+        sectionLink,
       });
       addUrlInput.value = '';
       addSelectedName = '';


### PR DESCRIPTION
Changes: 
Add default grid widths for icon block cards when no gr* milo tag is set (2 cards → width 10, 3+ → width 12)
Render logo in the product lockup area when product lockup is missing
Preserve block variant when blocks are added manually via the Figma mapping UI
