### PR TITLE
AI Block Mapping | Fix MWPW-202166

### DIFF
--- a/streamlibs/blocks/media.js
+++ b/streamlibs/blocks/media.js
@@ -172,9 +172,11 @@ export default async function mapBlockContent(sectionWrapper, blockContent, figC
     if (properties?.miloTag?.includes('app')) configData = mappingData.appstore;
     if (properties?.miloTag?.includes('sbcpy')) configData = mappingData.subcopy;
     configData.data.forEach((mappingConfig) => {
-      const value = mappingConfig.key === 'foregroundImage'
+      const rawValue = mappingConfig.key === 'foregroundImage'
         ? resolveForegroundImageValue(properties, properties[mappingConfig.key])
         : properties[mappingConfig.key];
+      const enabledFlag = `${mappingConfig.key}Enabled`;
+      const value = (enabledFlag in properties && !properties[enabledFlag]) ? '' : rawValue;
       const areaEl = handleComponents(blockContent, value, mappingConfig);
       switch (mappingConfig.key) {
         case 'actions':


### PR DESCRIPTION
Fix: Media block body/detail text shows when disabled

Body and detail text was rendering in the DA preview even when toggled off in Figma (bodyEnabled: false, detailEnabled: false). This happened because Figma stores text content in component properties regardless of boolean toggles — neither the mapper nor the parser checked the enabled flags before rendering/extracting.

Changes:

media.js (mapper): Skip rendering any text field when its *Enabled flag is explicitly false
media.json (guideline): Added hard gate to stop LLM from extracting body/detail/body2 text when the corresponding boolean is false

https://www.figma.com/design/7J1dfAmPnuNFThVgnzP6Eq/test1?node-id=0-1&p=f&t=bJUu8WJ1mdvGgyiF-0