### PR TITLE
Hero-marquee: theme-safe background + isCover routing

### DIFF
--- a/streamlibs/blocks/hero-marquee.js
+++ b/streamlibs/blocks/hero-marquee.js
@@ -80,10 +80,25 @@ function handleVariants(sectionWrapper, blockContent, properties) {
   if (properties?.miloTag?.includes('cover')) blockContent.classList.add('media-cover');
 }
 
+const THEME_BACKGROUNDS = { dark: '#000000', light: '#FFFFFF' };
+const CONFLICTING_COLORS = {
+  dark: ['#fff', '#ffffff', 'white'],
+  light: ['#000', '#000000', 'black'],
+};
+
+function getThemeSafeBackground(value, colorTheme) {
+  const theme = colorTheme?.toLowerCase().trim();
+  if (!THEME_BACKGROUNDS[theme]) return value;
+  const authored = (typeof value === 'string' ? value : value?.url) || '';
+  const color = authored.toLowerCase().trim();
+  // nothing authored: only a dark theme needs a fallback, light sits fine on the page
+  if (!color) return theme === 'dark' ? THEME_BACKGROUNDS.dark : value;
+  return CONFLICTING_COLORS[theme].includes(color) ? THEME_BACKGROUNDS[theme] : value;
+}
+
 function blockBackground(value, areaEl, properties) {
-  if (!properties?.miloTag?.includes('cover')) {
-    handleBackground(value, areaEl);
-  }
+  if (!areaEl || properties?.miloTag?.includes('cover')) return;
+  handleBackground(value, areaEl);
 }
 
 function handleLogo(value, areaEl) {
@@ -115,9 +130,13 @@ export default async function mapBlockContent(sectionWrapper, blockContent, figC
 
   try {
     const mappingData = await safeJsonFetch('hero-marquee.json');
-    const configData = properties?.miloTag?.includes('cover') ? mappingData.split : mappingData.standard;
+    const isCover = properties?.miloTag?.includes('cover');
+    const configData = isCover ? mappingData.split : mappingData.standard;
     configData.data.forEach((mappingConfig) => {
-      const value = properties[mappingConfig.key];
+      // only the standard layout paints the block itself, the split one gets a cover image
+      const value = !isCover && mappingConfig.key === 'background'
+        ? getThemeSafeBackground(properties.background, properties.colorTheme)
+        : properties[mappingConfig.key];
       const areaEl = handleComponents(blockContent, value, mappingConfig);
       switch (mappingConfig.key) {
         case 'productLockups':

--- a/streamlibs/blocks/hero-marquee.js
+++ b/streamlibs/blocks/hero-marquee.js
@@ -6,6 +6,9 @@ import { LOGOS } from '../utils/constants.js';
 import { safeJsonFetch } from '../utils/error-handler.js';
 import { divSwap, getFirstType, getIconSize } from '../utils/utils.js';
 
+// prefer the explicit isCover flag; fall back to the tag when it is missing/untagged
+const isCoverHero = (properties) => properties?.isCover ?? properties?.miloTag?.includes('cover');
+
 function handleSwap(blockContent, properties) {
   if (getFirstType(properties?.layout) === 'image') {
     divSwap(blockContent, ':scope > div:nth-child(2) > div:first-child', ':scope > div:nth-child(2) > div:last-child');
@@ -77,7 +80,7 @@ function handleVariants(sectionWrapper, blockContent, properties) {
   handleMinHeight(blockContent, properties);
   if (properties?.layout === 'centered') blockContent.classList.add('center');
   if (properties?.colorTheme) blockContent.classList.add(properties.colorTheme);
-  if (properties?.miloTag?.includes('cover')) blockContent.classList.add('media-cover');
+  if (isCoverHero(properties)) blockContent.classList.add('media-cover');
 }
 
 const THEME_BACKGROUNDS = { dark: '#000000', light: '#FFFFFF' };
@@ -97,7 +100,7 @@ function getThemeSafeBackground(value, colorTheme) {
 }
 
 function blockBackground(value, areaEl, properties) {
-  if (!areaEl || properties?.miloTag?.includes('cover')) return;
+  if (!areaEl || isCoverHero(properties)) return;
   handleBackground(value, areaEl);
 }
 
@@ -130,7 +133,7 @@ export default async function mapBlockContent(sectionWrapper, blockContent, figC
 
   try {
     const mappingData = await safeJsonFetch('hero-marquee.json');
-    const isCover = properties?.miloTag?.includes('cover');
+    const isCover = isCoverHero(properties);
     const configData = isCover ? mappingData.split : mappingData.standard;
     configData.data.forEach((mappingConfig) => {
       // only the standard layout paints the block itself, the split one gets a cover image

--- a/streamlibs/sources/figma.js
+++ b/streamlibs/sources/figma.js
@@ -203,10 +203,6 @@ async function processBlock(block, figmaUrl, onDetailResponse = () => {}) {
   let blockContent = getHtml(doc, block.miloId, block.variant);
   const props = figContent.details.properties;
   props.miloTag = block.tag;
-  if (block.aiMapping && block.id === 'hero-marquee' && props.bgImage
-    && typeof props.background === 'string' && /^https?:\/\//.test(props.background)) {
-    props.miloTag = 'hero-mq';
-  }
   blockContent = await mapFigmaContent(blockContent, block, figContent);
   block.blockDomEl = blockContent;
   return blockContent || '';


### PR DESCRIPTION
Two related hero-marquee frontend fixes.

## 1. Theme-safe background (standard hero)
`getThemeSafeBackground` swaps a background COLOR that conflicts with the color theme (dark + white, or light + black) for a theme-safe color, so copy stays readable. Applied to the standard config's `background`. Also removes a stale `sources/figma.js` override that force-set `miloTag = 'hero-mq'` for AI hero-marquee whenever `background` was a URL.

## 2. isCover routing
Adds `isCoverHero(p) = p?.isCover ?? p?.miloTag?.includes('cover')`, used at the 3 routing spots (split-vs-standard config select, the `media-cover` class, and the `blockBackground` guard). Split-vs-standard now survives a missing / untagged Milo Tag node. Pairs with the stream-service guideline that emits the new `isCover` property.

## Files
- `streamlibs/blocks/hero-marquee.js`
- `streamlibs/sources/figma.js`