### PR TITLE
AI Block Mapping | Fix/MWPW 201456

### DIFF
--- a/streamlibs/blocks/table.js
+++ b/streamlibs/blocks/table.js
@@ -9,6 +9,11 @@ function handleVariants(blockContent, properties) {
   if (properties?.colorTheme) blockContent.classList.add(properties.colorTheme);
   if (properties?.topSpacer) handleSpacer(blockContent, properties.topSpacer.name, 'top');
   if (properties?.bottomSpacer) handleSpacer(blockContent, properties.bottomSpacer.name, 'bottom');
+  // Header-less tables: Milo init promotes row-1 to .row-heading (bold column headers).
+  // Flag the block so preview CSS can style row-1 data columns as body text.
+  if (!properties?.hasHeader) {
+    blockContent.classList.add('left', 'no-column-header');
+  }
 }
 
 function createHeaderColumn(columnHeading, offerCell, columnTemplate) {

--- a/streamlibs/styles/styles.css
+++ b/streamlibs/styles/styles.css
@@ -1026,4 +1026,35 @@ main > .section,
       "image list";
   }
 }
-  
+
+/* Header-less tables only: row-1 is body data, not column titles (hasHeader=false) */
+.table.no-column-header .row-1.row-heading .col-heading {
+  flex-direction: row;
+  align-items: center;
+}
+
+.table.left.no-column-header .row-1.row-heading .col-heading {
+  text-align: start;
+  justify-content: flex-start;
+}
+
+.table.no-column-header .row-1.row-heading .col-heading.col-1 .tracking-header {
+  font-size: var(--type-body-s-size);
+  line-height: var(--type-body-s-lh);
+  padding: 0;
+}
+
+.table.no-column-header .row-1.row-heading .col-heading .heading-button {
+  display: none;
+}
+
+.table.no-column-header .row-1.row-heading .col-heading:not(.col-1),
+.table.no-column-header .row-1.row-heading .col-heading:not(.col-1) .tracking-header {
+  font-weight: 400;
+  font-size: var(--type-body-s-size);
+  line-height: var(--type-body-s-lh);
+}
+
+.table.no-column-header .row-1.row-heading .col-heading:not(.col-1) .tracking-header {
+  padding: 0;
+}


### PR DESCRIPTION
https://jira.corp.adobe.com/browse/MWPW-201456

Summary
Fixes header-less table preview styling when hasHeader=false. Milo init promotes row 1 to .row-heading, which made data cells look like bold column headers — this adds a no-column-header class and CSS so row 1 renders as normal body text.

Changes
table.js — add left + no-column-header when hasHeader=false
styles.css — override row-1 heading styles for header-less tables
