### PR TITLE
AI Block Mapping | Masonry icon fallback fix

### DIFF
--- a/streamlibs/blocks/masonry.js
+++ b/streamlibs/blocks/masonry.js
@@ -74,18 +74,27 @@ function handleAppList(appList, appListEl) {
   });
 }
 
+function isLoadableItemIconUrl(url) {
+  if (!url || typeof url !== 'string') return false;
+  if (url.startsWith('data:')) return true;
+  if (!/^https?:\/\//.test(url)) return false;
+  if (url.includes('...') || /figma-\d+:/.test(url)) return false;
+  return true;
+}
+
 function resolveItemIconUrl(icon) {
-  if (!icon) return '';
-  if (typeof icon === 'string') {
-    if (/^(https?:)?\/\//.test(icon) || icon.startsWith('data:')) return icon;
-    return LOGOS[icon] || SVG_ICONS[icon] || '';
-  }
-  if (typeof icon === 'object') {
+  let candidate = '';
+  if (!icon) {
+    candidate = '';
+  } else if (typeof icon === 'string') {
+    if (/^(https?:)?\/\//.test(icon) || icon.startsWith('data:')) candidate = icon;
+    else candidate = LOGOS[icon] || SVG_ICONS[icon] || '';
+  } else if (typeof icon === 'object') {
     const ref = icon.imageRef || icon.url;
-    if (ref && (/^(https?:)?\/\//.test(ref) || ref.startsWith('data:'))) return ref;
-    if (icon.name) return LOGOS[icon.name] || SVG_ICONS[icon.name] || '';
+    if (ref && (/^(https?:)?\/\//.test(ref) || ref.startsWith('data:'))) candidate = ref;
+    else if (icon.name) candidate = LOGOS[icon.name] || SVG_ICONS[icon.name] || '';
   }
-  return '';
+  return isLoadableItemIconUrl(candidate) ? candidate : SVG_ICONS.placeholder;
 }
 
 function createIconPicture(src, alt = '') {


### PR DESCRIPTION
**Fallback to placeholder SVG for invalid masonry Icon List icon URLs**
Reject AI-fabricated or malformed icon URLs (e.g. figma-5:2631, truncated paths) and use SVG_ICONS.placeholder so Icon List rows render in preview instead of broken images.

<img width="652" height="242" alt="image" src="https://github.com/user-attachments/assets/71185a08-69ac-4bfc-9ce5-a1a7eb498ecc" />



Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--{repo}--{owner}.aem.live/
- After: https://<branch>--{repo}--{owner}.aem.live/
