### PR TITLE
AI Block Mapping | Fix/MWPW 201329

### DIFF
--- a/streamlibs/blocks/action-scroller.js
+++ b/streamlibs/blocks/action-scroller.js
@@ -14,6 +14,8 @@ export default async function mapActionScrollerBlockContent(sectionWrapper, bloc
       // eslint-disable-next-line no-restricted-syntax
       for (const item of Items) {
         const clonedActionItem = actionItem.cloneNode(true);
+        // Icon action gallery tiles always use Milo action-item static-links variant.
+        clonedActionItem.classList.add('static-links');
         const actionItemFigContent = {
           ...figContent,
           details: {


### PR DESCRIPTION
Title: [MWPW-201329](https://jira.corp.adobe.com/browse/MWPW-201329)

Icon action gallery: apply static-links on gallery tiles

Summary

In action-scroller.js, add static-links to each cloned .action-item when mapping icon action gallery tiles.
Uses Milo’s existing action-item static-link behavior (wraps content in a.static) without a Figma/parser flag.
