### PR TITLE
AI Block Mapping | Accordion fix MWPW-200787

### DIFF
--- a/streamlibs/sources/figma.js
+++ b/streamlibs/sources/figma.js
@@ -324,10 +324,8 @@ function getBlockVariant(match) {
 }
 
 function findSupportedBlock(comp, supportedBlocks) {
-  return supportedBlocks.find(
-    (b) => getBlockProp(b, 'name', 'Name') === comp.name
-      || getBlockProp(b, 'id', 'Id', 'ID') === comp.id,
-  );
+  return supportedBlocks.find((b) => getBlockProp(b, 'name', 'Name') === comp.name)
+    || supportedBlocks.find((b) => getBlockProp(b, 'id', 'Id', 'ID') === comp.id);
 }
 
 // eslint-disable-next-line object-curly-newline


### PR DESCRIPTION
`findSupportedBlock` matched supported-blocks by `name` **or** `id` and returned
the first hit. Several blocks share an `id` but differ by variant (e.g. rich
"Accordion" v1 and "Basic Accordion" v0 are both `id: accordion`), and the
richer entry is listed first — so a "Basic Accordion" matched the rich entry by
`id` and resolved to the **wrong variant (1)**. `showBlockMappingReview` then
picked the rich template while the mapper used the basic config, so the body and
media fell back to the block-template placeholders (headings still rendered).

Now it matches by **name first**, falling back to `id` only when no name matches.
