### PR TITLE
AI Block Mapping | Carousel

### DIFF
--- a/streamlibs/blocks/card-editorial.js
+++ b/streamlibs/blocks/card-editorial.js
@@ -20,6 +20,7 @@ function handleVariants(sectionWrapper, blockContent, properties) {
 }
 
 function handleProductLockup(value, areaEl) {
+  if (!value || !areaEl) return;
   const tileName = value?.productTile?.name || 'placeholder';
   const a = document.createElement('a');
   a.href = LOGOS[tileName] || LOGOS.placeholder;
@@ -30,12 +31,11 @@ function handleProductLockup(value, areaEl) {
 }
 
 function handleCardProductLockups(card, areaEl) {
+  if (!areaEl || !card.productLockups?.length) return;
   areaEl.innerHTML = '';
-  const productLockup1 = card.productLockups[0];
-  handleProductLockup(productLockup1, areaEl);
+  handleProductLockup(card.productLockups[0], areaEl);
   if (!card.hasMultipleProductLockups) return;
-  const productLockup2 = card.productLockups[1];
-  handleProductLockup(productLockup2, areaEl);
+  handleProductLockup(card.productLockups[1], areaEl);
 }
 
 export default async function mapBlockContent(sectionWrapper, blockContent, figContent) {
@@ -83,7 +83,7 @@ export default async function mapBlockContent(sectionWrapper, blockContent, figC
     });
     blockContent.classList.add('to-remove');
     sectionWrapper.querySelectorAll('.to-remove').forEach((el) => el.remove());
-    handleUpsWithSectionMetadata(sectionWrapper, blockContent, properties.miloTag.toLowerCase(), properties.cards?.length);
+    handleUpsWithSectionMetadata(sectionWrapper, blockContent, properties.miloTag?.toLowerCase(), properties.cards?.length);
     if (properties.background) handleBackgroundWithSectionMetadata(sectionWrapper, blockContent, properties.background);
     handleVariants(sectionWrapper, blockContent, properties);
   } catch (error) {

--- a/streamlibs/blocks/carousel.js
+++ b/streamlibs/blocks/carousel.js
@@ -37,6 +37,9 @@ async function processItemsWithTemplate(items, div, templateElement, figContent,
 export default async function mapcarousel(sectionWrapper, blockContent, figContent) {
   const properties = figContent?.details?.properties;
   if (!properties) return undefined;
+  ['medias', 'cards', 'bricks', 'texts'].forEach((key) => {
+    if (!Array.isArray(properties[key])) properties[key] = [];
+  });
   const carouselDivs = Array.from(blockContent);
   const sections = [];
 
@@ -116,10 +119,10 @@ export default async function mapcarousel(sectionWrapper, blockContent, figConte
             'editorial-card.plain.html',
             '.card-editorial',
           );
-          if (properties.card.name.toLowerCase().includes('open')) {
+          if (properties.card?.name?.toLowerCase().includes('open')) {
             templateElement.classList.add('open');
           }
-          if (properties.card.name.toLowerCase().includes('center')) {
+          if (properties.card?.name?.toLowerCase().includes('center')) {
             templateElement.classList.add('center');
           }
           // eslint-disable-next-line no-await-in-loop

--- a/streamlibs/blocks/masonry.js
+++ b/streamlibs/blocks/masonry.js
@@ -94,6 +94,9 @@ export default async function mapBlockContent(sectionWrapper, blockContent, figC
     properties.masonryArrangement = [];
     properties.bricks.forEach((brick) => {
       if (!brick.brickType || !brick.spanLayout) return;
+      if (!brick.productLockup) brick.productLockup = {};
+      if (!Array.isArray(brick.appList)) brick.appList = [];
+      if (!Array.isArray(brick.itemList)) brick.itemList = [];
       const blockTemplate = blockContent.cloneNode(true);
       if (brick.colorTheme) blockTemplate.classList.add(brick.colorTheme);
       properties.masonryArrangement.push(brick.spanLayout.toLowerCase());

--- a/streamlibs/components/components.js
+++ b/streamlibs/components/components.js
@@ -248,20 +248,19 @@ export function handleColorThemeWithSectionMetadata(secEl, blockEl, value) {
 
 export function handleUpsWithSectionMetadata(secEl, blockEl, value, count) {
   const styleLoc = addOrUpdateSectionMetadata(secEl, blockEl, 'style');
+  const upsByCount = {
+    2: 'two-up', 3: 'three-up', 4: 'four-up', 5: 'five-up', 6: 'six-up',
+  };
+  let up = '';
+  if (/2\s*up/i.test(value)) up = 'two-up';
+  else if (/3\s*up/i.test(value)) up = 'three-up';
+  else if (/4\s*up/i.test(value)) up = 'four-up';
+  else if (/5\s*up/i.test(value)) up = 'five-up';
+  else if (/6\s*up/i.test(value)) up = 'six-up';
+  if (!up) up = upsByCount[count] || '';
+  if (!up) return;
   if (styleLoc.innerHTML) styleLoc.innerHTML += ', ';
-  const hasUp = /[2-6]\s*up/i.test(value);
-  if (/2\s*up/i.test(value)) styleLoc.innerHTML += 'two-up';
-  if (/3\s*up/i.test(value)) styleLoc.innerHTML += 'three-up';
-  if (/4\s*up/i.test(value)) styleLoc.innerHTML += 'four-up';
-  if (/5\s*up/i.test(value)) styleLoc.innerHTML += 'five-up';
-  if (/6\s*up/i.test(value)) styleLoc.innerHTML += 'six-up';
-  if (!hasUp) {
-    // fallback: no up-value in the milotag, infer it from the card/block count
-    const upsByCount = {
-      2: 'two-up', 3: 'three-up', 4: 'four-up', 5: 'five-up', 6: 'six-up',
-    };
-    if (upsByCount[count]) styleLoc.innerHTML += upsByCount[count];
-  }
+  styleLoc.innerHTML += up;
 }
 
 export function handleSpacerWithSectionMetadata(secEl, blockEl, spacer, position) {


### PR DESCRIPTION
# Carousel AI-mapping fixes

Hardens the carousel renderer and its nested-slide mappers so AI-mapped
carousels render instead of falling back to placeholders / "Manual authoring
required".

- **carousel.js** — coerce `medias`/`cards`/`bricks`/`texts` to arrays (renderer
  reads `.length`); optional-chain `card?.name?.…` so a missing `card` doesn't
  crash template selection.
- **card-editorial.js** — guard `handleProductLockup`/`handleCardProductLockups`
  against a missing area or empty lockups (a card with no lockup crashed and
  left placeholder text); optional-chain `miloTag?.toLowerCase()`.
- **masonry.js** — default `productLockup = {}` (a falsy value deletes the
  brick's content container), `appList = []`, `itemList = []`.
- **components.js** — `handleUpsWithSectionMetadata` computes the up-value
  before appending, so a no-match no longer leaves a dangling empty style token
  that made Milo's `handleStyle` throw.

AI carousel path only; tagged path unaffected.
