### PR TITLE
AI Block Mapping |  Card horizontal changes

### DIFF
--- a/streamlibs/blocks/card-horizontal.js
+++ b/streamlibs/blocks/card-horizontal.js
@@ -34,8 +34,8 @@ export default async function mapBlockContent(sectionWrapper, blockContent, figC
     const mappingData = await safeJsonFetch('card-horizontal.json');
     properties.cards.forEach((card) => {
       const blockTemplate = blockContent.cloneNode(true);
-      if (properties?.cardType?.name.toLowerCase().includes('tile')) {
-        blockContent.classList.add('tile');
+      if (properties?.cardType?.name?.toLowerCase().includes('tile')) {
+        blockTemplate.classList.add('tile');
       }
       sectionWrapper.appendChild(blockTemplate);
       mappingData.data.forEach((mappingConfig) => {


### PR DESCRIPTION
Tile class now applied consistently across all card-horizontal cards
The tile card-type class was being added to the shared source node (blockContent) after each card's clone was taken inside the cards.forEach loop. This caused the class to leak into subsequent iterations' clones — so the first card never received tile, while cards 2, 3, etc. did.

Fix applies the class to the per-card clone (blockTemplate) instead, and adds optional chaining on cardType.name to avoid a TypeError (silently swallowed by the surrounding try/catch) when a cardType has no name.



Test URLs:
- Before: https://main--{repo}--{owner}.aem.live/
- After: https://<branch>--{repo}--{owner}.aem.live/
