### PR TITLE
Apply the theme-safe background to the split hero backdrop

### DIFF
--- a/streamlibs/blocks/hero-marquee.js
+++ b/streamlibs/blocks/hero-marquee.js
@@ -135,10 +135,11 @@ export default async function mapBlockContent(sectionWrapper, blockContent, figC
     const mappingData = await safeJsonFetch('hero-marquee.json');
     const isCover = isCoverHero(properties);
     const configData = isCover ? mappingData.split : mappingData.standard;
+    // the backdrop the block paints itself with, standard vs split
+    const blockBgKey = isCover ? 'coverBackground' : 'background';
     configData.data.forEach((mappingConfig) => {
-      // only the standard layout paints the block itself, the split one gets a cover image
-      const value = !isCover && mappingConfig.key === 'background'
-        ? getThemeSafeBackground(properties.background, properties.colorTheme)
+      const value = mappingConfig.key === blockBgKey
+        ? getThemeSafeBackground(properties[blockBgKey], properties.colorTheme)
         : properties[mappingConfig.key];
       const areaEl = handleComponents(blockContent, value, mappingConfig);
       switch (mappingConfig.key) {


### PR DESCRIPTION
The split config paints the block from `coverBackground`, not `background`, so the dark-theme fallback added in #244 never ran for a media-cover hero. A split cover with no authored backdrop had its whole row dropped (`to-remove`), leaving white copy on nothing.

Pairs with stream-service `fix/hero-marquee-split-cover-backdrop`, which stops emitting `coverBackground: false` for split covers in the first place.

Test URLs:
- Before: https://dev--stream-mapper--adobecom.aem.page/
- After: branch preview off this head