### PR TITLE
AI Block Mapping | Editorial cards handle ups with count

### DIFF
--- a/streamlibs/blocks/card-editorial-media.js
+++ b/streamlibs/blocks/card-editorial-media.js
@@ -40,7 +40,7 @@ export default async function mapBlockContent(sectionWrapper, blockContent, figC
     });
     blockContent.classList.add('to-remove');
     sectionWrapper.querySelectorAll('.to-remove').forEach((el) => el.remove());
-    handleUpsWithSectionMetadata(sectionWrapper, blockContent, properties.miloTag.toLowerCase());
+    handleUpsWithSectionMetadata(sectionWrapper, blockContent, properties.miloTag.toLowerCase(), properties.cards?.length);
     if (properties.background) handleBackgroundWithSectionMetadata(sectionWrapper, blockContent, properties.background);
     handleVariants(sectionWrapper, blockContent, properties);
   } catch (error) {

--- a/streamlibs/blocks/card-editorial.js
+++ b/streamlibs/blocks/card-editorial.js
@@ -83,7 +83,7 @@ export default async function mapBlockContent(sectionWrapper, blockContent, figC
     });
     blockContent.classList.add('to-remove');
     sectionWrapper.querySelectorAll('.to-remove').forEach((el) => el.remove());
-    handleUpsWithSectionMetadata(sectionWrapper, blockContent, properties.miloTag.toLowerCase());
+    handleUpsWithSectionMetadata(sectionWrapper, blockContent, properties.miloTag.toLowerCase(), properties.cards?.length);
     if (properties.background) handleBackgroundWithSectionMetadata(sectionWrapper, blockContent, properties.background);
     handleVariants(sectionWrapper, blockContent, properties);
   } catch (error) {

--- a/streamlibs/blocks/card-horizontal.js
+++ b/streamlibs/blocks/card-horizontal.js
@@ -55,7 +55,12 @@ export default async function mapBlockContent(sectionWrapper, blockContent, figC
     });
     blockContent.classList.add('to-remove');
     sectionWrapper.querySelectorAll('.to-remove').forEach((el) => el.remove());
-    handleUpsWithSectionMetadata(sectionWrapper, blockContent, properties.miloTag.toLowerCase());
+    handleUpsWithSectionMetadata(
+      sectionWrapper,
+      blockContent,
+      properties.miloTag.toLowerCase(),
+      properties.cards?.length,
+    );
     if (properties.background) {
       handleBackgroundWithSectionMetadata(sectionWrapper, blockContent, properties.background);
     }

--- a/streamlibs/blocks/text-cards.js
+++ b/streamlibs/blocks/text-cards.js
@@ -51,7 +51,12 @@ export default async function mapBlockContent(sectionWrapper, blockContent, figC
     });
     blockContent.classList.add('to-remove');
     sectionWrapper.querySelectorAll('.to-remove').forEach((el) => el.remove());
-    handleUpsWithSectionMetadata(sectionWrapper, blockContent, properties.miloTag.toLowerCase());
+    handleUpsWithSectionMetadata(
+      sectionWrapper,
+      blockContent,
+      properties.miloTag.toLowerCase(),
+      properties.blocks?.length,
+    );
     if (properties.background) {
       handleBackgroundWithSectionMetadata(sectionWrapper, blockContent, properties.background);
     }

--- a/streamlibs/components/components.js
+++ b/streamlibs/components/components.js
@@ -246,14 +246,22 @@ export function handleColorThemeWithSectionMetadata(secEl, blockEl, value) {
   styleLoc.innerHTML += value;
 }
 
-export function handleUpsWithSectionMetadata(secEl, blockEl, value) {
+export function handleUpsWithSectionMetadata(secEl, blockEl, value, count) {
   const styleLoc = addOrUpdateSectionMetadata(secEl, blockEl, 'style');
   if (styleLoc.innerHTML) styleLoc.innerHTML += ', ';
+  const hasUp = /[2-6]\s*up/i.test(value);
   if (/2\s*up/i.test(value)) styleLoc.innerHTML += 'two-up';
   if (/3\s*up/i.test(value)) styleLoc.innerHTML += 'three-up';
   if (/4\s*up/i.test(value)) styleLoc.innerHTML += 'four-up';
   if (/5\s*up/i.test(value)) styleLoc.innerHTML += 'five-up';
   if (/6\s*up/i.test(value)) styleLoc.innerHTML += 'six-up';
+  if (!hasUp) {
+    // fallback: no up-value in the milotag, infer it from the card/block count
+    const upsByCount = {
+      2: 'two-up', 3: 'three-up', 4: 'four-up', 5: 'five-up', 6: 'six-up',
+    };
+    if (upsByCount[count]) styleLoc.innerHTML += upsByCount[count];
+  }
 }
 
 export function handleSpacerWithSectionMetadata(secEl, blockEl, spacer, position) {


### PR DESCRIPTION
Handling ups with count also if there is no tag present. Ups on basis on block count.


Test URLs:
- Before: https://main--{repo}--{owner}.aem.live/
- After: https://<branch>--{repo}--{owner}.aem.live/
