### PR TITLE
AI Block Mapping | Icon-block-fix

### DIFF
--- a/streamlibs/blocks/icon-block.js
+++ b/streamlibs/blocks/icon-block.js
@@ -5,6 +5,10 @@ import {
 import { LOGOS } from '../utils/constants.js';
 import { safeJsonFetch } from '../utils/error-handler.js';
 
+function isBioBlock(properties) {
+  return properties?.miloTag?.includes('bio') || properties?.bio;
+}
+
 function handleBlockVariants(blockContent, properties) {
   if (properties?.miloTag?.includes('intro')) {
     blockContent.classList.add('intro');
@@ -39,7 +43,7 @@ function handleVariants(sectionWrapper, blockContent, properties) {
     handleAccentBar(sectionWrapper, blockContent, properties.accentBar.name);
   }
   handleAlign(blockContent, properties.align);
-  handleIconSize(blockContent, properties, properties?.miloTag, properties?.miloTag?.includes('bio') ? 'bioDetails' : 'productLockup');
+  handleIconSize(blockContent, properties, properties?.miloTag, isBioBlock(properties) ? 'bioDetails' : 'productLockup');
 }
 
 function handleProductLockup(value, areaEl) {
@@ -75,13 +79,28 @@ function handleAvatar(value, areaEl) {
 
 function handleLogo(value, areaEl) {
   if (!areaEl || !value) return;
-  const url = value.image || value.url || value;
+  const { url, altText } = typeof value === 'object' && (value.image || value.url)
+    ? { url: value.image || value.url, altText: value.altText || '' }
+    : resolveImageValue(value);
   if (!url) return;
+
   areaEl.querySelectorAll('source').forEach((source) => { source.srcset = url; });
   const imgEl = areaEl.querySelector('img');
   if (imgEl) {
     imgEl.src = url;
-    if (value.altText) imgEl.alt = value.altText;
+    if (altText) imgEl.alt = altText;
+    return;
+  }
+
+  // Icon Block variant 0 uses <p><a href="...svg"> — no <img> until we inject one
+  const anchorElement = areaEl.querySelector('a');
+  if (anchorElement) {
+    anchorElement.setAttribute('href', url);
+    anchorElement.innerHTML = '';
+    const img = document.createElement('img');
+    img.src = url;
+    if (altText) img.alt = altText;
+    anchorElement.appendChild(img);
   }
 }
 
@@ -97,7 +116,7 @@ export default async function mapBlockContent(
   try {
     if (!mapConfig) {
       let configJson = 'icon-block.json';
-      if (properties?.miloTag?.includes('bio')) {
+      if (isBioBlock(properties)) {
         configJson = 'icon-bio-block.json';
       }
       mappingData = await safeJsonFetch(configJson);
@@ -117,9 +136,15 @@ export default async function mapBlockContent(
             handleLogo(properties.logo, logoArea);
           }
           break;
-        case 'actions':
-          handleActionButtons(blockContent, properties, value, areaEl);
+        case 'actions': {
+          const hasActions = value || properties.action1 || properties.action2 || properties.action3;
+          if (!hasActions) break;
+          const actionArea = areaEl || blockContent.querySelector(mappingConfig.selector);
+          actionArea?.classList.remove('to-remove');
+          if (!value) actionArea.innerHTML = '';
+          handleActionButtons(blockContent, properties, true, actionArea);
           break;
+        }
         case 'bio':
           handleAvatar(value, areaEl);
           break;

--- a/streamlibs/utils/config.js
+++ b/streamlibs/utils/config.js
@@ -42,8 +42,7 @@ export const CONFIG = {
   },
   dev: {
     streamMapper: {
-      // serviceEP: 'https://adobe-acom-stream-service-deploy-ethos502-prod-or2-1de07c.cloud.adobe.io',
-      serviceEP: 'http://localhost:8082',
+      serviceEP: 'https://adobe-acom-stream-service-deploy-ethos502-prod-or2-1de07c.cloud.adobe.io',
       figmaMappingUrl: '/api/ai/fig-comps',
       figmaBlockContentUrl: '/api/fig-comp-details',
       figmaAIBlockContentUrl: '/api/ai/fig-comp-details',

--- a/streamlibs/utils/config.js
+++ b/streamlibs/utils/config.js
@@ -42,7 +42,8 @@ export const CONFIG = {
   },
   dev: {
     streamMapper: {
-      serviceEP: 'https://adobe-acom-stream-service-deploy-ethos502-prod-or2-1de07c.cloud.adobe.io',
+      // serviceEP: 'https://adobe-acom-stream-service-deploy-ethos502-prod-or2-1de07c.cloud.adobe.io',
+      serviceEP: 'http://localhost:8082',
       figmaMappingUrl: '/api/ai/fig-comps',
       figmaBlockContentUrl: '/api/fig-comp-details',
       figmaAIBlockContentUrl: '/api/ai/fig-comp-details',


### PR DESCRIPTION
`icon-block.js`
Render custom logo.image on variant 0 templates (anchor-based logo slot, not only <img>)
Render CTAs when action1/action2/action3 exist even if actions: true is missing
Route to icon-bio-block mapping when properties.bio is present (not only miloTag)



Fix #<gh-issue-id>

Test URLs:
- Before: https://main--{repo}--{owner}.aem.live/
- After: https://<branch>--{repo}--{owner}.aem.live/
