### PR TITLE
Validate icon-block logo asset before rendering logo slot

### DIFF
--- a/streamlibs/blocks/icon-block.js
+++ b/streamlibs/blocks/icon-block.js
@@ -95,14 +95,17 @@ function createLogoSlot(lockupArea) {
   return logoArea;
 }
 
-function handleLogo(value, areaEl) {
-  if (!areaEl || !value) return;
+function resolveLogoImage(value) {
+  if (!value) return null;
   const asset = [value.image, value.imageRef].find((v) => typeof v === 'string' && v);
   const { url, altText } = asset
     ? resolveImageValue({ url: asset, altText: value.altText })
     : resolveImageValue(value);
-  if (!SAFE_URL.test(url)) return;
+  return SAFE_URL.test(url) ? { url, altText } : null;
+}
 
+function handleLogo({ url, altText }, areaEl) {
+  if (!areaEl) return;
   areaEl.querySelectorAll('source').forEach((source) => { source.srcset = url; });
   const imgEl = areaEl.querySelector('img');
   if (imgEl) {
@@ -158,24 +161,27 @@ export default async function mapBlockContent(
       const value = properties[mappingConfig.key];
       const areaEl = handleComponents(blockContent, value, mappingConfig);
       switch (mappingConfig.key) {
-        case 'productLockup':
+        case 'productLockup': {
+          const logoImage = resolveLogoImage(properties.logo);
           if (value) {
             const lockupArea = areaEl || blockContent.querySelector(mappingConfig.selector);
             lockupArea?.classList.add('icon-area');
             handleProductLockup(value, lockupArea);
-            if (properties.logo && lockupArea?.parentElement) {
+            if (logoImage && lockupArea?.parentElement) {
               const logoArea = createLogoSlot(lockupArea);
               lockupArea.parentElement.insertBefore(logoArea, lockupArea.nextSibling);
-              handleLogo(properties.logo, logoArea);
+              handleLogo(logoImage, logoArea);
             }
-          } else if (properties.logo) {
+          } else if (logoImage) {
             const logoArea = areaEl || blockContent.querySelector(mappingConfig.selector);
             logoArea?.classList.remove('to-remove');
-            handleLogo(properties.logo, logoArea);
+            handleLogo(logoImage, logoArea);
           }
           break;
+        }
         case 'actions': {
-          const hasActions = value || properties.action1 || properties.action2 || properties.action3;
+          const hasActions = value || properties.action1
+            || properties.action2 || properties.action3;
           if (!hasActions) break;
           const actionArea = areaEl || blockContent.querySelector(mappingConfig.selector);
           actionArea?.classList.remove('to-remove');


### PR DESCRIPTION
## Description
Resolves and SAFE_URL-checks the icon-block logo up front via a new
`resolveLogoImage()` helper, so a non-URL Figma ref (e.g. a component id like
"1:209") no longer renders a clone of the product lockup icon or leaves an
empty icon-area in the output. `handleLogo()` is now a pure renderer of a
validated `{ url, altText }`.

## Related Issue
N/A

## Test URLs
- Before: https://dev--stream-mapper--adobecom.aem.live/
- After: https://icon-block-logo-fix--stream-mapper--saurabhsircar11.aem.live/