### PR TITLE
AI Block Mapping | Fix icon block ai mapping

### DIFF
--- a/streamlibs/blocks/icon-block.js
+++ b/streamlibs/blocks/icon-block.js
@@ -77,6 +77,16 @@ function handleAvatar(value, areaEl) {
   if (altText) imgEl.alt = altText;
 }
 
+function createLogoSlot(lockupArea) {
+  const logoArea = lockupArea.cloneNode(true);
+  logoArea.classList.add('icon-area');
+  logoArea.querySelectorAll('img').forEach((img) => {
+    img.removeAttribute('width');
+    img.removeAttribute('height');
+  });
+  return logoArea;
+}
+
 function handleLogo(value, areaEl) {
   if (!areaEl || !value) return;
   const { url, altText } = typeof value === 'object' && (value.image || value.url)
@@ -101,7 +111,19 @@ function handleLogo(value, areaEl) {
     img.src = url;
     if (altText) img.alt = altText;
     anchorElement.appendChild(img);
+    return;
   }
+
+  // Dual-icon layout: second <p> may be empty — inject picture/img
+  const pic = document.createElement('picture');
+  const source = document.createElement('source');
+  source.srcset = url;
+  const img = document.createElement('img');
+  img.src = url;
+  if (altText) img.alt = altText;
+  pic.append(source, img);
+  areaEl.classList.add('icon-area');
+  areaEl.append(pic);
 }
 
 export default async function mapBlockContent(
@@ -129,7 +151,14 @@ export default async function mapBlockContent(
       switch (mappingConfig.key) {
         case 'productLockup':
           if (value) {
-            handleProductLockup(value, areaEl);
+            const lockupArea = areaEl || blockContent.querySelector(mappingConfig.selector);
+            lockupArea?.classList.add('icon-area');
+            handleProductLockup(value, lockupArea);
+            if (properties.logo && lockupArea?.parentElement) {
+              const logoArea = createLogoSlot(lockupArea);
+              lockupArea.parentElement.insertBefore(logoArea, lockupArea.nextSibling);
+              handleLogo(properties.logo, logoArea);
+            }
           } else if (properties.logo) {
             const logoArea = areaEl || blockContent.querySelector(mappingConfig.selector);
             logoArea?.classList.remove('to-remove');


### PR DESCRIPTION
Fix icon-block dual-icon rendering for productLockup + logo
- When both `productLockup` and `logo` are present, clone the lockup `<p>` into a second slot and render the logo below the app tile — the mapping config only provides one DOM target today
- Add `icon-area` class and strip fixed `width`/`height` on the cloned slot so Milo CSS caps logo size correctly (fixes oversized second icon)
- Add early `return` in `handleLogo` after anchor-based injection to avoid duplicate picture elements
- Add picture/img fallback in `handleLogo` for empty logo slots (edge case)

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--{repo}--{owner}.aem.live/
- After: https://<branch>--{repo}--{owner}.aem.live/
