### PR TITLE
AI Block Mapping | Aside-std and Aside

### DIFF
--- a/streamlibs/blocks/aside.js
+++ b/streamlibs/blocks/aside.js
@@ -73,7 +73,8 @@ function handleInline(blockContent, properties) {
 
 function handleSplitHalf(blockContent, properties) {
   const half = extractByPattern(properties?.miloTag, 'half');
-  if (half?.raw) {
+  const splitHalf = typeof properties?.split === 'string' && properties.split.toLowerCase().includes('half');
+  if (half?.raw || splitHalf) {
     blockContent?.classList.add('half');
   }
 }

--- a/streamlibs/sources/figma.js
+++ b/streamlibs/sources/figma.js
@@ -184,6 +184,17 @@ async function mapFigmaContent(blockContent, block, figContent) {
   }
 }
 
+function resolveAsideVariant(block, properties) {
+  if (block.id === 'aside-std') return 0;
+  if (block.id !== 'aside') return block.variant ?? 0;
+
+  if (block.tag?.includes('inline') || properties?.miloTag?.includes?.('inline')) return 1;
+
+  if (properties?.productGrid || properties?.productLinks?.length || properties?.split) return 2;
+
+  return block.variant ?? 2;
+}
+
 async function processBlock(block, figmaUrl, onDetailResponse = () => {}) {
   if (!block.id || !block.path) return { _failed: true, block };
   const [doc, figContent] = await Promise.all([
@@ -200,7 +211,7 @@ async function processBlock(block, figmaUrl, onDetailResponse = () => {}) {
     return placeholder;
   }
 
-  let blockContent = getHtml(doc, block.miloId, block.variant);
+  let blockContent = getHtml(doc, block.miloId, resolveAsideVariant(block, properties));
   figContent.details.properties.miloTag = block.tag;
   blockContent = await mapFigmaContent(blockContent, block, figContent);
   block.blockDomEl = blockContent;


### PR DESCRIPTION
Title: Fix aside split preview template variant selection

Summary:

Infer correct Milo template variant in processBlock when id is aside but discovery left variant at 0 (split blocks were mapping onto the standard aside shell).
Add .half class fallback from properties.split when miloTag is missing.
Sync variant from catalog in block review UI via getBlockVariant.

Figma tested:
https://www.figma.com/design/m3ouuWlIym6VeitipsNUBY/ai-aside?t=iItk7EAVGSxwJdjf-0
https://www.figma.com/design/7sf1nYE3HORI41OJAHstH9/ai-aside-split