### PR TITLE
AI block Mapping | Fix duplicate content in Accordion

### DIFF
--- a/streamlibs/blocks/accordion-child.js
+++ b/streamlibs/blocks/accordion-child.js
@@ -26,8 +26,17 @@ export default async function mapAccordionChildContent(
   const properties = figContent?.details?.properties;
   if (!properties) return;
 
-  try {
-    mapConfig?.data?.forEach((mappingConfig) => {
+  if (!mapConfig?.data?.length) {
+    // eslint-disable-next-line no-console
+    console.error(
+      'Error mapping accordion child block: missing/malformed mapConfig — item left as unmapped template content',
+      { heading: properties?.heading, miloTag: properties?.miloTag },
+    );
+    return;
+  }
+
+  mapConfig.data.forEach((mappingConfig) => {
+    try {
       const value = properties[mappingConfig.key];
       const areaEl = handleComponents(childContent, value, mappingConfig);
 
@@ -44,10 +53,15 @@ export default async function mapAccordionChildContent(
         default:
           break;
       }
-    });
+    } catch (error) {
+      console.error(`Error mapping accordion child field "${mappingConfig.key}":`, error);
+    }
+  });
+
+  try {
     blockContent.querySelectorAll('.to-remove').forEach((el) => el.remove());
   } catch (error) {
     // eslint-disable-next-line no-console
-    console.error('Error mapping accordion child block:', error);
+    console.error('Error cleaning up accordion child block:', error);
   }
 }

--- a/streamlibs/blocks/accordion.js
+++ b/streamlibs/blocks/accordion.js
@@ -62,6 +62,13 @@ export default async function mapBlockContent(sectionWrapper, blockContent, figC
     const mappingData = await safeJsonFetch(configJson);
     const configData = properties?.miloTag === 'acd-rm' ? mappingData.rich : mappingData.basic;
 
+    if (!configData?.data?.length) {
+      console.error(
+        `Error mapping accordion block: mapping config for miloTag "${properties?.miloTag}" is missing/malformed — all items will render as unmapped template content`,
+        mappingData,
+      );
+    }
+
     const accordions = (properties?.accordions || []).filter(
       (accChild) => accChild.body && accChild.heading,
     );


### PR DESCRIPTION
Map each accordion child field (heading/body/media/actions) independently instead of inside one shared try block — a single bad field (e.g. an unresolvable image ref) no longer aborts mapping of the rest of that item. Also logs clearly when the accordion.json mapping config comes back missing/malformed, instead of silently no-op'ing.

Why: accordion items were rendering as duplicated, unmodified demo placeholder content with no visible error — the per-item field loop was aborting partway through on a single throw.
