### PR TITLE
AI Block Mapping | Fix/ MWPW 202172

### DIFF
--- a/streamlibs/blocks/aside-std.js
+++ b/streamlibs/blocks/aside-std.js
@@ -106,6 +106,14 @@ export default async function mapBlockContent(
           break;
         case 'background':
           handleBackground(value, areaEl);
+          if (value === false && properties?.colorTheme === 'dark') {
+            if (areaEl) {
+              areaEl.classList.remove('to-remove');
+              handleBackground('#000000', areaEl);
+            } else {
+              sectionWrapper.style.background = '#000000';
+            }
+          }
           break;
         case 'productLockup':
           if (areaEl) {


### PR DESCRIPTION
Jira:
[MWPW-202172](https://jira.corp.adobe.com/browse/MWPW-202172)

When `background: false` and `colorTheme: dark`, the mapper now sets a black background instead of leaving content invisible. The previous fix attempt passed `'#000000'` to `handleBackground` with a null `areaEl`, causing a TypeError that silently broke the entire block render. This change guards against the null case and removes the `to-remove` class before setting the background so the element survives cleanup.
<img width="2560" height="1440" alt="Screenshot 2026-07-29 at 3 15 34 PM" src="https://github.com/user-attachments/assets/dbfd6094-44e4-4ccb-9526-f049e4f855c7" />
